### PR TITLE
Strip out some of our explicit Mockito dependencies

### DIFF
--- a/.travis/test_run_job.py
+++ b/.travis/test_run_job.py
@@ -12,10 +12,13 @@ def repo():
     yield Repository(".sbt_metadata")
 
 
-@pytest.mark.parametrize('project_name, path, should_run_project', [
-    ("id_minter", "snapshots/Makefile", False),
-    ("id_minter", "pipeline/Makefile", True),
-])
+@pytest.mark.parametrize(
+    "project_name, path, should_run_project",
+    [
+        ("id_minter", "snapshots/Makefile", False),
+        ("id_minter", "pipeline/Makefile", True),
+    ],
+)
 def test_should_run_sbt_project(repo, project_name, path, should_run_project):
     project = repo.get_project(project_name)
     result = should_run_sbt_project(project, changed_paths=[path])

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherConcurrencyTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherConcurrencyTest.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.matcher.matcher
 
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.matcher.MatcherResult
 import uk.ac.wellcome.models.work.generators.WorksGenerators
@@ -17,7 +16,6 @@ class WorkMatcherConcurrencyTest
     with Matchers
     with MatcherFixtures
     with ScalaFutures
-    with MockitoSugar
     with WorksGenerators {
 
   it("processes one of two conflicting concurrent updates and locks the other") {

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
@@ -5,7 +5,6 @@ import com.gu.scanamo.syntax._
 import org.mockito.Matchers.any
 import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.matcher.{
   MatchedIdentifiers,
@@ -33,7 +32,6 @@ class WorkMatcherTest
     with Matchers
     with MatcherFixtures
     with ScalaFutures
-    with MockitoSugar
     with WorksGenerators {
 
   private val identifierA = createSierraSystemSourceIdentifierWith(value = "A")

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.merger.services
 import org.mockito.Matchers.any
 import org.mockito.Mockito.{atLeastOnce, times, verify}
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SNS.Topic
@@ -33,7 +32,6 @@ class MergerWorkerServiceTest
     with LocalWorksVhs
     with MatcherResultFixture
     with Matchers
-    with MockitoSugar
     with WorkerServiceFixture {
 
   it(

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.recorder.services
 import com.gu.scanamo.Scanamo
 import io.circe.Decoder
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.json.JsonUtil._
@@ -22,7 +21,6 @@ import uk.ac.wellcome.storage.vhs.HybridRecord
 class RecorderWorkerServiceTest
     extends FunSpec
     with Matchers
-    with MockitoSugar
     with Akka
     with LocalVersionedHybridStore
     with SQS

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.transformer.miro.services
 
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SNS.Topic
@@ -31,7 +30,6 @@ class MiroVHSRecordReceiverTest
     with Eventually
     with MiroVHSRecordReceiverFixture
     with IntegrationPatience
-    with MockitoSugar
     with ScalaFutures
     with MiroRecordGenerators
     with WorksGenerators {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -210,15 +210,12 @@ object CatalogueDependencies {
 
   val miroTransformerDependencies: Seq[ModuleID] =
      ExternalDependencies.apacheCommonsDependencies ++
-     ExternalDependencies.mockitoDependencies ++
      WellcomeDependencies.messagingTypesafeLibrary
 
   val recorderDependencies: Seq[ModuleID] =
-    ExternalDependencies.mockitoDependencies ++
     WellcomeDependencies.messagingTypesafeLibrary
 
   val reindexWorkerDependencies: Seq[ModuleID] =
-    ExternalDependencies.mockitoDependencies ++
     WellcomeDependencies.messagingTypesafeLibrary
 
   val sierraTransformerDependencies: Seq[ModuleID] =

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/BulkSNSSenderTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/BulkSNSSenderTest.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.platform.reindex.reindex_worker.services
 
 import com.amazonaws.SdkClientException
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.messaging.fixtures.SNS
 import uk.ac.wellcome.messaging.fixtures.SNS.Topic
@@ -13,7 +12,6 @@ import scala.util.Random
 class BulkSNSSenderTest
     extends FunSpec
     with Matchers
-    with MockitoSugar
     with ScalaFutures
     with BulkSNSSenderFixture
     with IntegrationPatience

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/ReindexWorkerServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/ReindexWorkerServiceTest.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.platform.reindex.reindex_worker.services
 
 import com.gu.scanamo.Scanamo
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.messaging.fixtures.SNS.Topic
@@ -22,7 +21,6 @@ import uk.ac.wellcome.storage.vhs.HybridRecord
 class ReindexWorkerServiceTest
     extends FunSpec
     with Matchers
-    with MockitoSugar
     with Akka
     with DynamoFixtures
     with ReindexableTable

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.sierra_bib_merger
 
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS
@@ -17,7 +16,6 @@ class SierraBibMergerFeatureTest
     extends FunSpec
     with Matchers
     with Eventually
-    with MockitoSugar
     with IntegrationPatience
     with ScalaFutures
     with SQS

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.platform.sierra_bib_merger.services
 
 import org.mockito.Mockito.{never, verify}
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.fixtures.{Messaging, SQS}
@@ -16,7 +15,6 @@ import uk.ac.wellcome.fixtures.TestWith
 
 class SierraBibMergerWorkerServiceTest
     extends FunSpec
-    with MockitoSugar
     with ScalaFutures
     with Matchers
     with SQS

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/DynamoInserterTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/DynamoInserterTest.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.platform.sierra_items_to_dynamo.services
 
 import com.amazonaws.services.dynamodbv2.model.ResourceNotFoundException
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.models.transformable.sierra.SierraItemRecord
@@ -17,7 +16,6 @@ class DynamoInserterTest
     extends FunSpec
     with Matchers
     with ScalaFutures
-    with MockitoSugar
     with DynamoInserterFixture
     with IntegrationPatience
     with SierraGenerators {


### PR DESCRIPTION
Even in the new split-repo world, the Catalogue takes a really long time to build, and I don’t know why.

I do know the Mockito imports caused a pile of grief when I was porting the repo, and in a bunch of cases aren’t actually needed. So maybe taking them out will make things a little better? idk