### PR TITLE
Relative Location Header in redirect

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -16,7 +16,10 @@ import uk.ac.wellcome.platform.api.elasticsearch.ElasticErrorHandler
 import uk.ac.wellcome.platform.api.models.WorkQuery._
 import uk.ac.wellcome.platform.api.models._
 import uk.ac.wellcome.platform.api.requests._
-import uk.ac.wellcome.platform.api.responses.{ResultListResponse, ResultResponse}
+import uk.ac.wellcome.platform.api.responses.{
+  ResultListResponse,
+  ResultResponse
+}
 import uk.ac.wellcome.platform.api.services.{WorksSearchOptions, WorksService}
 
 import scala.collection.JavaConverters._
@@ -241,16 +244,16 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
 
     val params = originalRequest.params.toMap
       .filterNot {
-        case (k,_) => k == "id"
+        case (k, _) => k == "id"
       }
       .map {
-        case (k,v) => s"$k=$v"
+        case (k, v) => s"$k=$v"
       }
 
     val paramString =
       params.reduce((a: String, b: String) => s"${a}&${b}")
 
-    val appendToPath = if(!paramString.isEmpty) {
+    val appendToPath = if (!paramString.isEmpty) {
       s"?${paramString}"
     } else {
       ""


### PR DESCRIPTION
Currently redirects are absolute and the host points at `localhost` which is useless to clients.

This uses a relative scheme, correcting that issue.