### PR TITLE
Another go at fixing the API redirects

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/RedirectedWorkController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/RedirectedWorkController.scala
@@ -1,8 +1,8 @@
 package uk.ac.wellcome.platform.api.controllers
 
-import com.twitter.finagle.http.Request
+import java.net.URI
+
 import uk.ac.wellcome.models.work.internal.IdentifiedRedirectedWork
-import uk.ac.wellcome.platform.api.models.ApiConfig
 
 trait RedirectedWorkController {
 
@@ -12,26 +12,21 @@ trait RedirectedWorkController {
     * of the form /works/{id}.
     *
     */
-  def createRedirectResponseURI(originalRequest: Request,
+  def createRedirectResponseURI(originalUri: String,
                                 work: IdentifiedRedirectedWork,
-                                apiConfig: ApiConfig): String = {
-    val path = originalRequest.path.replaceAll(
-      s"/${work.canonicalId}",
-      s"/${work.redirect.canonicalId}"
+                                apiScheme: String,
+                                apiHost: String): URI = {
+    val original = new URI(originalUri)
+
+    new URI(
+      apiScheme,
+      apiHost,
+      original.getPath.replaceAll(
+        s"/works/${work.canonicalId}",
+        s"/works/${work.redirect.canonicalId}"
+      ),
+      original.getQuery,
+      original.getFragment
     )
-
-    val params = originalRequest.params
-      .filterNot { case (k, _) => k == "id" }
-      .map { case (k, v) => s"$k=$v" }
-
-    val appendToPath = if (params.nonEmpty) {
-      val paramString =
-        params.reduce((a: String, b: String) => s"$a&$b")
-      s"?$paramString"
-    } else {
-      ""
-    }
-
-    s"$path$appendToPath"
   }
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/RedirectedWorkController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/RedirectedWorkController.scala
@@ -1,0 +1,37 @@
+package uk.ac.wellcome.platform.api.controllers
+
+import com.twitter.finagle.http.Request
+import uk.ac.wellcome.models.work.internal.IdentifiedRedirectedWork
+import uk.ac.wellcome.platform.api.models.ApiConfig
+
+trait RedirectedWorkController {
+
+  /** Create a 302 Redirect to a new Work.
+    *
+    * Assumes the original URI requested was for a single work, i.e. a request
+    * of the form /works/{id}.
+    *
+    */
+  def createRedirectResponseURI(originalRequest: Request,
+                                work: IdentifiedRedirectedWork,
+                                apiConfig: ApiConfig): String = {
+    val path = originalRequest.path.replaceAll(
+      s"/${work.canonicalId}",
+      s"/${work.redirect.canonicalId}"
+    )
+
+    val params = originalRequest.params
+      .filterNot { case (k, _) => k == "id" }
+      .map { case (k, v) => s"$k=$v" }
+
+    val appendToPath = if (params.nonEmpty) {
+      val paramString =
+        params.reduce((a: String, b: String) => s"$a&$b")
+      s"?$paramString"
+    } else {
+      ""
+    }
+
+    s"$path$appendToPath"
+  }
+}

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -234,7 +234,12 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
     response.found
       .body("")
       .location(
-        uri = createRedirectResponseURI(originalRequest, work, apiConfig)
+        uri = createRedirectResponseURI(
+          originalUri = originalRequest.uri,
+          work = work,
+          apiScheme = apiConfig.scheme,
+          apiHost = apiConfig.host
+        )
       )
 
   private def respondWithGoneError(contextUri: String) = {

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -33,6 +33,7 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
   defaultIndex: Index,
   worksService: WorksService)(implicit ec: ExecutionContext)
     extends Controller
+    with RedirectedWorkController
     with SwaggerController {
 
   protected val includeParameterName: String
@@ -227,43 +228,14 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
     contextUri: String): ResponseBuilder#EnrichedResponse =
     response.ok.json(ResultResponse(context = contextUri, result = result))
 
-  /** Create a 302 Redirect to a new Work.
-    *
-    * Assumes the original URI requested was for a single work, i.e. a request
-    * of the form /works/{id}.
-    *
-    */
   private def respondWithRedirect(originalRequest: Request,
                                   work: IdentifiedRedirectedWork,
-                                  contextUri: String) = {
-
-    val path = originalRequest.path.replaceAll(
-      s"/${work.canonicalId}",
-      s"/${work.redirect.canonicalId}"
-    )
-
-    val params = originalRequest.params.toMap
-      .filterNot {
-        case (k, _) => k == "id"
-      }
-      .map {
-        case (k, v) => s"$k=$v"
-      }
-
-    val appendToPath = if (params.nonEmpty) {
-      val paramString =
-        params.reduce((a: String, b: String) => s"${a}&${b}")
-      s"?$paramString"
-    } else {
-      ""
-    }
-
+                                  contextUri: String): ResponseBuilder#EnrichedResponse =
     response.found
       .body("")
       .location(
-        uri = s"${path}${appendToPath}"
+        uri = createRedirectResponseURI(originalRequest, work, apiConfig)
       )
-  }
 
   private def respondWithGoneError(contextUri: String) = {
     val result = Error(

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -228,9 +228,10 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
     contextUri: String): ResponseBuilder#EnrichedResponse =
     response.ok.json(ResultResponse(context = contextUri, result = result))
 
-  private def respondWithRedirect(originalRequest: Request,
-                                  work: IdentifiedRedirectedWork,
-                                  contextUri: String): ResponseBuilder#EnrichedResponse =
+  private def respondWithRedirect(
+    originalRequest: Request,
+    work: IdentifiedRedirectedWork,
+    contextUri: String): ResponseBuilder#EnrichedResponse =
     response.found
       .body("")
       .location(

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/modules/ApiConfigModule.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/modules/ApiConfigModule.scala
@@ -6,7 +6,7 @@ import uk.ac.wellcome.platform.api.models.ApiConfig
 
 object ApiConfigModule extends TwitterModule {
   private val host =
-    flag(name = "api.host", default = "localhost:8888", help = "API hostname")
+    flag[String](name = "api.host", help = "API hostname")
   private val scheme =
     flag(name = "api.scheme", default = "https", help = "API protocol scheme")
   private val defaultPageSize =

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/controllers/RedirectedWorkControllerTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/controllers/RedirectedWorkControllerTest.scala
@@ -4,7 +4,10 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.IdentifiedRedirectedWork
 
-class RedirectedWorkControllerTest extends FunSpec with Matchers with WorksGenerators {
+class RedirectedWorkControllerTest
+    extends FunSpec
+    with Matchers
+    with WorksGenerators {
   val canonicalId: String = createCanonicalId
 
   val controller: RedirectedWorkController = new RedirectedWorkController {}
@@ -12,9 +15,10 @@ class RedirectedWorkControllerTest extends FunSpec with Matchers with WorksGener
   val apiScheme = "https"
   val apiHost = "api.wellcomecollection.org"
 
-  val redirectedWork: IdentifiedRedirectedWork = createIdentifiedRedirectedWorkWith(
-    canonicalId = canonicalId
-  )
+  val redirectedWork: IdentifiedRedirectedWork =
+    createIdentifiedRedirectedWorkWith(
+      canonicalId = canonicalId
+    )
 
   it("creates a redirect URI") {
     val redirectURI = createRedirectResponseUri(
@@ -35,11 +39,13 @@ class RedirectedWorkControllerTest extends FunSpec with Matchers with WorksGener
   private def createRedirectResponseUri(uri: String): String = {
     val controller = new RedirectedWorkController {}
 
-    controller.createRedirectResponseURI(
-      originalUri = uri,
-      work = redirectedWork,
-      apiScheme = apiScheme,
-      apiHost = apiHost
-    ).toString
+    controller
+      .createRedirectResponseURI(
+        originalUri = uri,
+        work = redirectedWork,
+        apiScheme = apiScheme,
+        apiHost = apiHost
+      )
+      .toString
   }
 }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/controllers/RedirectedWorkControllerTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/controllers/RedirectedWorkControllerTest.scala
@@ -1,0 +1,45 @@
+package uk.ac.wellcome.platform.api.controllers
+
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.work.generators.WorksGenerators
+import uk.ac.wellcome.models.work.internal.IdentifiedRedirectedWork
+
+class RedirectedWorkControllerTest extends FunSpec with Matchers with WorksGenerators {
+  val canonicalId: String = createCanonicalId
+
+  val controller: RedirectedWorkController = new RedirectedWorkController {}
+
+  val apiScheme = "https"
+  val apiHost = "api.wellcomecollection.org"
+
+  val redirectedWork: IdentifiedRedirectedWork = createIdentifiedRedirectedWorkWith(
+    canonicalId = canonicalId
+  )
+
+  it("creates a redirect URI") {
+    val redirectURI = createRedirectResponseUri(
+      s"http://localhost:8888/catalogue/v2/works/$canonicalId"
+    )
+
+    redirectURI shouldBe s"$apiScheme://$apiHost/catalogue/v2/works/${redirectedWork.redirect.canonicalId}"
+  }
+
+  it("preserves API query parameters") {
+    val redirectURI = createRedirectResponseUri(
+      s"http://localhost:8888/catalogue/v2/works/$canonicalId?query=hello%20world"
+    )
+
+    redirectURI should endWith("?query=hello%20world")
+  }
+
+  private def createRedirectResponseUri(uri: String): String = {
+    val controller = new RedirectedWorkController {}
+
+    controller.createRedirectResponseURI(
+      originalUri = uri,
+      work = redirectedWork,
+      apiScheme = apiScheme,
+      apiHost = apiHost
+    ).toString
+  }
+}

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTestBase.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiErrorsTestBase.scala
@@ -169,7 +169,7 @@ trait ApiErrorsTestBase { this: ApiWorksTestBase =>
           andExpect = Status.InternalServerError,
           withJsonBody = s"""
                |{
-               |  "@context": "https://localhost:8888/${getApiPrefix()}/context.json",
+               |  "@context": "${contextUrl(getApiPrefix())}",
                |  "type": "Error",
                |  "errorType": "http",
                |  "httpStatus": 500,

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -24,6 +24,9 @@ trait ApiWorksTestBase
       toJson(t).get
   }
 
+  val apiScheme: String = "https"
+  val apiHost: String = "api-testing.local"
+
   def withServer[R](indexV1: Index, indexV2: Index)(
     testWith: TestWith[EmbeddedHttpServer, R]): R = {
 
@@ -32,6 +35,9 @@ trait ApiWorksTestBase
       flags = displayEsLocalFlags(
         indexV1 = indexV1,
         indexV2 = indexV2
+      ) ++ Map(
+        "api.scheme" -> apiScheme,
+        "api.host" -> apiHost
       )
     )
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -70,6 +70,9 @@ trait ApiWorksTestBase
       testWith(server)
     }
 
+  def contextUrl(apiPrefix: String): String =
+    s"$apiScheme://$apiHost/$apiPrefix/context.json"
+
   def emptyJsonResult(apiPrefix: String): String = s"""
     |{
     |  ${resultList(apiPrefix, totalPages = 0, totalResults = 0)},
@@ -78,7 +81,7 @@ trait ApiWorksTestBase
 
   def badRequest(apiPrefix: String, description: String) =
     s"""{
-      "@context": "https://localhost:8888/$apiPrefix/context.json",
+      "@context": "${contextUrl(apiPrefix)}",
       "type": "Error",
       "errorType": "http",
       "httpStatus": 400,
@@ -91,16 +94,22 @@ trait ApiWorksTestBase
                  totalPages: Int = 1,
                  totalResults: Int = 1) =
     s"""
-      "@context": "https://localhost:8888/$apiPrefix/context.json",
+      "@context": "${contextUrl(apiPrefix)}",
       "type": "ResultList",
       "pageSize": $pageSize,
       "totalPages": $totalPages,
       "totalResults": $totalResults
     """
 
+  def singleWorkResult(apiPrefix: String): String =
+    s"""
+        "@context": "${contextUrl(apiPrefix)}",
+        "type": "Work"
+     """.stripMargin
+
   def notFound(apiPrefix: String, description: String) =
     s"""{
-      "@context": "https://localhost:8888/$apiPrefix/context.json",
+      "@context": "${contextUrl(apiPrefix)}",
       "type": "Error",
       "errorType": "http",
       "httpStatus": 404,
@@ -110,7 +119,7 @@ trait ApiWorksTestBase
 
   def gone(apiPrefix: String) =
     s"""{
-      "@context": "https://localhost:8888/$apiPrefix/context.json",
+      "@context": "${contextUrl(apiPrefix)}",
       "type": "Error",
       "errorType": "http",
       "httpStatus": 410,

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1RedirectsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1RedirectsTest.scala
@@ -31,7 +31,7 @@ class ApiV1RedirectsTest extends ApiV1WorksTestBase {
           andExpect = Status.Found
         )
 
-        resp.headerMap.getOrNull("Location") should startWith("https://")
+        resp.headerMap.getOrNull("Location") should startWith(s"$apiScheme://$apiHost")
     }
   }
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1RedirectsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1RedirectsTest.scala
@@ -20,7 +20,7 @@ class ApiV1RedirectsTest extends ApiV1WorksTestBase {
     }
   }
 
-  it("returns a relative URL in the Location header") {
+  it("uses the configured host/scheme for the Location header") {
     val redirectedWork = createIdentifiedRedirectedWork
 
     withV1Api {
@@ -31,7 +31,7 @@ class ApiV1RedirectsTest extends ApiV1WorksTestBase {
           andExpect = Status.Found
         )
 
-        resp.headerMap.getOrNull("Location") should startWith(s"/$apiPrefix/works")
+        resp.headerMap.getOrNull("Location") should startWith("https://")
     }
   }
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1RedirectsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1RedirectsTest.scala
@@ -31,7 +31,8 @@ class ApiV1RedirectsTest extends ApiV1WorksTestBase {
           andExpect = Status.Found
         )
 
-        resp.headerMap.getOrNull("Location") should startWith(s"$apiScheme://$apiHost")
+        resp.headerMap.getOrNull("Location") should startWith(
+          s"$apiScheme://$apiHost")
     }
   }
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1RedirectsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1RedirectsTest.scala
@@ -20,6 +20,21 @@ class ApiV1RedirectsTest extends ApiV1WorksTestBase {
     }
   }
 
+  it("returns a relative URL in the Location header") {
+    val redirectedWork = createIdentifiedRedirectedWork
+
+    withV1Api {
+      case (indexV1, server: EmbeddedHttpServer) =>
+        insertIntoElasticsearch(indexV1, redirectedWork)
+        val resp = server.httpGet(
+          path = s"/$apiPrefix/works/${redirectedWork.canonicalId}",
+          andExpect = Status.Found
+        )
+
+        resp.headerMap.getOrNull("Location") should startWith(s"/$apiPrefix/works")
+    }
+  }
+
   it("preserves query parameters on a 302 Redirect") {
     val redirectedWork = createIdentifiedRedirectedWork
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v1/ApiV1WorksTest.scala
@@ -73,8 +73,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
             andExpect = Status.Ok,
             withJsonBody = s"""
                  |{
-                 | "@context": "https://localhost:8888/$apiPrefix/context.json",
-                 | "type": "Work",
+                 | ${singleWorkResult(apiPrefix)},
                  | "id": "${work.canonicalId}",
                  | "title": "${work.title}",
                  | "creators": [ ],
@@ -104,8 +103,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
             andExpect = Status.Ok,
             withJsonBody = s"""
                  |{
-                 | "@context": "https://localhost:8888/$apiPrefix/context.json",
-                 | "type": "Work",
+                 | ${singleWorkResult(apiPrefix)},
                  | "id": "${work.canonicalId}",
                  | "title": "${work.title}",
                  | "creators": [ ],
@@ -140,8 +138,8 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
                                 pageSize = 1,
                                 totalPages = 3,
                                 totalResults = 3)},
-                 |  "prevPage": "https://localhost:8888/$apiPrefix/works?page=1&pageSize=1",
-                 |  "nextPage": "https://localhost:8888/$apiPrefix/works?page=3&pageSize=1",
+                 |  "prevPage": "$apiScheme://$apiHost/$apiPrefix/works?page=1&pageSize=1",
+                 |  "nextPage": "$apiScheme://$apiHost/$apiPrefix/works?page=3&pageSize=1",
                  |  "results": [
                  |   {
                  |     "type": "Work",
@@ -169,7 +167,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
                                 pageSize = 1,
                                 totalPages = 3,
                                 totalResults = 3)},
-                 |  "nextPage": "https://localhost:8888/$apiPrefix/works?page=2&pageSize=1",
+                 |  "nextPage": "$apiScheme://$apiHost/$apiPrefix/works?page=2&pageSize=1",
                  |  "results": [
                  |   {
                  |     "type": "Work",
@@ -197,7 +195,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
                                 pageSize = 1,
                                 totalPages = 3,
                                 totalResults = 3)},
-                 |  "prevPage": "https://localhost:8888/$apiPrefix/works?page=2&pageSize=1",
+                 |  "prevPage": "$apiScheme://$apiHost/$apiPrefix/works?page=2&pageSize=1",
                  |  "results": [
                  |   {
                  |     "type": "Work",
@@ -343,8 +341,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
             andExpect = Status.Ok,
             withJsonBody = s"""
                  |{
-                 | "@context": "https://localhost:8888/$apiPrefix/context.json",
-                 | "type": "Work",
+                 | ${singleWorkResult(apiPrefix)},
                  | "id": "${work.canonicalId}",
                  | "title": "${work.title}",
                  | "creators": [ ],
@@ -377,8 +374,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
               andExpect = Status.Ok,
               withJsonBody = s"""
                    |{
-                   | "@context": "https://localhost:8888/$apiPrefix/context.json",
-                   | "type": "Work",
+                   | ${singleWorkResult(apiPrefix)},
                    | "id": "${work.canonicalId}",
                    | "title": "${work.title}",
                    | "creators": [ ],
@@ -398,8 +394,7 @@ class ApiV1WorksTest extends ApiV1WorksTestBase {
               andExpect = Status.Ok,
               withJsonBody = s"""
                    |{
-                   | "@context": "https://localhost:8888/$apiPrefix/context.json",
-                   | "type": "Work",
+                   | ${singleWorkResult(apiPrefix)},
                    | "id": "${altWork.canonicalId}",
                    | "title": "${altWork.title}",
                    | "creators": [ ],

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2RedirectsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2RedirectsTest.scala
@@ -20,6 +20,21 @@ class ApiV2RedirectsTest extends ApiV2WorksTestBase {
     }
   }
 
+  it("returns a relative URL in the Location header") {
+    val redirectedWork = createIdentifiedRedirectedWork
+
+    withV2Api {
+      case (indexV2, server: EmbeddedHttpServer) =>
+        insertIntoElasticsearch(indexV2, redirectedWork)
+        val resp = server.httpGet(
+          path = s"/$apiPrefix/works/${redirectedWork.canonicalId}",
+          andExpect = Status.Found
+        )
+
+        resp.headerMap.getOrNull("Location") should startWith(s"/$apiPrefix/works")
+    }
+  }
+
   it("preserves query parameters on a 302 Redirect") {
     val redirectedWork = createIdentifiedRedirectedWork
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2RedirectsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2RedirectsTest.scala
@@ -31,7 +31,8 @@ class ApiV2RedirectsTest extends ApiV2WorksTestBase {
           andExpect = Status.Found
         )
 
-        resp.headerMap.getOrNull("Location") should startWith(s"$apiScheme://$apiHost")
+        resp.headerMap.getOrNull("Location") should startWith(
+          s"$apiScheme://$apiHost")
     }
   }
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2RedirectsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2RedirectsTest.scala
@@ -31,7 +31,7 @@ class ApiV2RedirectsTest extends ApiV2WorksTestBase {
           andExpect = Status.Found
         )
 
-        resp.headerMap.getOrNull("Location") should startWith("https://")
+        resp.headerMap.getOrNull("Location") should startWith(s"$apiScheme://$apiHost")
     }
   }
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2RedirectsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2RedirectsTest.scala
@@ -20,7 +20,7 @@ class ApiV2RedirectsTest extends ApiV2WorksTestBase {
     }
   }
 
-  it("returns a relative URL in the Location header") {
+  it("uses the configured host/scheme for the Location header") {
     val redirectedWork = createIdentifiedRedirectedWork
 
     withV2Api {
@@ -31,7 +31,7 @@ class ApiV2RedirectsTest extends ApiV2WorksTestBase {
           andExpect = Status.Found
         )
 
-        resp.headerMap.getOrNull("Location") should startWith(s"/$apiPrefix/works")
+        resp.headerMap.getOrNull("Location") should startWith("https://")
     }
   }
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksIncludesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksIncludesTest.scala
@@ -74,8 +74,7 @@ class ApiV2WorksIncludesTest
             withJsonBody =
               s"""
                               |{
-                              | "@context": "https://localhost:8888/$apiPrefix/context.json",
-                              | "type": "Work",
+                              | ${singleWorkResult(apiPrefix)},
                               | "id": "${work.canonicalId}",
                               | "title": "${work.title}",
                               | "identifiers": [ ${identifier(
@@ -102,8 +101,7 @@ class ApiV2WorksIncludesTest
             andExpect = Status.Ok,
             withJsonBody = s"""
                               |{
-                              | "@context": "https://localhost:8888/$apiPrefix/context.json",
-                              | "type": "Work",
+                              | ${singleWorkResult(apiPrefix)},
                               | "id": "${work.canonicalId}",
                               | "title": "${work.title}",
                               | "items": [ ${items(work.items)} ]
@@ -170,8 +168,7 @@ class ApiV2WorksIncludesTest
             andExpect = Status.Ok,
             withJsonBody = s"""
                  |{
-                 |  "@context": "https://localhost:8888/$apiPrefix/context.json",
-                 |  "type": "Work",
+                 |  ${singleWorkResult(apiPrefix)},
                  |  "id": "${work.canonicalId}",
                  |  "title": "${work.title}",
                  |  "subjects": [ ${subjects(subject)}]
@@ -240,8 +237,7 @@ class ApiV2WorksIncludesTest
             andExpect = Status.Ok,
             withJsonBody = s"""
                  |{
-                 |  "@context": "https://localhost:8888/$apiPrefix/context.json",
-                 |  "type": "Work",
+                 |  ${singleWorkResult(apiPrefix)},
                  |  "id": "${work.canonicalId}",
                  |  "title": "${work.title}",
                  |  "genres": [ ${genres(genre)}]
@@ -311,8 +307,7 @@ class ApiV2WorksIncludesTest
             andExpect = Status.Ok,
             withJsonBody = s"""
                  |{
-                 |  "@context": "https://localhost:8888/$apiPrefix/context.json",
-                 |  "type": "Work",
+                 |  ${singleWorkResult(apiPrefix)},
                  |  "id": "${work.canonicalId}",
                  |  "title": "${work.title}",
                  |  "contributors": [ ${contributors(contributor)}]
@@ -381,8 +376,7 @@ class ApiV2WorksIncludesTest
             andExpect = Status.Ok,
             withJsonBody = s"""
                  |{
-                 |  "@context": "https://localhost:8888/$apiPrefix/context.json",
-                 |  "type": "Work",
+                 |  ${singleWorkResult(apiPrefix)},
                  |  "id": "${work.canonicalId}",
                  |  "title": "${work.title}",
                  |  "production": [ ${production(productionEventList)}]

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -57,8 +57,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
             andExpect = Status.Ok,
             withJsonBody = s"""
                |{
-               | "@context": "https://localhost:8888/$apiPrefix/context.json",
-               | "type": "Work",
+               | ${singleWorkResult(apiPrefix)},
                | "id": "${work.canonicalId}",
                | "title": "${work.title}"
                |}
@@ -87,8 +86,8 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
                                 pageSize = 1,
                                 totalPages = 3,
                                 totalResults = 3)},
-               |  "prevPage": "https://localhost:8888/$apiPrefix/works?page=1&pageSize=1",
-               |  "nextPage": "https://localhost:8888/$apiPrefix/works?page=3&pageSize=1",
+               |  "prevPage": "$apiScheme://$apiHost/$apiPrefix/works?page=1&pageSize=1",
+               |  "nextPage": "$apiScheme://$apiHost/$apiPrefix/works?page=3&pageSize=1",
                |  "results": [
                |   {
                |     "type": "Work",
@@ -111,7 +110,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
                                 pageSize = 1,
                                 totalPages = 3,
                                 totalResults = 3)},
-               |  "nextPage": "https://localhost:8888/$apiPrefix/works?page=2&pageSize=1",
+               |  "nextPage": "$apiScheme://$apiHost/$apiPrefix/works?page=2&pageSize=1",
                |  "results": [
                |   {
                |     "type": "Work",
@@ -134,7 +133,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
                                 pageSize = 1,
                                 totalPages = 3,
                                 totalResults = 3)},
-               |  "prevPage": "https://localhost:8888/$apiPrefix/works?page=2&pageSize=1",
+               |  "prevPage": "$apiScheme://$apiHost/$apiPrefix/works?page=2&pageSize=1",
                |  "results": [
                |   {
                |     "type": "Work",
@@ -216,8 +215,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
               andExpect = Status.Ok,
               withJsonBody = s"""
                    |{
-                   | "@context": "https://localhost:8888/$apiPrefix/context.json",
-                   | "type": "Work",
+                   | ${singleWorkResult(apiPrefix)},
                    | "id": "${work.canonicalId}",
                    | "title": "${work.title}"
                    |}
@@ -232,8 +230,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
               andExpect = Status.Ok,
               withJsonBody = s"""
                    |{
-                   | "@context": "https://localhost:8888/$apiPrefix/context.json",
-                   | "type": "Work",
+                   | ${singleWorkResult(apiPrefix)},
                    | "id": "${altWork.canonicalId}",
                    | "title": "${altWork.title}"
                    |}

--- a/api/terraform/locals.tf
+++ b/api/terraform/locals.tf
@@ -10,9 +10,9 @@ locals {
 
   # API pins
 
-  production_api     = "romulus"
+  production_api     = "remus"
   pinned_nginx       = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_api-gw:bad0dbfa548874938d16496e313b05adb71268b7"
-  pinned_remus_api   = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/api:dd9a66fa8727cd23486a8306b8946d3a38ada4a1"
+  pinned_remus_api   = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/api:e8fd84d9870c2cf198bd5046dcf528bc733cc4a3"
   pinned_romulus_api = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/api:41f52261f4250f180366bbe140bbc224c4e86ba1"
   romulus_es_config = {
     index_v1 = "v1-2019-01-24-production-changes"


### PR DESCRIPTION
It turns out that `originalRequest.path` gives you back the entire URL, `http://localhost:8888` and all. Additionally, it looks like the Finatra test helpers look for a match somewhere in the Location header, but don't check for an exact match! See https://github.com/wellcometrust/platform/issues/3470

Rather than doing our own URL-handling logic, this patch uses `java.net.URI` to unpack the original URI, replace the host/scheme with those supplied by the API config, then construct that back into a URL we can return to the user. I split this out into a separate trait for easier testing, and added an extra test.