### PR TITLE
Add query type query

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -149,6 +149,7 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
       case Some("broaderboost") => BroaderBoostQuery(queryString)
       case Some("slop")         => SlopQuery(queryString)
       case Some("minimummatch") => MinimumMatchQuery(queryString)
+      case Some("querystring")  => QueryString(queryString)
       case _                    => SimpleQuery(queryString)
     }
   }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkQuery.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkQuery.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.api.models
 
 import com.sksamuel.elastic4s.http.ElasticDsl._
-import com.sksamuel.elastic4s.searches.queries.{Query, SimpleStringQuery}
+import com.sksamuel.elastic4s.searches.queries.{Query, SimpleStringQuery, QueryStringQuery}
 import com.sksamuel.elastic4s.searches.queries.matches.{
   MultiMatchQuery,
   MultiMatchQueryBuilderType
@@ -17,6 +17,12 @@ object WorkQuery {
   case class SimpleQuery(queryString: String) extends WorkQuery {
     override def query(): SimpleStringQuery = {
       simpleStringQuery(queryString)
+    }
+  }
+
+  case class QueryString(queryString: String) extends WorkQuery {
+    override def query(): QueryStringQuery = {
+      queryStringQuery(queryString)
     }
   }
 
@@ -53,7 +59,7 @@ object WorkQuery {
       "lettering",
       "contributors"
     )
-    override def query() = {
+    override def query(): MultiMatchQuery = {
       multiMatchQuery(queryString)
         .fields(all_fields)
         .matchType(MultiMatchQueryBuilderType.PHRASE)

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/models/WorkQueryTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/models/WorkQueryTest.scala
@@ -16,7 +16,7 @@ class WorkQueryTest extends FunSpec with ElasticsearchFixtures {
 
   it("creates a QueryStringQuery") {
     assertQuery(
-      SimpleQuery("the query").query(),
+      QueryString("the query").query(),
       """{"query_string":{"query":"the query"}}""")
   }
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/models/WorkQueryTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/models/WorkQueryTest.scala
@@ -14,6 +14,12 @@ class WorkQueryTest extends FunSpec with ElasticsearchFixtures {
       """{"simple_query_string":{"query":"the query"}}""")
   }
 
+  it("creates a QueryStringQuery") {
+    assertQuery(
+      SimpleQuery("the query").query(),
+      """{"query_string":{"query":"the query"}}""")
+  }
+
   it("creates a JustBoostQuery") {
     assertQuery(
       JustBoostQuery("the query").query(),

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -7,20 +7,11 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.models.work.generators.{
-  ContributorGenerators,
-  GenreGenerators,
-  SubjectGenerators,
-  WorksGenerators
-}
+import uk.ac.wellcome.models.work.generators.{ContributorGenerators, GenreGenerators, SubjectGenerators, WorksGenerators}
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.api.generators.SearchOptionsGenerators
 import uk.ac.wellcome.platform.api.models.WorkQuery._
-import uk.ac.wellcome.platform.api.models.{
-  ItemLocationTypeFilter,
-  WorkQuery,
-  WorkTypeFilter
-}
+import uk.ac.wellcome.platform.api.models.{ItemLocationTypeFilter, WorkQuery, WorkTypeFilter}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.Random
@@ -244,16 +235,23 @@ class ElasticsearchServiceTest
 
     it("finds results for a QueryStringQuery search") {
       withLocalWorksIndex { index =>
-        val work1 = createIdentifiedWorkWith(title = "Amid an Aegean")
-        val work2 = createIdentifiedWorkWith(title = "Before a Bengal")
-        val work3 = createIdentifiedWorkWith(title = "Circling a Cheetah")
+        val workWithoutContributors = createIdentifiedWorkWith(title = "Before a Bengal", description = Some("Contributors agent label Abigail Armstrong"))
+        val workWithContributors = createIdentifiedWorkWith(title = "Amid an Aegean", contributors = List(createPersonContributorWith(s"Abigail Armstrong")))
+        val workWithoutSubjects = createIdentifiedWorkWith(title = "Circling a Cheetah", description = Some("Subjects concept label Egging on an elephant"))
+        val workWithSubjects = createIdentifiedWorkWith(title = "Dodging a dog", subjects = List(createSubjectWith(s"Egging on an elephant")))
 
-        insertIntoElasticsearch(index, work1, work2, work3)
+
+        insertIntoElasticsearch(index, workWithoutContributors, workWithContributors, workWithoutSubjects, workWithSubjects)
 
         assertSearchResultsAreCorrect(
           index = index,
-          workQuery = SimpleQuery("Aegean"),
-          expectedWorks = List(work1))
+          workQuery = QueryString("contributors.agent.label:\"Abigail Armstrong\""),
+          expectedWorks = List(workWithContributors))
+
+        assertSearchResultsAreCorrect(
+          index = index,
+          workQuery = QueryString("subjects.label:\"Egging on an elephant\""),
+          expectedWorks = List(workWithSubjects))
       }
     }
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -274,7 +274,8 @@ class ElasticsearchServiceTest
 
         assertSearchResultsAreCorrect(
           index = index,
-          workQuery = QueryString("subjects.agent.label:\"Egging on an elephant\""),
+          workQuery =
+            QueryString("subjects.agent.label:\"Egging on an elephant\""),
           expectedWorks = List(workWithSubjects))
       }
     }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -44,7 +44,7 @@ class ElasticsearchServiceTest
     createElasticsearchQueryOptions
 
   describe("simpleStringQueryResults") {
-    it("finds results for a simpleStringQuery search") {
+    it("finds results for a SimpleStringQuery search") {
       withLocalWorksIndex { index =>
         val work1 = createIdentifiedWorkWith(title = "Amid an Aegean")
         val work2 = createIdentifiedWorkWith(title = "Before a Bengal")
@@ -241,6 +241,21 @@ class ElasticsearchServiceTest
   describe("searches using Selectable queries") {
     val noMatch =
       createIdentifiedWorkWith(title = "Before a Bengal")
+
+    it("finds results for a QueryStringQuery search") {
+      withLocalWorksIndex { index =>
+        val work1 = createIdentifiedWorkWith(title = "Amid an Aegean")
+        val work2 = createIdentifiedWorkWith(title = "Before a Bengal")
+        val work3 = createIdentifiedWorkWith(title = "Circling a Cheetah")
+
+        insertIntoElasticsearch(index, work1, work2, work3)
+
+        assertSearchResultsAreCorrect(
+          index = index,
+          workQuery = SimpleQuery("Aegean"),
+          expectedWorks = List(work1))
+      }
+    }
 
     it("finds results for a JustBoostQuery search") {
       withLocalWorksIndex { index =>

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -245,12 +245,12 @@ class ElasticsearchServiceTest
 
         assertSearchResultsAreCorrect(
           index = index,
-          workQuery = QueryString("contributors.agent.label:\"Abigail Armstrong\""),
+          workQuery = QueryString("contributors.agent.agent.label:\"Abigail Armstrong\""),
           expectedWorks = List(workWithContributors))
 
         assertSearchResultsAreCorrect(
           index = index,
-          workQuery = QueryString("subjects.label:\"Egging on an elephant\""),
+          workQuery = QueryString("subjects.agent.label:\"Egging on an elephant\""),
           expectedWorks = List(workWithSubjects))
       }
     }


### PR DESCRIPTION
For some reason, as a standard, we've gone with a simple string query to Elastic Search, where a [query string query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html) would be really powerful, especially on the front end to test different querying interfaces on the web-app. 

I might need a little help on the tests, as even creating new contributors (to test the query string stuff) on a work is proving tricky.

__TODO__
- [x] write tests to check query string queries