### PR TITLE
Refactoring to improve logging of cataloguing errors

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/Main.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/Main.scala
@@ -28,7 +28,7 @@ object Main extends WellcomeTypesafeApp {
     implicit val materializer: ActorMaterializer =
       AkkaBuilder.buildActorMaterializer()
 
-    val messageReceiver = new HybridRecordReceiver[SierraTransformable](
+    val messageReceiver = new HybridRecordReceiver(
       messageWriter =
         MessagingBuilder.buildMessageWriter[TransformedBaseWork](config),
       objectStore = S3Builder.buildObjectStore[SierraTransformable](config)

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
@@ -90,7 +90,7 @@ class SierraTransformableTransformer
                 genres = getGenres(sierraBibData),
                 contributors = getContributors(sierraBibData),
                 thumbnail = None,
-                production = getProduction(sierraBibData),
+                production = getProduction(bibId, sierraBibData),
                 language = getLanguage(sierraBibData),
                 dimensions = getDimensions(sierraBibData),
                 items = getItems(

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
@@ -86,7 +86,7 @@ class SierraTransformableTransformer
                 extent = getExtent(sierraBibData),
                 lettering = getLettering(sierraBibData),
                 createdDate = None,
-                subjects = getSubjects(sierraBibData),
+                subjects = getSubjects(bibId, sierraBibData),
                 genres = getGenres(sierraBibData),
                 contributors = getContributors(sierraBibData),
                 thumbnail = None,

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/data/SierraMaterialTypes.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/data/SierraMaterialTypes.scala
@@ -47,13 +47,11 @@ object SierraMaterialTypes {
         workTypeMap.get(c) match {
           case Some(workType) => workType
           case None =>
-            throw SierraTransformerException(
-              new IllegalArgumentException(s"Unrecognised work type code: $c"))
+            throw SierraTransformerException(s"Unrecognised work type code: $c")
         }
       case _ =>
         throw SierraTransformerException(
-          new IllegalArgumentException(
-            s"Work type code is not a single character: <<$code>>"))
+          s"Work type code is not a single character: <<$code>>")
     }
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/exceptions/CataloguingException.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/exceptions/CataloguingException.scala
@@ -1,0 +1,11 @@
+package uk.ac.wellcome.platform.transformer.sierra.exceptions
+
+import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
+
+// Thrown if the data has a cataloguing error -- that is, the transformer
+// cannot handle it without a change in the source data.
+//
+// These errors are reported to a separate queue.
+//
+class CataloguingException(bibId: SierraBibNumber, message: String)
+  extends SierraTransformerException(new RuntimeException(s"${bibId.withCheckDigit}: $message"))

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/exceptions/CataloguingException.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/exceptions/CataloguingException.scala
@@ -8,9 +8,10 @@ import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 // These errors are reported to a separate queue.
 //
 class CataloguingException(bibId: SierraBibNumber, message: String)
-  extends SierraTransformerException(new RuntimeException(
-    s"Problem in the Sierra data for ${bibId.withCheckDigit}: $message"
-  ))
+    extends SierraTransformerException(
+      new RuntimeException(
+        s"Problem in the Sierra data for ${bibId.withCheckDigit}: $message"
+      ))
 
 case object CataloguingException {
   def apply(bibId: SierraBibNumber, message: String): CataloguingException =

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/exceptions/CataloguingException.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/exceptions/CataloguingException.scala
@@ -8,4 +8,11 @@ import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 // These errors are reported to a separate queue.
 //
 class CataloguingException(bibId: SierraBibNumber, message: String)
-  extends SierraTransformerException(new RuntimeException(s"${bibId.withCheckDigit}: $message"))
+  extends SierraTransformerException(new RuntimeException(
+    s"Problem in the Sierra data for ${bibId.withCheckDigit}: $message"
+  ))
+
+case object CataloguingException {
+  def apply(bibId: SierraBibNumber, message: String): CataloguingException =
+    new CataloguingException(bibId = bibId, message = message)
+}

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/HybridRecordReceiver.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/HybridRecordReceiver.scala
@@ -17,9 +17,10 @@ class HybridRecordReceiver(
   objectStore: ObjectStore[SierraTransformable])(implicit ec: ExecutionContext)
     extends Logging {
 
-  def receiveMessage(
-    message: NotificationMessage,
-    transformToWork: (SierraTransformable, Int) => Try[TransformedBaseWork]): Future[Unit] = {
+  def receiveMessage(message: NotificationMessage,
+                     transformToWork: (
+                       SierraTransformable,
+                       Int) => Try[TransformedBaseWork]): Future[Unit] = {
     debug(s"Starting to process message $message")
 
     for {
@@ -33,7 +34,8 @@ class HybridRecordReceiver(
     } yield ()
   }
 
-  private def getTransformable(hybridRecord: HybridRecord): Future[SierraTransformable] =
+  private def getTransformable(
+    hybridRecord: HybridRecord): Future[SierraTransformable] =
     objectStore.get(hybridRecord.location)
 
   private def publishMessage(

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/HybridRecordReceiver.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/HybridRecordReceiver.scala
@@ -1,13 +1,11 @@
 package uk.ac.wellcome.platform.transformer.sierra.services
 
 import grizzled.slf4j.Logging
-import io.circe.ParsingFailure
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.message.MessageWriter
 import uk.ac.wellcome.messaging.sns.{NotificationMessage, PublishAttempt}
 import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
-import uk.ac.wellcome.platform.transformer.sierra.exceptions.SierraTransformerException
 import uk.ac.wellcome.storage.ObjectStore
 import uk.ac.wellcome.storage.vhs.HybridRecord
 
@@ -24,7 +22,7 @@ class HybridRecordReceiver(
     transformToWork: (SierraTransformable, Int) => Try[TransformedBaseWork]): Future[Unit] = {
     debug(s"Starting to process message $message")
 
-    val futurePublishAttempt = for {
+    for {
       hybridRecord <- Future.fromTry(fromJson[HybridRecord](message.body))
       transformable <- getTransformable(hybridRecord)
       work <- Future.fromTry(
@@ -32,15 +30,7 @@ class HybridRecordReceiver(
       publishResult <- publishMessage(work)
       _ = debug(
         s"Published work: ${work.sourceIdentifier} with message $publishResult")
-    } yield publishResult
-
-    futurePublishAttempt
-      .recover {
-        case e: ParsingFailure =>
-          info("Recoverable failure parsing HybridRecord from message", e)
-          throw SierraTransformerException(e)
-      }
-      .map(_ => ())
+    } yield ()
   }
 
   private def getTransformable(hybridRecord: HybridRecord): Future[SierraTransformable] =

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/HybridRecordReceiver.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/HybridRecordReceiver.scala
@@ -5,6 +5,7 @@ import io.circe.ParsingFailure
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.message.MessageWriter
 import uk.ac.wellcome.messaging.sns.{NotificationMessage, PublishAttempt}
+import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.platform.transformer.sierra.exceptions.SierraTransformerException
 import uk.ac.wellcome.storage.ObjectStore
@@ -13,21 +14,21 @@ import uk.ac.wellcome.storage.vhs.HybridRecord
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
-class HybridRecordReceiver[T](
+class HybridRecordReceiver(
   messageWriter: MessageWriter[TransformedBaseWork],
-  objectStore: ObjectStore[T])(implicit ec: ExecutionContext)
+  objectStore: ObjectStore[SierraTransformable])(implicit ec: ExecutionContext)
     extends Logging {
 
   def receiveMessage(
     message: NotificationMessage,
-    transformToWork: (T, Int) => Try[TransformedBaseWork]): Future[Unit] = {
+    transformToWork: (SierraTransformable, Int) => Try[TransformedBaseWork]): Future[Unit] = {
     debug(s"Starting to process message $message")
 
     val futurePublishAttempt = for {
       hybridRecord <- Future.fromTry(fromJson[HybridRecord](message.body))
-      transformableRecord <- getTransformable(hybridRecord)
+      transformable <- getTransformable(hybridRecord)
       work <- Future.fromTry(
-        transformToWork(transformableRecord, hybridRecord.version))
+        transformToWork(transformable, hybridRecord.version))
       publishResult <- publishMessage(work)
       _ = debug(
         s"Published work: ${work.sourceIdentifier} with message $publishResult")
@@ -40,10 +41,9 @@ class HybridRecordReceiver[T](
           throw SierraTransformerException(e)
       }
       .map(_ => ())
-
   }
 
-  private def getTransformable(hybridRecord: HybridRecord): Future[T] =
+  private def getTransformable(hybridRecord: HybridRecord): Future[SierraTransformable] =
     objectStore.get(hybridRecord.location)
 
   private def publishMessage(

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/SierraTransformerWorkerService.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/SierraTransformerWorkerService.scala
@@ -4,14 +4,13 @@ import akka.Done
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.sqs.SQSStream
-import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.platform.transformer.sierra.SierraTransformableTransformer
 import uk.ac.wellcome.typesafe.Runnable
 
 import scala.concurrent.Future
 
 class SierraTransformerWorkerService(
-  messageReceiver: HybridRecordReceiver[SierraTransformable],
+  messageReceiver: HybridRecordReceiver,
   sierraTransformer: SierraTransformableTransformer,
   sqsStream: SQSStream[NotificationMessage]
 ) extends Runnable {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraProduction.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraProduction.scala
@@ -2,10 +2,7 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.platform.transformer.sierra.exceptions.{
-  CataloguingException,
-  SierraTransformerException
-}
+import uk.ac.wellcome.platform.transformer.sierra.exceptions.CataloguingException
 import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
   SierraBibData,
@@ -36,7 +33,7 @@ trait SierraProduction {
     (maybeMarc260fields, maybeMarc264fields) match {
       case (Nil, Nil)           => List()
       case (marc260fields, Nil) => getProductionFrom260Fields(marc260fields)
-      case (Nil, marc264fields) => getProductionFrom264Fields(marc264fields)
+      case (Nil, marc264fields) => getProductionFrom264Fields(bibId, marc264fields)
       case (marc260fields, marc264fields) =>
         getProductionFromBothFields(bibId, marc260fields, marc264fields)
     }
@@ -122,7 +119,7 @@ trait SierraProduction {
   //
   // https://www.loc.gov/marc/bibliographic/bd264.html
   //
-  private def getProductionFrom264Fields(varFields: List[VarField]) =
+  private def getProductionFrom264Fields(bibId: SierraBibNumber, varFields: List[VarField]) =
     varFields
       .filterNot { vf =>
         vf.indicator2.contains("4") || vf.indicator2.contains(" ")
@@ -139,8 +136,8 @@ trait SierraProduction {
           case Some("2") => "Distribution"
           case Some("3") => "Manufacture"
           case other =>
-            throw SierraTransformerException(
-              s"Unrecognised second indicator for production function: [$other]"
+            throw CataloguingException(
+              bibId, message = s"Unrecognised second indicator for production function: [$other]"
             )
         }
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraProduction.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraProduction.scala
@@ -33,7 +33,8 @@ trait SierraProduction {
     (maybeMarc260fields, maybeMarc264fields) match {
       case (Nil, Nil)           => List()
       case (marc260fields, Nil) => getProductionFrom260Fields(marc260fields)
-      case (Nil, marc264fields) => getProductionFrom264Fields(bibId, marc264fields)
+      case (Nil, marc264fields) =>
+        getProductionFrom264Fields(bibId, marc264fields)
       case (marc260fields, marc264fields) =>
         getProductionFromBothFields(bibId, marc260fields, marc264fields)
     }
@@ -119,7 +120,8 @@ trait SierraProduction {
   //
   // https://www.loc.gov/marc/bibliographic/bd264.html
   //
-  private def getProductionFrom264Fields(bibId: SierraBibNumber, varFields: List[VarField]) =
+  private def getProductionFrom264Fields(bibId: SierraBibNumber,
+                                         varFields: List[VarField]) =
     varFields
       .filterNot { vf =>
         vf.indicator2.contains("4") || vf.indicator2.contains(" ")
@@ -137,7 +139,9 @@ trait SierraProduction {
           case Some("3") => "Manufacture"
           case other =>
             throw CataloguingException(
-              bibId, message = s"Unrecognised second indicator for production function: [$other]"
+              bibId,
+              message =
+                s"Unrecognised second indicator for production function: [$other]"
             )
         }
 
@@ -166,10 +170,9 @@ trait SierraProduction {
     * In general, this is a cataloguing error, but sometimes we can do
     * something more sensible depending on if/how they're duplicated.
     */
-  private def getProductionFromBothFields(
-    bibId: SierraBibNumber,
-    marc260fields: List[VarField],
-    marc264fields: List[VarField]) = {
+  private def getProductionFromBothFields(bibId: SierraBibNumber,
+                                          marc260fields: List[VarField],
+                                          marc264fields: List[VarField]) = {
 
     // We've seen cases where the 264 field only has the following subfields:
     //
@@ -193,7 +196,8 @@ trait SierraProduction {
     // rare, so let it bubble on to a DLQ.
     else {
       throw CataloguingException(
-        bibId, message = "Record has both 260 and 264 fields."
+        bibId,
+        message = "Record has both 260 and 264 fields."
       )
     }
   }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraSubjects.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraSubjects.scala
@@ -1,9 +1,17 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
-import uk.ac.wellcome.models.work.internal.{AbstractRootConcept, MaybeDisplayable, Subject}
+import uk.ac.wellcome.models.work.internal.{
+  AbstractRootConcept,
+  MaybeDisplayable,
+  Subject
+}
 import uk.ac.wellcome.platform.transformer.sierra.source.SierraBibData
-import uk.ac.wellcome.platform.transformer.sierra.transformers.subjects.{SierraConceptSubjects, SierraOrganisationSubjects, SierraPersonSubjects}
+import uk.ac.wellcome.platform.transformer.sierra.transformers.subjects.{
+  SierraConceptSubjects,
+  SierraOrganisationSubjects,
+  SierraPersonSubjects
+}
 
 trait SierraSubjects
     extends SierraConceptSubjects

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraSubjects.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraSubjects.scala
@@ -1,24 +1,17 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
-import uk.ac.wellcome.models.work.internal.{
-  AbstractRootConcept,
-  MaybeDisplayable,
-  Subject
-}
+import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
+import uk.ac.wellcome.models.work.internal.{AbstractRootConcept, MaybeDisplayable, Subject}
 import uk.ac.wellcome.platform.transformer.sierra.source.SierraBibData
-import uk.ac.wellcome.platform.transformer.sierra.transformers.subjects.{
-  SierraConceptSubjects,
-  SierraOrganisationSubjects,
-  SierraPersonSubjects
-}
+import uk.ac.wellcome.platform.transformer.sierra.transformers.subjects.{SierraConceptSubjects, SierraOrganisationSubjects, SierraPersonSubjects}
 
 trait SierraSubjects
     extends SierraConceptSubjects
     with SierraPersonSubjects
     with SierraOrganisationSubjects {
-  def getSubjects(bibData: SierraBibData)
+  def getSubjects(bibId: SierraBibNumber, bibData: SierraBibData)
     : List[MaybeDisplayable[Subject[MaybeDisplayable[AbstractRootConcept]]]] =
     getSubjectswithAbstractConcepts(bibData) ++
       getSubjectsWithPerson(bibData) ++
-      getSubjectsWithOrganisation(bibData)
+      getSubjectsWithOrganisation(bibId, bibData)
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraOrganisationSubjects.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraOrganisationSubjects.scala
@@ -1,7 +1,8 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers.subjects
 
+import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.platform.transformer.sierra.exceptions.SierraTransformerException
+import uk.ac.wellcome.platform.transformer.sierra.exceptions.CataloguingException
 import uk.ac.wellcome.platform.transformer.sierra.source.{
   SierraBibData,
   VarField
@@ -29,13 +30,13 @@ trait SierraOrganisationSubjects extends SierraAgents with MarcUtils {
   //
   // https://www.loc.gov/marc/bibliographic/bd610.html
   //
-  def getSubjectsWithOrganisation(bibData: SierraBibData)
+  def getSubjectsWithOrganisation(bibId: SierraBibNumber, bibData: SierraBibData)
     : List[MaybeDisplayable[Subject[MaybeDisplayable[Organisation]]]] =
     getMatchingVarFields(bibData, marcTag = "610").map { varField =>
       val label =
         createLabel(varField, subfieldTags = List("a", "b", "c", "d", "e"))
 
-      val organisation = createOrganisation(varField)
+      val organisation = createOrganisation(bibId, varField)
 
       val subject = Subject(
         label = label,
@@ -49,6 +50,7 @@ trait SierraOrganisationSubjects extends SierraAgents with MarcUtils {
     }
 
   private def createOrganisation(
+    bibId: SierraBibNumber,
     varField: VarField): MaybeDisplayable[Organisation] = {
     val label = createLabel(varField, subfieldTags = List("a", "b"))
 
@@ -56,8 +58,8 @@ trait SierraOrganisationSubjects extends SierraAgents with MarcUtils {
     // enough information to build the Organisation, so erroring out here is
     // the best we can do for now.
     if (label == "") {
-      throw SierraTransformerException(
-        s"Not enough information to build a label on $varField")
+      throw CataloguingException(
+        bibId, s"Not enough information to build a label on $varField")
     }
 
     Unidentifiable(Organisation(label = label))

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraOrganisationSubjects.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraOrganisationSubjects.scala
@@ -30,7 +30,8 @@ trait SierraOrganisationSubjects extends SierraAgents with MarcUtils {
   //
   // https://www.loc.gov/marc/bibliographic/bd610.html
   //
-  def getSubjectsWithOrganisation(bibId: SierraBibNumber, bibData: SierraBibData)
+  def getSubjectsWithOrganisation(bibId: SierraBibNumber,
+                                  bibData: SierraBibData)
     : List[MaybeDisplayable[Subject[MaybeDisplayable[Organisation]]]] =
     getMatchingVarFields(bibData, marcTag = "610").map { varField =>
       val label =
@@ -59,7 +60,8 @@ trait SierraOrganisationSubjects extends SierraAgents with MarcUtils {
     // the best we can do for now.
     if (label == "") {
       throw CataloguingException(
-        bibId, s"Not enough information to build a label on $varField")
+        bibId,
+        s"Not enough information to build a label on $varField")
     }
 
     Unidentifiable(Organisation(label = label))

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformerFeatureTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformerFeatureTest.scala
@@ -97,20 +97,19 @@ class SierraTransformerFeatureTest
 
   def withWorkerService[R](topic: Topic, bucket: Bucket, queue: Queue)(
     testWith: TestWith[SierraTransformerWorkerService, R]): R =
-    withHybridRecordReceiver(topic, bucket) {
-      messageReceiver =>
-        withActorSystem { implicit actorSystem =>
-          withSQSStream[NotificationMessage, R](queue) { sqsStream =>
-            val workerService = new SierraTransformerWorkerService(
-              messageReceiver = messageReceiver,
-              sierraTransformer = new SierraTransformableTransformer,
-              sqsStream = sqsStream
-            )
+    withHybridRecordReceiver(topic, bucket) { messageReceiver =>
+      withActorSystem { implicit actorSystem =>
+        withSQSStream[NotificationMessage, R](queue) { sqsStream =>
+          val workerService = new SierraTransformerWorkerService(
+            messageReceiver = messageReceiver,
+            sierraTransformer = new SierraTransformableTransformer,
+            sqsStream = sqsStream
+          )
 
-            workerService.run()
+          workerService.run()
 
-            testWith(workerService)
-          }
+          testWith(workerService)
         }
+      }
     }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformerFeatureTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformerFeatureTest.scala
@@ -97,7 +97,7 @@ class SierraTransformerFeatureTest
 
   def withWorkerService[R](topic: Topic, bucket: Bucket, queue: Queue)(
     testWith: TestWith[SierraTransformerWorkerService, R]): R =
-    withHybridRecordReceiver[SierraTransformable, R](topic, bucket) {
+    withHybridRecordReceiver(topic, bucket) {
       messageReceiver =>
         withActorSystem { implicit actorSystem =>
           withSQSStream[NotificationMessage, R](queue) { sqsStream =>

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/fixtures/HybridRecordReceiverFixture.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/fixtures/HybridRecordReceiverFixture.scala
@@ -9,21 +9,22 @@ import uk.ac.wellcome.platform.transformer.sierra.services.HybridRecordReceiver
 import uk.ac.wellcome.storage.ObjectStore
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
 import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.models.transformable.SierraTransformable
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
 trait HybridRecordReceiverFixture extends Messaging with SNS {
-  def withHybridRecordReceiver[T, R](
+  def withHybridRecordReceiver[R](
     topic: Topic,
     bucket: Bucket,
     snsClient: AmazonSNS = snsClient
-  )(testWith: TestWith[HybridRecordReceiver[T], R])(
-    implicit objectStore: ObjectStore[T]): R =
+  )(testWith: TestWith[HybridRecordReceiver, R])(
+    implicit objectStore: ObjectStore[SierraTransformable]): R =
     withMessageWriter[TransformedBaseWork, R](
       bucket,
       topic,
       writerSnsClient = snsClient) { messageWriter =>
-      val recordReceiver = new HybridRecordReceiver[T](
+      val recordReceiver = new HybridRecordReceiver(
         messageWriter = messageWriter,
         objectStore = objectStore
       )

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/services/HybridRecordReceiverTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/services/HybridRecordReceiverTest.scala
@@ -2,6 +2,7 @@ package uk.ac.wellcome.platform.transformer.sierra.services
 
 import com.amazonaws.services.sns.AmazonSNS
 import com.amazonaws.services.sns.model.PublishRequest
+import io.circe.ParsingFailure
 import org.mockito.Matchers.any
 import org.mockito.Mockito.when
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
@@ -18,7 +19,6 @@ import uk.ac.wellcome.models.work.internal.{
   TransformedBaseWork,
   UnidentifiedWork
 }
-import uk.ac.wellcome.platform.transformer.sierra.exceptions.SierraTransformerException
 import uk.ac.wellcome.platform.transformer.sierra.fixtures.HybridRecordReceiverFixture
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.vhs.HybridRecord
@@ -125,7 +125,7 @@ class HybridRecordReceiverTest
               recordReceiver.receiveMessage(invalidSqsMessage, transformToWork)
 
             whenReady(future.failed) { x =>
-              x shouldBe a[SierraTransformerException]
+              x shouldBe a[ParsingFailure]
             }
         }
       }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/services/HybridRecordReceiverTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/services/HybridRecordReceiverTest.scala
@@ -53,9 +53,7 @@ class HybridRecordReceiverTest
           bucket = bucket
         )
 
-        withHybridRecordReceiver(
-          topic,
-          bucket) { recordReceiver =>
+        withHybridRecordReceiver(topic, bucket) { recordReceiver =>
           val future =
             recordReceiver.receiveMessage(sqsMessage, transformToWork)
 
@@ -83,9 +81,7 @@ class HybridRecordReceiverTest
           bucket = bucket
         )
 
-        withHybridRecordReceiver(
-          topic,
-          bucket) { recordReceiver =>
+        withHybridRecordReceiver(topic, bucket) { recordReceiver =>
           val future =
             recordReceiver.receiveMessage(notification, transformToWork)
 
@@ -119,14 +115,13 @@ class HybridRecordReceiverTest
           message = hybridRecord
         )
 
-        withHybridRecordReceiver(topic, bucket) {
-          recordReceiver =>
-            val future =
-              recordReceiver.receiveMessage(invalidSqsMessage, transformToWork)
+        withHybridRecordReceiver(topic, bucket) { recordReceiver =>
+          val future =
+            recordReceiver.receiveMessage(invalidSqsMessage, transformToWork)
 
-            whenReady(future.failed) { x =>
-              x shouldBe a[ParsingFailure]
-            }
+          whenReady(future.failed) { x =>
+            x shouldBe a[ParsingFailure]
+          }
         }
       }
     }
@@ -139,14 +134,13 @@ class HybridRecordReceiverTest
           message = Random.alphanumeric take 50 mkString
         )
 
-        withHybridRecordReceiver(topic, bucket) {
-          recordReceiver =>
-            val future =
-              recordReceiver.receiveMessage(invalidSqsMessage, transformToWork)
+        withHybridRecordReceiver(topic, bucket) { recordReceiver =>
+          val future =
+            recordReceiver.receiveMessage(invalidSqsMessage, transformToWork)
 
-            whenReady(future.failed) {
-              _ shouldBe a[JsonDecodingError]
-            }
+          whenReady(future.failed) {
+            _ shouldBe a[JsonDecodingError]
+          }
         }
       }
     }
@@ -160,16 +154,15 @@ class HybridRecordReceiverTest
           bucket = bucket
         )
 
-        withHybridRecordReceiver(topic, bucket) {
-          recordReceiver =>
-            val future =
-              recordReceiver.receiveMessage(
-                failingSqsMessage,
-                failingTransformToWork)
+        withHybridRecordReceiver(topic, bucket) { recordReceiver =>
+          val future =
+            recordReceiver.receiveMessage(
+              failingSqsMessage,
+              failingTransformToWork)
 
-            whenReady(future.failed) {
-              _ shouldBe a[TestException]
-            }
+          whenReady(future.failed) {
+            _ shouldBe a[TestException]
+          }
         }
       }
     }
@@ -183,15 +176,13 @@ class HybridRecordReceiverTest
           bucket = bucket
         )
 
-        withHybridRecordReceiver(
-          topic,
-          bucket,
-          mockSnsClientFailPublishMessage) { recordReceiver =>
-          val future = recordReceiver.receiveMessage(message, transformToWork)
+        withHybridRecordReceiver(topic, bucket, mockSnsClientFailPublishMessage) {
+          recordReceiver =>
+            val future = recordReceiver.receiveMessage(message, transformToWork)
 
-          whenReady(future.failed) {
-            _.getMessage should be("Failed publishing message")
-          }
+            whenReady(future.failed) {
+              _.getMessage should be("Failed publishing message")
+            }
         }
       }
     }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraProductionTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraProductionTest.scala
@@ -298,7 +298,8 @@ class SierraProductionTest
 
         caught.getMessage should startWith("Problem in the Sierra data")
         caught.getMessage should include(bibId.withoutCheckDigit)
-        caught.getMessage should include("Unrecognised second indicator for production function")
+        caught.getMessage should include(
+          "Unrecognised second indicator for production function")
       }
     }
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraProductionTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraProductionTest.scala
@@ -2,10 +2,7 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.platform.transformer.sierra.exceptions.{
-  CataloguingException,
-  SierraTransformerException
-}
+import uk.ac.wellcome.platform.transformer.sierra.exceptions.CataloguingException
 import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
   VarField
@@ -292,11 +289,16 @@ class SierraProductionTest
           )
         )
 
-        val caught = intercept[SierraTransformerException] {
-          transformToProduction(varFields)
+        val bibData = createSierraBibDataWith(varFields = varFields)
+        val bibId = createSierraBibNumber
+
+        val caught = intercept[CataloguingException] {
+          transformer.getProduction(bibId, bibData)
         }
 
-        caught.e.getMessage shouldBe "Unrecognised second indicator for production function: [Some(x)]"
+        caught.getMessage should startWith("Problem in the Sierra data")
+        caught.getMessage should include(bibId.withoutCheckDigit)
+        caught.getMessage should include("Unrecognised second indicator for production function")
       }
     }
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraProductionTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraProductionTest.scala
@@ -563,14 +563,14 @@ class SierraProductionTest
     val bibData = createSierraBibDataWith(varFields = varFields)
 
     intercept[SierraTransformerException] {
-      transformer.getProduction(bibData)
+      transformer.getProduction(bibId = createSierraBibNumber, bibData)
     }
   }
 
   private def transformToProduction(varFields: List[VarField])
     : List[ProductionEvent[MaybeDisplayable[AbstractAgent]]] = {
     val bibData = createSierraBibDataWith(varFields = varFields)
-    transformer.getProduction(bibData)
+    transformer.getProduction(bibId = createSierraBibNumber, bibData)
   }
 
   val transformer = new SierraProduction {}

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraOrganisationSubjectsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraOrganisationSubjectsTest.scala
@@ -5,7 +5,11 @@ import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.sierra.exceptions.CataloguingException
 import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
-import uk.ac.wellcome.platform.transformer.sierra.source.{MarcSubfield, SierraBibData, VarField}
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  MarcSubfield,
+  SierraBibData,
+  VarField
+}
 
 class SierraOrganisationSubjectsTest
     extends FunSpec
@@ -13,7 +17,9 @@ class SierraOrganisationSubjectsTest
     with SierraDataGenerators {
   it("returns an empty list if there are no instances of MARC tag 610") {
     val bibData = createSierraBibDataWith(varFields = List())
-    transformer.getSubjectsWithOrganisation(bibId = createSierraBibNumber, bibData) shouldBe List()
+    transformer.getSubjectsWithOrganisation(
+      bibId = createSierraBibNumber,
+      bibData) shouldBe List()
   }
 
   describe("label") {
@@ -182,7 +188,8 @@ class SierraOrganisationSubjectsTest
 
       caught.getMessage should startWith("Problem in the Sierra data")
       caught.getMessage should include(bibId.withoutCheckDigit)
-      caught.getMessage should include("Not enough information to build a label")
+      caught.getMessage should include(
+        "Not enough information to build a label")
     }
   }
 
@@ -230,8 +237,8 @@ class SierraOrganisationSubjectsTest
 
   val transformer = new SierraOrganisationSubjects {}
 
-  private def getOrganisationSubjects(
-    bibData: SierraBibData,
-    bibId: SierraBibNumber = createSierraBibNumber) =
+  private def getOrganisationSubjects(bibData: SierraBibData,
+                                      bibId: SierraBibNumber =
+                                        createSierraBibNumber) =
     transformer.getSubjectsWithOrganisation(bibId = bibId, bibData = bibData)
 }


### PR DESCRIPTION
A first step towards https://github.com/wellcometrust/platform/issues/2562

This patch adds a new exception "CataloguingException", which records information about the affected bib record if/when we detect a cataloguing error. The current log isn't so helpful:

```
SierraTransformerException: Record has both 260 and 264 fields; this is a cataloguing error.
```

This patch adds the affected bib number, which should make it easier to parse the logs and work out which records are failing, and why.

It also opens the door to sending them to a different topic/dashboard at a later date.