### PR TITLE
Fix logging in the catalogue apps

### DIFF
--- a/api/api/src/test/resources/logback-test.xml
+++ b/api/api/src/test/resources/logback-test.xml
@@ -1,8 +1,11 @@
 <configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
   <root level="DEBUG">
     <appender-ref ref="STDOUT" />
   </root>
-
-  <logger name="io.swagger" level="ERROR"/>
-  <logger name="uk.ac.wellcome.platform.api.Server" level="INFO"/>
 </configuration>

--- a/goobi_adapter/goobi_reader/src/main/resources/logback.xml
+++ b/goobi_adapter/goobi_reader/src/main/resources/logback.xml
@@ -1,3 +1,16 @@
 <configuration>
-  <include resource="base-logback.xml"/>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="${log_level:-INFO}">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <!-- reduce external logging -->
+  <logger name="org.apache.http" level="ERROR"/>
+  <logger name="io.netty" level="ERROR"/>
+  <logger name="com.amazonaws" level="WARN"/>
 </configuration>

--- a/goobi_adapter/goobi_reader/src/test/resources/logback-test.xml
+++ b/goobi_adapter/goobi_reader/src/test/resources/logback-test.xml
@@ -1,5 +1,11 @@
 <configuration>
-  <include resource="base-logback-test.xml"/>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
 
-  <logger name="uk.ac.wellcome.platform.goobi_reader.Server" level="WARN"/>
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT" />
+  </root>
 </configuration>

--- a/pipeline/id_minter/src/test/resources/logback-test.xml
+++ b/pipeline/id_minter/src/test/resources/logback-test.xml
@@ -1,9 +1,11 @@
 <configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
   <root level="DEBUG">
     <appender-ref ref="STDOUT" />
   </root>
-
-  <logger name="org.flywaydb.core" level="WARN"/>
-  <logger name="scalikejdbc" level="INFO"/>
-  <logger name="uk.ac.wellcome.platform.idminter.Server" level="INFO"/>
 </configuration>

--- a/pipeline/ingestor/src/test/resources/logback-test.xml
+++ b/pipeline/ingestor/src/test/resources/logback-test.xml
@@ -1,4 +1,10 @@
 <configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
   <root level="DEBUG">
     <appender-ref ref="STDOUT" />
   </root>

--- a/pipeline/matcher/src/main/resources/logback.xml
+++ b/pipeline/matcher/src/main/resources/logback.xml
@@ -1,16 +1,16 @@
 <configuration>
-<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-  <encoder>
-    <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-  </encoder>
-</appender>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
 
-<root level="${log_level:-INFO}">
-  <appender-ref ref="STDOUT" />
-</root>
+  <root level="${log_level:-INFO}">
+    <appender-ref ref="STDOUT" />
+  </root>
 
-<!-- reduce external logging -->
-<logger name="org.apache.http" level="ERROR"/>
-<logger name="io.netty" level="ERROR"/>
-<logger name="com.amazonaws" level="WARN"/>
+  <!-- reduce external logging -->
+  <logger name="org.apache.http" level="ERROR"/>
+  <logger name="io.netty" level="ERROR"/>
+  <logger name="com.amazonaws" level="WARN"/>
 </configuration>

--- a/pipeline/matcher/src/test/resources/logback-test.xml
+++ b/pipeline/matcher/src/test/resources/logback-test.xml
@@ -1,4 +1,10 @@
 <configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
   <root level="DEBUG">
     <appender-ref ref="STDOUT" />
   </root>

--- a/pipeline/merger/src/test/resources/logback-test.xml
+++ b/pipeline/merger/src/test/resources/logback-test.xml
@@ -1,4 +1,10 @@
 <configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
   <root level="DEBUG">
     <appender-ref ref="STDOUT" />
   </root>

--- a/pipeline/recorder/src/test/resources/logback-test.xml
+++ b/pipeline/recorder/src/test/resources/logback-test.xml
@@ -1,4 +1,10 @@
 <configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
   <root level="DEBUG">
     <appender-ref ref="STDOUT" />
   </root>

--- a/pipeline/transformer/transformer_miro/src/main/resources/logback.xml
+++ b/pipeline/transformer/transformer_miro/src/main/resources/logback.xml
@@ -1,3 +1,16 @@
 <configuration>
-  <include resource="base-logback.xml"/>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="${log_level:-INFO}">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <!-- reduce external logging -->
+  <logger name="org.apache.http" level="ERROR"/>
+  <logger name="io.netty" level="ERROR"/>
+  <logger name="com.amazonaws" level="WARN"/>
 </configuration>

--- a/pipeline/transformer/transformer_miro/src/test/resources/logback-test.xml
+++ b/pipeline/transformer/transformer_miro/src/test/resources/logback-test.xml
@@ -1,5 +1,11 @@
 <configuration>
-  <include resource="base-logback-test.xml"/>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
 
-  <logger name="uk.ac.wellcome.platform.transformer" level="INFO"/>
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT" />
+  </root>
 </configuration>

--- a/pipeline/transformer/transformer_sierra/src/main/resources/logback.xml
+++ b/pipeline/transformer/transformer_sierra/src/main/resources/logback.xml
@@ -1,3 +1,16 @@
 <configuration>
-  <include resource="base-logback.xml"/>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="${log_level:-INFO}">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <!-- reduce external logging -->
+  <logger name="org.apache.http" level="ERROR"/>
+  <logger name="io.netty" level="ERROR"/>
+  <logger name="com.amazonaws" level="WARN"/>
 </configuration>

--- a/pipeline/transformer/transformer_sierra/src/test/resources/logback-test.xml
+++ b/pipeline/transformer/transformer_sierra/src/test/resources/logback-test.xml
@@ -1,5 +1,11 @@
 <configuration>
-  <include resource="base-logback-test.xml"/>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
 
-  <logger name="uk.ac.wellcome.platform.transformer" level="INFO"/>
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT" />
+  </root>
 </configuration>

--- a/reindexer/reindex_worker/src/main/resources/logback.xml
+++ b/reindexer/reindex_worker/src/main/resources/logback.xml
@@ -1,3 +1,16 @@
 <configuration>
-  <include resource="base-logback.xml"/>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="${log_level:-INFO}">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <!-- reduce external logging -->
+  <logger name="org.apache.http" level="ERROR"/>
+  <logger name="io.netty" level="ERROR"/>
+  <logger name="com.amazonaws" level="WARN"/>
 </configuration>

--- a/reindexer/reindex_worker/src/test/resources/logback-test.xml
+++ b/reindexer/reindex_worker/src/test/resources/logback-test.xml
@@ -1,5 +1,11 @@
 <configuration>
-  <include resource="base-logback-test.xml"/>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
 
-  <logger name="uk.ac.wellcome.platform.reindex.reindex_worker.Server" level="WARN"/>
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT" />
+  </root>
 </configuration>

--- a/sierra_adapter/common/src/test/resources/logback-test.xml
+++ b/sierra_adapter/common/src/test/resources/logback-test.xml
@@ -1,3 +1,11 @@
 <configuration>
-  <include resource="base-logback-test.xml"/>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT" />
+  </root>
 </configuration>

--- a/sierra_adapter/sierra_bib_merger/src/main/resources/logback.xml
+++ b/sierra_adapter/sierra_bib_merger/src/main/resources/logback.xml
@@ -1,3 +1,16 @@
 <configuration>
-  <include resource="base-logback.xml"/>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="${log_level:-INFO}">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <!-- reduce external logging -->
+  <logger name="org.apache.http" level="ERROR"/>
+  <logger name="io.netty" level="ERROR"/>
+  <logger name="com.amazonaws" level="WARN"/>
 </configuration>

--- a/sierra_adapter/sierra_bib_merger/src/test/resources/logback-test.xml
+++ b/sierra_adapter/sierra_bib_merger/src/test/resources/logback-test.xml
@@ -1,5 +1,11 @@
 <configuration>
-  <include resource="base-logback-test.xml"/>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
 
-  <logger name="uk.ac.wellcome.platform.sierra_bib_merger.Server" level="WARN"/>
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT" />
+  </root>
 </configuration>

--- a/sierra_adapter/sierra_item_merger/src/main/resources/logback.xml
+++ b/sierra_adapter/sierra_item_merger/src/main/resources/logback.xml
@@ -1,3 +1,16 @@
 <configuration>
-  <include resource="base-logback.xml"/>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="${log_level:-INFO}">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <!-- reduce external logging -->
+  <logger name="org.apache.http" level="ERROR"/>
+  <logger name="io.netty" level="ERROR"/>
+  <logger name="com.amazonaws" level="WARN"/>
 </configuration>

--- a/sierra_adapter/sierra_item_merger/src/test/resources/logback-test.xml
+++ b/sierra_adapter/sierra_item_merger/src/test/resources/logback-test.xml
@@ -1,5 +1,11 @@
 <configuration>
-  <include resource="base-logback-test.xml"/>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
 
-  <logger name="uk.ac.wellcome.platform.sierra_item_merger.Server" level="WARN"/>
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT" />
+  </root>
 </configuration>

--- a/sierra_adapter/sierra_items_to_dynamo/src/main/resources/logback.xml
+++ b/sierra_adapter/sierra_items_to_dynamo/src/main/resources/logback.xml
@@ -1,3 +1,16 @@
 <configuration>
-  <include resource="base-logback.xml"/>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="${log_level:-INFO}">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <!-- reduce external logging -->
+  <logger name="org.apache.http" level="ERROR"/>
+  <logger name="io.netty" level="ERROR"/>
+  <logger name="com.amazonaws" level="WARN"/>
 </configuration>

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/resources/logback-test.xml
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/resources/logback-test.xml
@@ -1,5 +1,11 @@
 <configuration>
-  <include resource="base-logback-test.xml"/>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
 
-  <logger name="uk.ac.wellcome.platform.sierra_items_to_dynamo.Server" level="WARN"/>
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT" />
+  </root>
 </configuration>

--- a/sierra_adapter/sierra_reader/src/main/resources/logback.xml
+++ b/sierra_adapter/sierra_reader/src/main/resources/logback.xml
@@ -1,3 +1,16 @@
 <configuration>
-  <include resource="base-logback.xml"/>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="${log_level:-INFO}">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <!-- reduce external logging -->
+  <logger name="org.apache.http" level="ERROR"/>
+  <logger name="io.netty" level="ERROR"/>
+  <logger name="com.amazonaws" level="WARN"/>
 </configuration>

--- a/sierra_adapter/sierra_reader/src/test/resources/logback-test.xml
+++ b/sierra_adapter/sierra_reader/src/test/resources/logback-test.xml
@@ -1,5 +1,11 @@
 <configuration>
-  <include resource="base-logback-test.xml"/>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
 
-  <logger name="uk.ac.wellcome.platform.sierra_reader.Server" level="WARN"/>
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT" />
+  </root>
 </configuration>

--- a/sierra_adapter/terraform/items_to_dynamo/terraform.tf
+++ b/sierra_adapter/terraform/items_to_dynamo/terraform.tf
@@ -2,6 +2,8 @@ data "terraform_remote_state" "catalogue_pipeline_data" {
   backend = "s3"
 
   config {
+    role_arn = "arn:aws:iam::760097843905:role/developer"
+
     bucket = "wellcomecollection-platform-infra"
     key    = "terraform/catalogue_pipeline_data.tfstate"
     region = "eu-west-1"

--- a/snapshots/snapshot_generator/src/main/resources/logback.xml
+++ b/snapshots/snapshot_generator/src/main/resources/logback.xml
@@ -1,3 +1,16 @@
 <configuration>
-  <include resource="base-logback.xml"/>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="${log_level:-INFO}">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <!-- reduce external logging -->
+  <logger name="org.apache.http" level="ERROR"/>
+  <logger name="io.netty" level="ERROR"/>
+  <logger name="com.amazonaws" level="WARN"/>
 </configuration>

--- a/snapshots/snapshot_generator/src/test/resources/logback-test.xml
+++ b/snapshots/snapshot_generator/src/test/resources/logback-test.xml
@@ -1,5 +1,11 @@
 <configuration>
-  <include resource="base-logback-test.xml"/>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
 
-  <logger name="uk.ac.wellcome.platform.snapshot_generator.Server" level="INFO"/>
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT" />
+  </root>
 </configuration>


### PR DESCRIPTION
Resolves https://github.com/wellcometrust/platform/issues/3490, and I’ve checked we get the nice error messages now, e.g.:

```
uk.ac.wellcome.platform.transformer.sierra.exceptions.CataloguingException: Problem in the Sierra data for b30860192: Record has both 260 and 264 fields.
```