### PR TITLE
Make the transformer a little more tolerant of incorrect 264 fields

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraProduction.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraProduction.scala
@@ -165,8 +165,7 @@ trait SierraProduction {
       case _ => false
     }
 
-  private def marc264IsOnlyPunctuation(
-    marc264fields: List[VarField]): Boolean =
+  private def marc264IsOnlyPunctuation(marc264fields: List[VarField]): Boolean =
     marc264fields
       .map { vf: VarField =>
         vf.subfields.map { _.content }.mkString("")

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraProductionTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraProductionTest.scala
@@ -467,8 +467,7 @@ class SierraProductionTest
       caught.getMessage should include("Record has both 260 and 264 fields")
     }
 
-    it(
-      "uses field 260 if field 264 only contains a copyright statement in subfield c") {
+    it("uses 260 if 264 only contains a copyright statement in subfield c") {
       val varFields = List(
         createVarFieldWith(
           marcTag = "260",
@@ -532,6 +531,36 @@ class SierraProductionTest
       )
 
       transformToProduction(varFields) shouldBe expectedProductions
+    }
+
+    // Based on b31500018, as retrieved on 28 March 2019
+    it("returns correctly if the 264 subfields only contain punctuation") {
+      val varFields = List(
+        createVarFieldWith(
+          marcTag = "260",
+          subfields = List(
+            MarcSubfield(tag = "c", content = "2019")
+          )
+        ),
+        createVarFieldWith(
+          marcTag = "264",
+          subfields = List(
+            MarcSubfield(tag = "a", content = ":"),
+            MarcSubfield(tag = "b", content = ","),
+            MarcSubfield(tag = "c", content = "")
+          )
+        )
+      )
+
+      transformToProduction(varFields) shouldBe List(
+        ProductionEvent(
+          label = "2019",
+          places = List(),
+          agents = List(),
+          dates = List(Period("2019")),
+          function = None
+        )
+      )
     }
   }
 


### PR DESCRIPTION
Pretty much all the recent Sierra transformer errors have been because the MARC record contains 260 and 264 fields, except the 264 field doesn't tell us anything useful:

```
260    2019 
264  1 :|b,|c 
```

We can detect these and not throw an error pretty easily, which should make the pipeline a bit less chatty.