### PR TITLE
Release secondary-miro-merges 

### DIFF
--- a/api/terraform/locals.tf
+++ b/api/terraform/locals.tf
@@ -8,13 +8,13 @@ locals {
 
   # API pins
 
-  production_api     = "remus"
+  production_api     = "romulus"
   pinned_nginx       = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_api-gw:bad0dbfa548874938d16496e313b05adb71268b7"
   pinned_remus_api   = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/api:e8fd84d9870c2cf198bd5046dcf528bc733cc4a3"
-  pinned_romulus_api = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/api:41f52261f4250f180366bbe140bbc224c4e86ba1"
+  pinned_romulus_api = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/api:e8fd84d9870c2cf198bd5046dcf528bc733cc4a3"
   romulus_es_config = {
     index_v1 = "v1-2019-01-24-production-changes"
-    index_v2 = "v2-2019-02-05-extra-subject-labels"
+    index_v2 = "v2-2019-04-16-secondary-miro-merge-candidates"
     doc_type = "work"
   }
   remus_es_config = {

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -1,7 +1,7 @@
-module "catalogue_pipeline_20190205" {
+module "catalogue_pipeline_20190416" {
   source = "stack"
 
-  namespace = "catalogue-20190205"
+  namespace = "catalogue-20190416"
 
   release_label = "latest"
 
@@ -15,29 +15,25 @@ module "catalogue_pipeline_20190205" {
   # Transformer config
   #
   # If this pipeline is meant to be reindexed, remember to uncomment the
-  # reindexer topic names.
+  # reindexer topic names_qs.
 
   sierra_adapter_topic_names = [
-    # "${local.sierra_reindexer_topic_name}",
+    "${local.sierra_reindexer_topic_name}",
     "${local.sierra_merged_bibs_topic_name}",
-
     "${local.sierra_merged_items_topic_name}",
   ]
   miro_adapter_topic_names = [
-    # "${local.miro_reindexer_topic_name}",
+    "${local.miro_reindexer_topic_name}",
     "${local.miro_updates_topic_name}",
   ]
 
   # Elasticsearch
-
-  es_works_index = "v2-2019-02-05-extra-subject-labels"
+  es_works_index = "v2-2019-04-16-secondary-miro-merge-candidates"
 
   # RDS
-
   rds_ids_access_security_group_id = "${local.rds_access_security_group_id}"
 
   # Adapter VHS
-
   vhs_sierra_read_policy = "${local.vhs_sierra_read_policy}"
   vhs_miro_read_policy   = "${local.vhs_miro_read_policy}"
 }

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -15,7 +15,7 @@ module "catalogue_pipeline_20190416" {
   # Transformer config
   #
   # If this pipeline is meant to be reindexed, remember to uncomment the
-  # reindexer topic names_qs.
+  # reindexer topic names.
 
   sierra_adapter_topic_names = [
     "${local.sierra_reindexer_topic_name}",

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -26,13 +26,10 @@ module "catalogue_pipeline_20190416" {
     "${local.miro_reindexer_topic_name}",
     "${local.miro_updates_topic_name}",
   ]
-
   # Elasticsearch
   es_works_index = "v2-2019-04-16-secondary-miro-merge-candidates"
-
   # RDS
   rds_ids_access_security_group_id = "${local.rds_access_security_group_id}"
-
   # Adapter VHS
   vhs_sierra_read_policy = "${local.vhs_sierra_read_policy}"
   vhs_miro_read_policy   = "${local.vhs_miro_read_policy}"


### PR DESCRIPTION
Release secondary-miro-merges to the production api.

Update to index `v2-2019-04-16-secondary-miro-merge-candidates` with Miro merges.