### PR TITLE
Extend label to be subfields a,b,c,d,t and remove prefix / numeration from person 

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAgents.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAgents.scala
@@ -89,7 +89,7 @@ trait SierraAgents {
 
   def getLabel(subfields: List[MarcSubfield]): Option[String] =
     subfields.filter { s =>
-      List("a", "b", "c", "t").contains(s.tag)
+      List("a", "b", "c", "d", "t").contains(s.tag)
     } map (_.content) match {
       case Nil          => None
       case nonEmptyList => Some(nonEmptyList mkString " ")

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraContributors.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraContributors.scala
@@ -43,7 +43,7 @@ trait SierraContributors extends MarcUtils with SierraAgents {
     val persons = getMatchingSubfields(
       bibData,
       marcTag = marcTag,
-      marcSubfieldTags = List("a", "b", "c", "e", "t", "0")
+      marcSubfieldTags = List("a", "b", "c", "d", "e", "t", "0")
     )
 
     persons
@@ -86,7 +86,7 @@ trait SierraContributors extends MarcUtils with SierraAgents {
     val organisations = getMatchingSubfields(
       bibData,
       marcTag = marcTag,
-      marcSubfieldTags = List("a", "b", "c", "e", "0")
+      marcSubfieldTags = List("a", "b", "c", "d", "e", "0")
     )
 
     organisations

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraPersonSubjects.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraPersonSubjects.scala
@@ -43,11 +43,11 @@ trait SierraPersonSubjects extends MarcUtils with SierraAgents {
       .filterNot { _.indicator2.contains("7") }
       .flatMap { varField: VarField =>
         val subfields = varField.subfields
-        val maybePerson = getPerson(subfields)
+        val maybePerson =
+          getPerson(subfields)
         val generalSubdivisions =
           varField.subfields
             .collect {
-              case MarcSubfield("t", content) => content
               case MarcSubfield("x", content) => content
             }
 
@@ -76,7 +76,7 @@ trait SierraPersonSubjects extends MarcUtils with SierraAgents {
                                     roles: List[String],
                                     dates: Option[String],
                                     generalSubdivisions: List[String]): String =
-    (List(person.label) ++ person.numeration ++ person.prefix ++ dates ++ roles ++ generalSubdivisions)
+    (List(person.label) ++ roles ++ generalSubdivisions)
       .mkString(" ")
 
   private def getConcepts(person: Person, generalSubdivisions: List[String])

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraContributorsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraContributorsTest.scala
@@ -73,8 +73,7 @@ class SierraContributorsTest
   }
 
   describe("Person") {
-    it(
-      "combines only subfields $$a $$b $$c with spaces from MARC field 100 / 700") {
+    it("extracts and combines only subfields $$a $$b $$c $$d for the label") {
       // Based on https://search.wellcomelibrary.org/iii/encore/record/C__Rb1795764?lang=eng
       // as retrieved on 25 April 2019.
 
@@ -95,12 +94,10 @@ class SierraContributorsTest
       val varFields = List(varField100, varField700)
 
       val expectedContributors = List(
-        Contributor(
-          agent = Unidentifiable(
-            Person(label = "Charles Emmanuel III, King of Sardinia"))),
-        Contributor(
-          agent = Unidentifiable(
-            Person(label = "Charles Emmanuel III, King of Sardinia")))
+        Contributor(agent = Unidentifiable(
+          Person(label = "Charles Emmanuel III, King of Sardinia, 1701-1773"))),
+        Contributor(agent = Unidentifiable(
+          Person(label = "Charles Emmanuel III, King of Sardinia, 1701-1773")))
       )
 
       transformAndCheckContributors(
@@ -109,7 +106,7 @@ class SierraContributorsTest
     }
 
     it(
-      "combines subfield $$t with $$a $$b $$c and creates an Agent, not a Person from MARC field 100 / 700") {
+      "combines subfield $$t with $$a $$b $$c $$d and creates an Agent, not a Person from MARC field 100 / 700") {
       // Based on https://search.wellcomelibrary.org/iii/encore/record/C__Rb1159639?marcData=Y
       // as retrieved on 4 February 2019.
       val varFields = List(
@@ -129,7 +126,7 @@ class SierraContributorsTest
       val contributor = contributors.head
 
       contributor.agent shouldBe Unidentifiable(
-        Agent(label = "Shakespeare, William, Hamlet."))
+        Agent(label = "Shakespeare, William, 1564-1616. Hamlet."))
     }
 
     it(
@@ -342,27 +339,30 @@ class SierraContributorsTest
     }
 
     it(
-      "combines only multiple subfields $$a $$b $$c with spaces from MARC field 110 / 710") {
-      // Based on https://search.wellcomelibrary.org/iii/encore/record/C__Rb1563778?lang=eng
+      "combines only subfields $$a $$b $$c $$d (multiples of) with spaces from MARC field 110 / 710") {
+      // Based on https://search.wellcomelibrary.org/iii/encore/record/C__Rb1000984
       // as retrieved from 25 April 2019
-      val name = "United States."
-      val subordinateUnit1 = "Office of the Assistant Secretary for Health."
-      val subordinateUnit2 = "Office of Research Integrity."
+      val name =
+        "IARC Working Group on the Evaluation of the Carcinogenic Risk of Chemicals to Man."
+      val subordinateUnit = "Meeting"
+      val date = "1972 :"
+      val place = "Lyon, France"
 
       val varFields = List(
         createVarFieldWith(
           marcTag = "110",
           subfields = List(
             MarcSubfield(tag = "a", content = name),
-            MarcSubfield(tag = "b", content = subordinateUnit1),
-            MarcSubfield(tag = "b", content = subordinateUnit2)
+            MarcSubfield(tag = "b", content = subordinateUnit),
+            MarcSubfield(tag = "d", content = date),
+            MarcSubfield(tag = "c", content = place)
           )
         )
       )
 
       val expectedContributors = List(
         Contributor(agent = Unidentifiable(Organisation(label =
-          "United States. Office of the Assistant Secretary for Health. Office of Research Integrity.")))
+          "IARC Working Group on the Evaluation of the Carcinogenic Risk of Chemicals to Man. Meeting 1972 : Lyon, France")))
       )
 
       transformAndCheckContributors(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraContributorsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraContributorsTest.scala
@@ -341,18 +341,28 @@ class SierraContributorsTest
         expectedContributors = expectedContributors)
     }
 
-    it("gets the name from MARC tag 710 subfield $$a") {
-      val name = "Karl the kale"
+    it(
+      "combines only multiple subfields $$a $$b $$c with spaces from MARC field 110 / 710") {
+      // Based on https://search.wellcomelibrary.org/iii/encore/record/C__Rb1563778?lang=eng
+      // as retrieved from 25 April 2019
+      val name = "United States."
+      val subordinateUnit1 = "Office of the Assistant Secretary for Health."
+      val subordinateUnit2 = "Office of Research Integrity."
 
       val varFields = List(
         createVarFieldWith(
-          marcTag = "710",
-          subfields = List(MarcSubfield(tag = "a", content = name))
+          marcTag = "110",
+          subfields = List(
+            MarcSubfield(tag = "a", content = name),
+            MarcSubfield(tag = "b", content = subordinateUnit1),
+            MarcSubfield(tag = "b", content = subordinateUnit2)
+          )
         )
       )
 
       val expectedContributors = List(
-        Contributor(agent = Unidentifiable(Organisation(label = name)))
+        Contributor(agent = Unidentifiable(Organisation(label =
+          "United States. Office of the Assistant Secretary for Health. Office of Research Integrity.")))
       )
 
       transformAndCheckContributors(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraContributorsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraContributorsTest.scala
@@ -36,7 +36,7 @@ class SierraContributorsTest
       createVarFieldWith(
         marcTag = "100",
         subfields = List(
-          MarcSubfield(tag = "a", content = "Sam the squash"),
+          MarcSubfield(tag = "a", content = "Sam the squash,"),
           MarcSubfield(tag = "c", content = "Sir")
         )
       ),
@@ -62,8 +62,7 @@ class SierraContributorsTest
 
     val expectedContributors = List(
       Contributor(agent = Unidentifiable(Person("Sarah the soybean"))),
-      Contributor(
-        agent = Unidentifiable(Person("Sam the squash", Some("Sir")))),
+      Contributor(agent = Unidentifiable(Person("Sam the squash, Sir"))),
       Contributor(agent = Unidentifiable(Organisation("Spinach Solicitors"))),
       Contributor(agent = Unidentifiable(Person("Sebastian the sugarsnap"))),
       Contributor(agent = Unidentifiable(Organisation("Shallot Swimmers")))
@@ -74,18 +73,34 @@ class SierraContributorsTest
   }
 
   describe("Person") {
-    it("gets the name from MARC tag 100 subfield $$a") {
-      val name = "Carol the Carrot"
+    it(
+      "combines only subfields $$a $$b $$c with spaces from MARC field 100 / 700") {
+      // Based on https://search.wellcomelibrary.org/iii/encore/record/C__Rb1795764?lang=eng
+      // as retrieved on 25 April 2019.
 
-      val varFields = List(
-        createVarFieldWith(
-          marcTag = "100",
-          subfields = List(MarcSubfield(tag = "a", content = name))
+      val name = "Charles Emmanuel"
+      val numeration = "III,"
+      val titlesAndOtherWords = "King of Sardinia,"
+      val dates = "1701-1773,"
+      val varField100 = createVarFieldWith(
+        marcTag = "100",
+        subfields = List(
+          MarcSubfield(tag = "a", content = name),
+          MarcSubfield(tag = "b", content = numeration),
+          MarcSubfield(tag = "c", content = titlesAndOtherWords),
+          MarcSubfield(tag = "d", content = dates),
         )
       )
+      val varField700 = varField100.copy(marcTag = Some("700"))
+      val varFields = List(varField100, varField700)
 
       val expectedContributors = List(
-        Contributor(agent = Unidentifiable(Person(label = name)))
+        Contributor(
+          agent = Unidentifiable(
+            Person(label = "Charles Emmanuel III, King of Sardinia"))),
+        Contributor(
+          agent = Unidentifiable(
+            Person(label = "Charles Emmanuel III, King of Sardinia")))
       )
 
       transformAndCheckContributors(
@@ -93,23 +108,28 @@ class SierraContributorsTest
         expectedContributors = expectedContributors)
     }
 
-    it("gets the name from MARC tag 700 subfield $$a") {
-      val name = "Bertrand the Beetroot"
-
+    it(
+      "combines subfield $$t with $$a $$b $$c and creates an Agent, not a Person from MARC field 100 / 700") {
+      // Based on https://search.wellcomelibrary.org/iii/encore/record/C__Rb1159639?marcData=Y
+      // as retrieved on 4 February 2019.
       val varFields = List(
         createVarFieldWith(
           marcTag = "700",
-          subfields = List(MarcSubfield(tag = "a", content = name))
+          subfields = List(
+            MarcSubfield(tag = "a", content = "Shakespeare, William,"),
+            MarcSubfield(tag = "d", content = "1564-1616."),
+            MarcSubfield(tag = "t", content = "Hamlet.")
+          )
         )
       )
 
-      val expectedContributors = List(
-        Contributor(agent = Unidentifiable(Person(label = name)))
-      )
+      val bibData = createSierraBibDataWith(varFields = varFields)
+      val contributors = transformer.getContributors(bibData)
+      contributors should have size 1
+      val contributor = contributors.head
 
-      transformAndCheckContributors(
-        varFields = varFields,
-        expectedContributors = expectedContributors)
+      contributor.agent shouldBe Unidentifiable(
+        Agent(label = "Shakespeare, William, Hamlet."))
     }
 
     it(
@@ -140,121 +160,6 @@ class SierraContributorsTest
         Contributor(agent = Unidentifiable(Person(label = name1))),
         Contributor(agent = Unidentifiable(Person(label = name2))),
         Contributor(agent = Unidentifiable(Person(label = name3)))
-      )
-
-      transformAndCheckContributors(
-        varFields = varFields,
-        expectedContributors = expectedContributors)
-    }
-
-    it("gets the creator prefix from MARC tag 100 subfield $$c") {
-      val name = "Darla the Dandelion"
-      val prefix = "Dr"
-
-      val varFields = List(
-        createVarFieldWith(
-          marcTag = "100",
-          subfields = List(
-            MarcSubfield(tag = "a", content = name),
-            MarcSubfield(tag = "c", content = prefix)
-          )
-        )
-      )
-
-      val expectedContributors = List(
-        Contributor(
-          agent = Unidentifiable(
-            Person(
-              label = name,
-              prefix = Some(prefix)
-            ))
-        )
-      )
-
-      transformAndCheckContributors(
-        varFields = varFields,
-        expectedContributors = expectedContributors)
-    }
-
-    it("gets the creator prefix from MARC tag 700 subfield $$c") {
-      val name = "Roland the Radish"
-      val prefix = "Rev"
-
-      val varFields = List(
-        createVarFieldWith(
-          marcTag = "100",
-          subfields = List(
-            MarcSubfield(tag = "a", content = name),
-            MarcSubfield(tag = "c", content = prefix)
-          )
-        )
-      )
-
-      val expectedContributors = List(
-        Contributor(
-          agent = Unidentifiable(
-            Person(
-              label = name,
-              prefix = Some(prefix)
-            ))
-        )
-      )
-
-      transformAndCheckContributors(
-        varFields = varFields,
-        expectedContributors = expectedContributors)
-    }
-
-    it("joins multiple instances of subfield $$c into a single prefix") {
-      val name = "Mick the Mallow"
-      val prefix1 = "Mx"
-      val prefix2 = "Mr"
-
-      val varFields = List(
-        createVarFieldWith(
-          marcTag = "100",
-          subfields = List(
-            MarcSubfield(tag = "a", content = name),
-            MarcSubfield(tag = "c", content = prefix1),
-            MarcSubfield(tag = "c", content = prefix2)
-          )
-        )
-      )
-
-      val expectedContributors = List(
-        Contributor(
-          agent = Unidentifiable(
-            Person(
-              label = name,
-              prefix = Some(s"${prefix1} ${prefix2}")
-            ))
-        )
-      )
-
-      transformAndCheckContributors(
-        varFields = varFields,
-        expectedContributors = expectedContributors)
-    }
-
-    it("gets the numeration from subfield $$b") {
-      val name = "Leopold the Lettuce"
-      val numeration = "LX"
-
-      val varFields = List(
-        createVarFieldWith(
-          marcTag = "100",
-          subfields = List(
-            MarcSubfield(tag = "a", content = name),
-            MarcSubfield(tag = "b", content = numeration)
-          )
-        )
-      )
-
-      val expectedContributors = List(
-        Contributor(
-          agent = Unidentifiable(
-            Person(label = name, numeration = Some(numeration))
-          ))
       )
 
       transformAndCheckContributors(
@@ -413,31 +318,6 @@ class SierraContributorsTest
       transformAndCheckContributors(
         varFields = varFields,
         expectedContributors = expectedContributors)
-    }
-  }
-
-  describe("MARC tag 700 with subfield t") {
-    // Based on https://search.wellcomelibrary.org/iii/encore/record/C__Rb1159639?marcData=Y
-    // as retrieved on 4 February 2019.
-    val varFields = List(
-      createVarFieldWith(
-        marcTag = "700",
-        subfields = List(
-          MarcSubfield(tag = "a", content = "Shakespeare, William,"),
-          MarcSubfield(tag = "d", content = "1564-1616."),
-          MarcSubfield(tag = "t", content = "Hamlet.")
-        )
-      )
-    )
-
-    val bibData = createSierraBibDataWith(varFields = varFields)
-    val contributors = transformer.getContributors(bibData)
-    contributors should have size 1
-    val contributor = contributors.head
-
-    it("creates an Agent, not a Person") {
-      contributor.agent shouldBe Unidentifiable(
-        Agent(label = "Shakespeare, William,"))
     }
   }
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraContributorsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraContributorsTest.scala
@@ -355,7 +355,8 @@ class SierraContributorsTest
             MarcSubfield(tag = "a", content = name),
             MarcSubfield(tag = "b", content = subordinateUnit),
             MarcSubfield(tag = "d", content = date),
-            MarcSubfield(tag = "c", content = place)
+            MarcSubfield(tag = "c", content = place),
+            MarcSubfield(tag = "n", content = "  79125097")
           )
         )
       )

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraPersonSubjectsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraPersonSubjectsTest.scala
@@ -61,7 +61,7 @@ class SierraPersonSubjectsTest
           label = "Larrey, D. J. baron",
           concepts = List(
             Unidentifiable(
-              Person(label = "Larrey, D. J.", prefix = Some("baron"))
+              Person(label = "Larrey, D. J. baron")
             ))
         )
       )
@@ -86,8 +86,8 @@ class SierraPersonSubjectsTest
       Unidentifiable(
         Subject(
           label = "David Attenborough sir doctor",
-          concepts = List(Unidentifiable(
-            Person(label = "David Attenborough", prefix = Some("sir doctor"))))
+          concepts = List(
+            Unidentifiable(Person(label = "David Attenborough sir doctor")))
         )
       )
     )
@@ -110,9 +110,8 @@ class SierraPersonSubjectsTest
       Unidentifiable(
         Subject(
           label = "David Attenborough II",
-          concepts = List(
-            Unidentifiable(
-              Person(label = "David Attenborough", numeration = Some("II"))))
+          concepts =
+            List(Unidentifiable(Person(label = "David Attenborough II")))
         )
       )
     )
@@ -160,8 +159,8 @@ class SierraPersonSubjectsTest
       Unidentifiable(
         Subject(
           label = "Rita Levi Montalcini, 22 April 1909 – 30 December 2012",
-          concepts =
-            List(Unidentifiable(Person(label = "Rita Levi Montalcini,")))
+          concepts = List(Unidentifiable(Person(
+            label = "Rita Levi Montalcini, 22 April 1909 – 30 December 2012")))
         )
       )
     )
@@ -323,8 +322,7 @@ class SierraPersonSubjectsTest
 
     it("in the concepts") {
       subject.agent.concepts shouldBe List(
-        Unidentifiable(Person("Aristophanes.")),
-        Unidentifiable(Concept("Birds."))
+        Unidentifiable(Person("Aristophanes. Birds.")),
       )
     }
 


### PR DESCRIPTION
Does the `Person` /  `Organisation` transformation bit for https://github.com/wellcometrust/platform/issues/3591