### PR TITLE
add context to GeneralExceptionMapper

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/GeneralExceptionMapper.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/GeneralExceptionMapper.scala
@@ -18,16 +18,17 @@ class GeneralExceptionMapper @Inject()(response: ResponseBuilder,
   override def toResponse(request: Request, exception: Exception): Response = {
 
     val version = getVersion(request, apiPrefix = apiConfig.pathPrefix)
+    val context = buildContextUri(apiConfig = apiConfig, version = version)
 
-    error(s"Sending HTTP 500 from GeneralExceptionMapper", exception)
+    error(
+      s"Sending HTTP 500 from GeneralExceptionMapper. Context: $context.",
+      exception)
     val result = DisplayError(
       Error(
         variant = "http-500",
         description = None
       ))
-    val errorResponse = ResultResponse(
-      context = buildContextUri(apiConfig = apiConfig, version = version),
-      result = result)
+    val errorResponse = ResultResponse(context = context, result = result)
     response.internalServerError.json(errorResponse)
   }
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/GeneralExceptionMapper.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/GeneralExceptionMapper.scala
@@ -21,7 +21,7 @@ class GeneralExceptionMapper @Inject()(response: ResponseBuilder,
     val context = buildContextUri(apiConfig = apiConfig, version = version)
 
     error(
-      s"Sending HTTP 500 from GeneralExceptionMapper. Context: $context.",
+      s"Sending HTTP 500 from GeneralExceptionMapper. URI: ${request.uri}.",
       exception)
     val result = DisplayError(
       Error(


### PR DESCRIPTION
Not sure if it would contain something useful, but I'd like to see if there's any patterns in the in the URLs that are returning `500 Connection reset by peers`.