### PR TITLE
Allow the reporting AWS account to access the bibs merger topic

### DIFF
--- a/infrastructure/critical/vhs/s3.tf
+++ b/infrastructure/critical/vhs/s3.tf
@@ -5,6 +5,8 @@ resource "aws_s3_bucket" "bucket" {
   lifecycle {
     prevent_destroy = true
   }
+
+  policy = "${length(var.s3_cross_account_access_accounts) == 0 ? "" : data.aws_iam_policy_document.allow_s3_cross_account_access_perm.json}"
 }
 
 resource "aws_s3_bucket" "transient_bucket" {
@@ -12,4 +14,20 @@ resource "aws_s3_bucket" "transient_bucket" {
   force_destroy = true
 
   bucket = "${local.bucket_name}"
+  policy = "${length(var.s3_cross_account_access_accounts) == 0 ? "" : data.aws_iam_policy_document.allow_s3_cross_account_access_perm.json}"
+}
+
+data "aws_iam_policy_document" "allow_s3_cross_account_access_perm" {
+  statement {
+    sid    = "AllowS3CrossAccountAccess"
+    effect = "Allow"
+
+    principals {
+      identifiers = "${formatlist("arn:aws:iam::%s:root", var.s3_cross_account_access_accounts)}"
+      type        = "AWS"
+    }
+
+    actions   = ["s3:GetObject"]
+    resources = ["arn:aws:s3:::${local.bucket_name}/*"]
+  }
 }

--- a/infrastructure/critical/vhs/variables.tf
+++ b/infrastructure/critical/vhs/variables.tf
@@ -34,3 +34,9 @@ variable "bucket_name" {
 }
 
 variable "account_id" {}
+
+variable "s3_cross_account_access_accounts" {
+  description = "The account numbers of any accounts that can access the VHS objects in S3"
+  type        = "list"
+  default     = []
+}

--- a/infrastructure/critical/vhs_sierra_sourcedata.tf
+++ b/infrastructure/critical/vhs_sierra_sourcedata.tf
@@ -5,4 +5,6 @@ module "vhs_sierra" {
   table_read_max_capacity  = 500
   table_write_max_capacity = 500
   account_id               = "${data.aws_caller_identity.current.account_id}"
+
+  s3_cross_account_access_accounts = ["269807742353"]
 }

--- a/sierra_adapter/terraform/bib_merger/topic.tf
+++ b/sierra_adapter/terraform/bib_merger/topic.tf
@@ -2,3 +2,69 @@ module "sierra_bib_merger_results" {
   source = "git::https://github.com/wellcometrust/terraform.git//sns?ref=v1.0.0"
   name   = "sierra_bib_merger_results"
 }
+
+resource "aws_sns_topic_policy" "allow_reporting_subscription" {
+  arn = "${module.sierra_bib_merger_results.arn}"
+  policy = "${data.aws_iam_policy_document.sns-topic-policy.json}"
+}
+
+data "aws_iam_policy_document" "sns-topic-policy" {
+  policy_id = "__default_policy_ID"
+
+  statement {
+    actions = [
+      "SNS:Subscribe",
+      "SNS:SetTopicAttributes",
+      "SNS:RemovePermission",
+      "SNS:Receive",
+      "SNS:Publish",
+      "SNS:ListSubscriptionsByTopic",
+      "SNS:GetTopicAttributes",
+      "SNS:DeleteTopic",
+      "SNS:AddPermission",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceOwner"
+
+      values = [
+        "${var.account_id}",
+      ]
+    }
+
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    resources = [
+      "${module.sierra_bib_merger_results.arn}"
+    ]
+
+    sid = "__default_statement_ID"
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "SNS:Subscribe",
+      "SNS:ListSubscriptionsByTopic",
+      "SNS:Receive",
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::269807742353:root"]
+    }
+
+    resources = [
+      "${module.sierra_bib_merger_results.arn}"
+    ]
+
+    sid = "ReportingAccess"
+  }
+}

--- a/sierra_adapter/terraform/bib_merger/topic.tf
+++ b/sierra_adapter/terraform/bib_merger/topic.tf
@@ -4,7 +4,7 @@ module "sierra_bib_merger_results" {
 }
 
 resource "aws_sns_topic_policy" "allow_reporting_subscription" {
-  arn = "${module.sierra_bib_merger_results.arn}"
+  arn    = "${module.sierra_bib_merger_results.arn}"
   policy = "${data.aws_iam_policy_document.sns-topic-policy.json}"
 }
 
@@ -41,7 +41,7 @@ data "aws_iam_policy_document" "sns-topic-policy" {
     }
 
     resources = [
-      "${module.sierra_bib_merger_results.arn}"
+      "${module.sierra_bib_merger_results.arn}",
     ]
 
     sid = "__default_statement_ID"
@@ -64,7 +64,7 @@ data "aws_iam_policy_document" "sns-topic-policy" {
     }
 
     resources = [
-      "${module.sierra_bib_merger_results.arn}"
+      "${module.sierra_bib_merger_results.arn}",
     ]
 
     sid = "ReportingAccess"

--- a/sierra_adapter/terraform/bib_merger/topic.tf
+++ b/sierra_adapter/terraform/bib_merger/topic.tf
@@ -54,6 +54,8 @@ data "aws_iam_policy_document" "sns-topic-policy" {
       "SNS:Subscribe",
       "SNS:ListSubscriptionsByTopic",
       "SNS:Receive",
+      "SNS:GetTopicAttributes",
+      "SNS:SetTopicAttributes",
     ]
 
     principals {


### PR DESCRIPTION
As the reporting account will have to access the platform (catalogue) account, we need to compose a new policy into the default policy (You can't add multiple policies - [this seems to be the suggested way for now](https://www.terraform.io/docs/providers/aws/r/sns_topic_subscription.html)).

I have also added the ability to grant cross account read access to the VHS S3 buckets.