### PR TITLE
Use the new storage/messaging libraries

### DIFF
--- a/goobi_adapter/goobi_reader/docker-compose.yml
+++ b/goobi_adapter/goobi_reader/docker-compose.yml
@@ -6,7 +6,3 @@ sqs:
   image: s12v/elasticmq
   ports:
     - "9324:9324"
-dynamodb:
-  image: peopleperhour/dynamodb
-  ports:
-    - "45678:8000"

--- a/goobi_adapter/goobi_reader/src/main/scala/uk/ac/wellcome/platform/goobi_reader/Main.scala
+++ b/goobi_adapter/goobi_reader/src/main/scala/uk/ac/wellcome/platform/goobi_reader/Main.scala
@@ -27,7 +27,8 @@ object Main extends WellcomeTypesafeApp {
     new GoobiReaderWorkerService(
       s3Client = S3Builder.buildS3Client(config),
       sqsStream = SQSBuilder.buildSQSStream[NotificationMessage](config),
-      vhs = VHSBuilder.buildVHS[String, InputStream, GoobiRecordMetadata](config)
+      vhs =
+        VHSBuilder.buildVHS[String, InputStream, GoobiRecordMetadata](config)
     )
   }
 }

--- a/goobi_adapter/goobi_reader/src/main/scala/uk/ac/wellcome/platform/goobi_reader/Main.scala
+++ b/goobi_adapter/goobi_reader/src/main/scala/uk/ac/wellcome/platform/goobi_reader/Main.scala
@@ -9,6 +9,7 @@ import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.typesafe.SQSBuilder
 import uk.ac.wellcome.platform.goobi_reader.models.GoobiRecordMetadata
 import uk.ac.wellcome.platform.goobi_reader.services.GoobiReaderWorkerService
+import uk.ac.wellcome.storage.dynamo._
 import uk.ac.wellcome.storage.typesafe.{S3Builder, VHSBuilder}
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
@@ -26,8 +27,7 @@ object Main extends WellcomeTypesafeApp {
     new GoobiReaderWorkerService(
       s3Client = S3Builder.buildS3Client(config),
       sqsStream = SQSBuilder.buildSQSStream[NotificationMessage](config),
-      versionedHybridStore =
-        VHSBuilder.buildVHS[InputStream, GoobiRecordMetadata](config)
+      vhs = VHSBuilder.buildVHS[String, InputStream, GoobiRecordMetadata](config)
     )
   }
 }

--- a/goobi_adapter/goobi_reader/src/main/scala/uk/ac/wellcome/platform/goobi_reader/services/GoobiReaderWorkerService.scala
+++ b/goobi_adapter/goobi_reader/src/main/scala/uk/ac/wellcome/platform/goobi_reader/services/GoobiReaderWorkerService.scala
@@ -8,7 +8,11 @@ import grizzled.slf4j.Logging
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.sqs._
-import uk.ac.wellcome.platform.goobi_reader.models.{GoobiRecordMetadata, S3Event, S3Record}
+import uk.ac.wellcome.platform.goobi_reader.models.{
+  GoobiRecordMetadata,
+  S3Event,
+  S3Record
+}
 import uk.ac.wellcome.storage.vhs.VersionedHybridStore
 import uk.ac.wellcome.typesafe.Runnable
 
@@ -60,15 +64,15 @@ class GoobiReaderWorkerService(
       debug(s"trying to retrieve object s3://$bucketName/$objectKey")
       s3Client.getObject(bucketName, objectKey).getObjectContent
     }
-    eventuallyContent.flatMap(updatedContent =>
-      vhs.update(id = id)(
-        ifNotExisting = (updatedContent, GoobiRecordMetadata(updateEventTime)))(
-        ifExisting = (existingContent, existingMetadata) => {
-          if (existingMetadata.eventTime.isBefore(updateEventTime))
-            (updatedContent, GoobiRecordMetadata(updateEventTime))
-          else
-            (existingContent, existingMetadata)
-        })
-    )
+    eventuallyContent.flatMap(
+      updatedContent =>
+        vhs.update(id = id)(ifNotExisting =
+          (updatedContent, GoobiRecordMetadata(updateEventTime)))(
+          ifExisting = (existingContent, existingMetadata) => {
+            if (existingMetadata.eventTime.isBefore(updateEventTime))
+              (updatedContent, GoobiRecordMetadata(updateEventTime))
+            else
+              (existingContent, existingMetadata)
+          }))
   }
 }

--- a/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/GoobiReaderFeatureTest.scala
+++ b/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/GoobiReaderFeatureTest.scala
@@ -62,7 +62,10 @@ class GoobiReaderFeatureTest
     }
   }
 
-  private def withWorkerService[R](queue: Queue, bucket: Bucket, dao: MemoryVersionedDao[String, Entry[String, GoobiRecordMetadata]])(
+  private def withWorkerService[R](
+    queue: Queue,
+    bucket: Bucket,
+    dao: MemoryVersionedDao[String, Entry[String, GoobiRecordMetadata]])(
     testWith: TestWith[GoobiReaderWorkerService, R]): R =
     withActorSystem { implicit actorSystem =>
       withSQSStream[NotificationMessage, R](queue) { sqsStream =>

--- a/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/GoobiReaderFeatureTest.scala
+++ b/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/GoobiReaderFeatureTest.scala
@@ -1,90 +1,80 @@
 package uk.ac.wellcome.platform.goobi_reader
 
-import java.io.InputStream
 import java.time.Instant
 
-import org.scalatest.concurrent.{Eventually, IntegrationPatience}
-import org.scalatest.{FunSpec, Inside, Matchers}
-import uk.ac.wellcome.akka.fixtures.Akka
+import org.scalatest.concurrent.Eventually
+import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
+import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.platform.goobi_reader.fixtures.GoobiReaderFixtures
 import uk.ac.wellcome.platform.goobi_reader.models.GoobiRecordMetadata
 import uk.ac.wellcome.platform.goobi_reader.services.GoobiReaderWorkerService
-import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
-import uk.ac.wellcome.storage.fixtures.{
-  LocalDynamoDb,
-  LocalVersionedHybridStore,
-  S3
-}
+import uk.ac.wellcome.storage.fixtures.S3
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
-import uk.ac.wellcome.storage.vhs.HybridRecord
+import uk.ac.wellcome.storage.memory.MemoryVersionedDao
+import uk.ac.wellcome.storage.vhs.Entry
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.Success
 
 class GoobiReaderFeatureTest
     extends FunSpec
-    with Akka
     with Eventually
     with Matchers
-    with IntegrationPatience
     with GoobiReaderFixtures
-    with Inside
-    with LocalDynamoDb
-    with LocalVersionedHybridStore
     with SQS
     with S3 {
-  private val eventTime = Instant.parse("2018-01-01T01:00:00.000Z")
+
+  private val eventTime = Instant.now()
 
   it("gets an S3 notification and puts the new record in VHS") {
     withLocalS3Bucket { bucket =>
-      withLocalDynamoDbTable { table =>
-        withLocalSqsQueue { queue =>
-          val id = "mets-0001"
-          val sourceKey = s"$id.xml"
-          val contents = "muddling the machinations of morose METS"
+      withLocalSqsQueue { queue =>
+        val id = "mets-0001"
+        val sourceKey = s"$id.xml"
+        val contents = "muddling the machinations of morose METS"
 
-          s3Client.putObject(bucket.name, sourceKey, contents)
+        s3Client.putObject(bucket.name, sourceKey, contents)
 
-          sendNotificationToSQS(
-            queue = queue,
-            body = anS3Notification(sourceKey, bucket.name, eventTime)
-          )
+        sendNotificationToSQS(
+          queue = queue,
+          body = createS3Notification(sourceKey, bucket.name, eventTime)
+        )
 
-          withWorkerService(queue, bucket, table) { _ =>
-            eventually {
-              val hybridRecord: HybridRecord = getHybridRecord(table, id)
-              inside(hybridRecord) {
-                case HybridRecord(actualId, actualVersion, location) =>
-                  actualId shouldBe id
-                  actualVersion shouldBe 1
-                  val s3contents = getContentFromS3(location)
-                  s3contents shouldBe contents
-              }
-            }
+        val dao = MemoryVersionedDao[String, Entry[String, GoobiRecordMetadata]]
+
+        withWorkerService(queue, bucket, dao) { _ =>
+          eventually {
+            val storedEntry = dao.get(id)
+            storedEntry shouldBe a[Success[_]]
+
+            storedEntry.get.get.id shouldBe id
+            storedEntry.get.get.version shouldBe 1
+
+            val location = storedEntry.get.get.location
+            val s3contents = getContentFromS3(location)
+            s3contents shouldBe contents
           }
         }
       }
     }
   }
 
-  private def withWorkerService[R](queue: Queue, bucket: Bucket, table: Table)(
+  private def withWorkerService[R](queue: Queue, bucket: Bucket, dao: MemoryVersionedDao[String, Entry[String, GoobiRecordMetadata]])(
     testWith: TestWith[GoobiReaderWorkerService, R]): R =
     withActorSystem { implicit actorSystem =>
       withSQSStream[NotificationMessage, R](queue) { sqsStream =>
-        withTypeVHS[InputStream, GoobiRecordMetadata, R](bucket, table) { vhs =>
-          val workerService = new GoobiReaderWorkerService(
-            s3Client = s3Client,
-            sqsStream = sqsStream,
-            versionedHybridStore = vhs
-          )
+        val workerService = new GoobiReaderWorkerService(
+          s3Client = s3Client,
+          sqsStream = sqsStream,
+          vhs = createVHS(bucket, dao)
+        )
 
-          workerService.run()
+        workerService.run()
 
-          testWith(workerService)
-        }
+        testWith(workerService)
       }
     }
 }

--- a/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/fixtures/GoobiReaderFixtures.scala
+++ b/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/fixtures/GoobiReaderFixtures.scala
@@ -65,7 +65,8 @@ trait GoobiReaderFixtures extends S3 {
 
   def createVHS(bucket: Bucket, dao: GoobiDao): GoobiVHS =
     new VersionedHybridStore[String, InputStream, GoobiRecordMetadata] {
-      override protected val versionedDao: VersionedDao[String, Entry[String, GoobiRecordMetadata]] = dao
+      override protected val versionedDao
+        : VersionedDao[String, Entry[String, GoobiRecordMetadata]] = dao
       override protected val objectStore: ObjectStore[InputStream] =
         ObjectStore[InputStream]
 

--- a/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/services/GoobiReaderWorkerServiceTest.scala
+++ b/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/services/GoobiReaderWorkerServiceTest.scala
@@ -72,7 +72,8 @@ class GoobiReaderWorkerServiceTest
 
         sendNotificationToSQS(
           queue = queue,
-          body = createS3Notification(urlEncodedSourceKey, bucket.name, eventTime)
+          body =
+            createS3Notification(urlEncodedSourceKey, bucket.name, eventTime)
         )
 
         eventually {
@@ -250,21 +251,23 @@ class GoobiReaderWorkerServiceTest
   }
 
   private def withGoobiReaderWorkerService[R](s3Client: AmazonS3)(
-    testWith: TestWith[(Bucket,
-                        QueuePair,
-                        MetricsSender,
-                        MemoryVersionedDao[String, Entry[String, GoobiRecordMetadata]],
-                        GoobiVHS),
-                       R]): R =
+    testWith: TestWith[
+      (Bucket,
+       QueuePair,
+       MetricsSender,
+       MemoryVersionedDao[String, Entry[String, GoobiRecordMetadata]],
+       GoobiVHS),
+      R]): R =
     withActorSystem { implicit actorSystem =>
       withLocalSqsQueueAndDlq {
-        case queuePair@QueuePair(queue, dlq) =>
+        case queuePair @ QueuePair(queue, dlq) =>
           withMockMetricsSender { mockMetricsSender =>
             withSQSStream[NotificationMessage, R](
               queue = queue,
               metricsSender = mockMetricsSender) { sqsStream =>
               withLocalS3Bucket[R] { bucket =>
-                val dao = MemoryVersionedDao[String, Entry[String, GoobiRecordMetadata]]
+                val dao =
+                  MemoryVersionedDao[String, Entry[String, GoobiRecordMetadata]]
                 val vhs = createVHS(bucket, dao)
 
                 val service = new GoobiReaderWorkerService(

--- a/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/services/GoobiReaderWorkerServiceTest.scala
+++ b/goobi_adapter/goobi_reader/src/test/scala/uk/ac/wellcome/platform/goobi_reader/services/GoobiReaderWorkerServiceTest.scala
@@ -1,53 +1,40 @@
 package uk.ac.wellcome.platform.goobi_reader.services
 
-import java.io.{ByteArrayInputStream, InputStream}
+import java.io.ByteArrayInputStream
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3Client}
-import com.gu.scanamo.Scanamo
 import org.mockito.Matchers.{any, endsWith}
 import org.mockito.Mockito.{times, verify, when}
-import org.scalatest.{Assertion, FunSpec, Inside}
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.mockito.MockitoSugar
-import uk.ac.wellcome.akka.fixtures.Akka
+import org.scalatest.{Assertion, FunSpec, Inside}
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.messaging.sns.NotificationMessage
-import uk.ac.wellcome.messaging.fixtures.{Messaging, SQS}
+import uk.ac.wellcome.messaging.fixtures.Messaging
 import uk.ac.wellcome.messaging.fixtures.SQS.{Queue, QueuePair}
+import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.goobi_reader.fixtures.GoobiReaderFixtures
 import uk.ac.wellcome.platform.goobi_reader.models.GoobiRecordMetadata
-import uk.ac.wellcome.storage.ObjectStore
-import uk.ac.wellcome.storage.dynamo._
-import uk.ac.wellcome.storage.fixtures.{
-  LocalDynamoDb,
-  LocalVersionedHybridStore
-}
-import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
-import uk.ac.wellcome.storage.vhs.{HybridRecord, VersionedHybridStore}
+import uk.ac.wellcome.storage.memory.MemoryVersionedDao
+import uk.ac.wellcome.storage.vhs.Entry
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class GoobiReaderWorkerServiceTest
     extends FunSpec
-    with Akka
     with MetricsSenderFixture
     with ScalaFutures
     with IntegrationPatience
     with MockitoSugar
     with GoobiReaderFixtures
     with Messaging
-    with SQS
-    with Inside
-    with LocalDynamoDb
-    with LocalVersionedHybridStore {
+    with Inside {
 
   private val id = "mets-0001"
-  private val goobiS3Prefix = "goobi"
   private val sourceKey = s"$id.xml"
   private val contents = "muddling the machinations of morose METS"
   private val updatedContents = "Updated contents"
@@ -55,12 +42,12 @@ class GoobiReaderWorkerServiceTest
 
   it("processes a notification") {
     withGoobiReaderWorkerService(s3Client) {
-      case (bucket, QueuePair(queue, _), _, table, _) =>
+      case (bucket, QueuePair(queue, _), _, dao, _) =>
         s3Client.putObject(bucket.name, sourceKey, contents)
 
         sendNotificationToSQS(
           queue = queue,
-          body = anS3Notification(sourceKey, bucket.name, eventTime)
+          body = createS3Notification(sourceKey, bucket.name, eventTime)
         )
 
         eventually {
@@ -69,7 +56,7 @@ class GoobiReaderWorkerServiceTest
             version = 1,
             expectedMetadata = GoobiRecordMetadata(eventTime),
             expectedContents = contents,
-            table = table,
+            dao = dao,
             bucket = bucket)
         }
     }
@@ -77,7 +64,7 @@ class GoobiReaderWorkerServiceTest
 
   it("ingests an object with a space in the s3Key") {
     withGoobiReaderWorkerService(s3Client) {
-      case (bucket, QueuePair(queue, _), _, table, _) =>
+      case (bucket, QueuePair(queue, _), _, dao, _) =>
         val sourceKey = s"$id work.xml"
         val urlEncodedSourceKey =
           java.net.URLEncoder.encode(sourceKey, "utf-8")
@@ -85,7 +72,7 @@ class GoobiReaderWorkerServiceTest
 
         sendNotificationToSQS(
           queue = queue,
-          body = anS3Notification(urlEncodedSourceKey, bucket.name, eventTime)
+          body = createS3Notification(urlEncodedSourceKey, bucket.name, eventTime)
         )
 
         eventually {
@@ -95,7 +82,7 @@ class GoobiReaderWorkerServiceTest
             version = 1,
             expectedMetadata = GoobiRecordMetadata(eventTime),
             expectedContents = contents,
-            table = table,
+            dao = dao,
             bucket = bucket)
         }
     }
@@ -103,9 +90,9 @@ class GoobiReaderWorkerServiceTest
 
   it("doesn't overwrite a newer work with an older work") {
     withGoobiReaderWorkerService(s3Client) {
-      case (bucket, QueuePair(queue, _), _, table, vhs) =>
+      case (bucket, QueuePair(queue, _), _, dao, vhs) =>
         val contentStream = new ByteArrayInputStream(contents.getBytes)
-        vhs.updateRecord(id = id)(
+        vhs.update(id)(
           ifNotExisting = (contentStream, GoobiRecordMetadata(eventTime)))(
           ifExisting = (t, m) => (t, m))
         eventually {
@@ -115,7 +102,7 @@ class GoobiReaderWorkerServiceTest
             version = 1,
             expectedMetadata = expectedMetadata,
             expectedContents = contents,
-            table = table,
+            dao = dao,
             bucket = bucket)
         }
 
@@ -125,19 +112,19 @@ class GoobiReaderWorkerServiceTest
 
         sendNotificationToSQS(
           queue = queue,
-          body = anS3Notification(sourceKey, bucket.name, olderEventTime)
+          body = createS3Notification(sourceKey, bucket.name, olderEventTime)
         )
 
         eventually {
-
           val expectedMetadata = GoobiRecordMetadata(eventTime)
           assertRecordStored(
             id = id,
             version = 1,
             expectedMetadata,
-            contents,
-            table,
-            bucket)
+            expectedContents = contents,
+            dao = dao,
+            bucket = bucket
+          )
         }
     }
   }
@@ -146,11 +133,10 @@ class GoobiReaderWorkerServiceTest
     withGoobiReaderWorkerService(s3Client) {
       case (bucket, QueuePair(queue, _), _, table, vhs) =>
         val contentStream = new ByteArrayInputStream(contents.getBytes)
-        vhs.updateRecord(id = id)(
+        vhs.update(id)(
           ifNotExisting = (contentStream, GoobiRecordMetadata(eventTime)))(
           ifExisting = (t, m) => (t, m))
         eventually {
-
           assertRecordStored(
             id = id,
             version = 1,
@@ -165,7 +151,7 @@ class GoobiReaderWorkerServiceTest
 
         sendNotificationToSQS(
           queue = queue,
-          body = anS3Notification(sourceKey, bucket.name, newerEventTime)
+          body = createS3Notification(sourceKey, bucket.name, newerEventTime)
         )
 
         eventually {
@@ -205,7 +191,7 @@ class GoobiReaderWorkerServiceTest
 
         sendNotificationToSQS(
           queue = queue,
-          body = anS3Notification(sourceKey, bucket.name, eventTime)
+          body = createS3Notification(sourceKey, bucket.name, eventTime)
         )
 
         eventually {
@@ -227,7 +213,7 @@ class GoobiReaderWorkerServiceTest
         val sourceKey = "any.xml"
         sendNotificationToSQS(
           queue = queue,
-          body = anS3Notification(sourceKey, bucket.name, eventTime)
+          body = createS3Notification(sourceKey, bucket.name, eventTime)
         )
 
         eventually {
@@ -243,13 +229,13 @@ class GoobiReaderWorkerServiceTest
                                  version: Int,
                                  expectedMetadata: GoobiRecordMetadata,
                                  expectedContents: String,
-                                 table: Table,
+                                 dao: GoobiDao,
                                  bucket: Bucket): Assertion =
-    inside(getHybridRecord(table, id)) {
-      case HybridRecord(actualId, actualVersion, location) =>
+    inside(dao.get(id).get.get) {
+      case Entry(actualId, actualVersion, location, actualMetadata) =>
         actualId shouldBe id
         actualVersion shouldBe version
-        getRecordMetadata[GoobiRecordMetadata](table, id) shouldBe expectedMetadata
+        actualMetadata shouldBe expectedMetadata
         getContentFromS3(location) shouldBe expectedContents
     }
 
@@ -258,69 +244,38 @@ class GoobiReaderWorkerServiceTest
     assertQueueHasSize(dlq, 1)
   }
 
-  private def assertUpdateNotSaved(bucket: Bucket, table: Table) = {
-    assertDynamoTableIsEmpty(table)
-    assertS3StorageIsEmpty(bucket)
-  }
-
-  private def assertDynamoTableIsEmpty(table: Table) = {
-    Scanamo.scan[HybridRecord](dynamoDbClient)(table.name) shouldBe empty
-  }
-
-  private def assertS3StorageIsEmpty(bucket: Bucket) =
+  private def assertUpdateNotSaved(bucket: Bucket, dao: GoobiDao): Assertion = {
+    // TODO: Add a way to check a dao is empty
     listKeysInBucket(bucket) shouldBe empty
-
-  private def withS3StreamStoreFixtures[R](
-    testWith: TestWith[(Bucket,
-                        Table,
-                        VersionedHybridStore[InputStream,
-                                             GoobiRecordMetadata,
-                                             ObjectStore[InputStream]]),
-                       R]): R =
-    withLocalS3Bucket[R] { bucket =>
-      withLocalDynamoDbTable[R] { table =>
-        withTypeVHS[InputStream, GoobiRecordMetadata, R](
-          bucket,
-          table,
-          goobiS3Prefix) { vhs =>
-          testWith((bucket, table, vhs))
-        }
-      }
-    }
+  }
 
   private def withGoobiReaderWorkerService[R](s3Client: AmazonS3)(
     testWith: TestWith[(Bucket,
                         QueuePair,
                         MetricsSender,
-                        Table,
-                        VersionedHybridStore[InputStream,
-                                             GoobiRecordMetadata,
-                                             ObjectStore[InputStream]]),
+                        MemoryVersionedDao[String, Entry[String, GoobiRecordMetadata]],
+                        GoobiVHS),
                        R]): R =
     withActorSystem { implicit actorSystem =>
       withLocalSqsQueueAndDlq {
-        case queuePair @ QueuePair(queue, dlq) =>
+        case queuePair@QueuePair(queue, dlq) =>
           withMockMetricsSender { mockMetricsSender =>
             withSQSStream[NotificationMessage, R](
               queue = queue,
               metricsSender = mockMetricsSender) { sqsStream =>
-              withS3StreamStoreFixtures {
-                case (bucket, table, versionedHybridStore) =>
-                  val service = new GoobiReaderWorkerService(
-                    s3Client = s3Client,
-                    sqsStream = sqsStream,
-                    versionedHybridStore = versionedHybridStore
-                  )
+              withLocalS3Bucket[R] { bucket =>
+                val dao = MemoryVersionedDao[String, Entry[String, GoobiRecordMetadata]]
+                val vhs = createVHS(bucket, dao)
 
-                  service.run()
+                val service = new GoobiReaderWorkerService(
+                  s3Client = s3Client,
+                  sqsStream = sqsStream,
+                  vhs = vhs
+                )
 
-                  testWith(
-                    (
-                      bucket,
-                      queuePair,
-                      mockMetricsSender,
-                      table,
-                      versionedHybridStore))
+                service.run()
+
+                testWith((bucket, queuePair, mockMetricsSender, dao, vhs))
               }
             }
           }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,9 +4,9 @@ object WellcomeDependencies {
   lazy val versions = new {
     val fixtures   = "1.0.0"
     val json       = "1.1.1"
-    val messaging  = "1.6.0"
-    val monitoring = "2.0.0"
-    val storage    = "3.6.0"
+    val messaging  = "5.1.0"
+    val monitoring = "2.2.0"
+    val storage    = "5.0.0"
     val typesafe   = "1.0.0"
 
     val sierraStreamsSource = "0.4"


### PR DESCRIPTION
Closes wellcometrust/platform#3628

Now we can run lots of stuff in-memory, so it's faster and easier to debug. Containers we no longer need to run:

* goobi_adapter: no DynamoDB

Rough edges are being documented in wellcometrust/platform#3630