### PR TITLE
New candidate query types

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -146,11 +146,10 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
     queryString: String,
     maybeQueryType: Option[String]): WorkQuery = {
     maybeQueryType.map(_.toLowerCase) match {
-      case Some("justboost")    => JustBoostQuery(queryString)
-      case Some("broaderboost") => BroaderBoostQuery(queryString)
-      case Some("slop")         => SlopQuery(queryString)
-      case Some("minimummatch") => MinimumMatchQuery(queryString)
-      case _                    => SimpleQuery(queryString)
+      case Some("boost")    => BoostQuery(queryString)
+      case Some("msm")      => MSMQuery(queryString)
+      case Some("msmboost") => MSMBoostQuery(queryString)
+      case _                => SimpleQuery(queryString)
     }
   }
 

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkQuery.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkQuery.scala
@@ -20,51 +20,39 @@ object WorkQuery {
     }
   }
 
-  case class JustBoostQuery(queryString: String) extends WorkQuery {
+  case class MSMQuery(queryString: String) extends WorkQuery {
     override def query(): MultiMatchQuery = {
       multiMatchQuery(queryString)
-        .fields("*", "subjects*^4", "genres*^4", "title^3")
+        .fields("*")
         .matchType(MultiMatchQueryBuilderType.CROSS_FIELDS)
+        .minimumShouldMatch("70%")
     }
   }
 
-  case class BroaderBoostQuery(queryString: String) extends WorkQuery {
+  case class BoostQuery(queryString: String) extends WorkQuery {
     override def query(): MultiMatchQuery = {
       multiMatchQuery(queryString)
         .fields(
           "*",
+          "title^9",
           "subjects*^8",
           "genres*^8",
-          "title^5",
-          "description*^2",
-          "lettering*^2",
+          "description*^5",
           "contributors*^2")
         .matchType(MultiMatchQueryBuilderType.CROSS_FIELDS)
     }
   }
 
-  case class SlopQuery(queryString: String) extends WorkQuery {
-    // TODO: 'phrase_match' rather than 'cross_fields' seems to reject fields("*") as used elsewhere, why?
-    private val all_fields = List(
-      "subjects",
-      "genres",
-      "title",
-      "description",
-      "lettering",
-      "contributors"
-    )
-    override def query() = {
-      multiMatchQuery(queryString)
-        .fields(all_fields)
-        .matchType(MultiMatchQueryBuilderType.PHRASE)
-        .slop(3)
-    }
-  }
-
-  case class MinimumMatchQuery(queryString: String) extends WorkQuery {
+  case class MSMBoostQuery(queryString: String) extends WorkQuery {
     override def query(): MultiMatchQuery = {
       multiMatchQuery(queryString)
-        .fields("*")
+        .fields(
+          "*",
+          "title^9",
+          "subjects*^8",
+          "genres*^8",
+          "description*^5",
+          "contributors*^2")
         .matchType(MultiMatchQueryBuilderType.CROSS_FIELDS)
         .minimumShouldMatch("70%")
     }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkQuery.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkQuery.scala
@@ -25,7 +25,7 @@ object WorkQuery {
       multiMatchQuery(queryString)
         .fields("*")
         .matchType(MultiMatchQueryBuilderType.CROSS_FIELDS)
-        .minimumShouldMatch("70%")
+        .minimumShouldMatch("60%")
     }
   }
 
@@ -54,7 +54,7 @@ object WorkQuery {
           "description*^5",
           "contributors*^2")
         .matchType(MultiMatchQueryBuilderType.CROSS_FIELDS)
-        .minimumShouldMatch("70%")
+        .minimumShouldMatch("60%")
     }
   }
 }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/models/WorkQueryTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/models/WorkQueryTest.scala
@@ -17,20 +17,20 @@ class WorkQueryTest extends FunSpec with ElasticsearchFixtures {
   it("creates a BoostQuery") {
     assertQuery(
       BoostQuery("the query").query(),
-      """{"multi_match":{"query":"the query","fields":["*","subjects*^8","genres*^8","title^9","description*^5","contributors*^2"],"type":"cross_fields"}}"""
+      """{"query":{"multi_match":{"query":"the query","fields":["*","title^9","subjects*^8","genres*^8","description*^5","contributors*^2"],"type":"cross_fields"}}}"""
     )
   }
 
   it("creates a MSMQuery") {
     assertQuery(
       MSMQuery("the query").query(),
-      """{"multi_match":{"query":"the query","fields":["*"],"type":"cross_fields","minimum_should_match":"60%"}}""")
+      """{"query":{"multi_match":{"query":"the query","fields":["*"],"type":"cross_fields","minimum_should_match":"70%"}}},Some(application/json))" did not include substring "{"multi_match":{"query":"the query","fields":["*"],"type":"cross_fields","minimum_should_match":"60%"}}""")
   }
   
   it("creates a MSMBoostQuery") {
     assertQuery(
       MSMBoostQuery("the query").query(),
-      """{"multi_match":{"query":"the query","fields":["*","subjects*^8","genres*^8","title^9","description*^5","contributors*^2"],"type":"cross_fields","minimum_should_match":"60%"}}""")
+      """{"query":{"multi_match":{"query":"the query","fields":["*","title^9","subjects*^8","genres*^8","description*^5","contributors*^2"],"type":"cross_fields","minimum_should_match":"60%"}}}""")
   }
 
   private def assertQuery(query: Query, expectedJsonQuery: String): Any = {

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/models/WorkQueryTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/models/WorkQueryTest.scala
@@ -24,7 +24,7 @@ class WorkQueryTest extends FunSpec with ElasticsearchFixtures {
   it("creates a MSMQuery") {
     assertQuery(
       MSMQuery("the query").query(),
-      """{"query":{"multi_match":{"query":"the query","fields":["*"],"type":"cross_fields","minimum_should_match":"70%"}}},Some(application/json))" did not include substring "{"multi_match":{"query":"the query","fields":["*"],"type":"cross_fields","minimum_should_match":"60%"}}""")
+      """{"query":{"multi_match":{"query":"the query","fields":["*"],"type":"cross_fields","minimum_should_match":"60%"}}}""")
   }
 
   it("creates a MSMBoostQuery") {

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/models/WorkQueryTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/models/WorkQueryTest.scala
@@ -14,31 +14,23 @@ class WorkQueryTest extends FunSpec with ElasticsearchFixtures {
       """{"simple_query_string":{"query":"the query"}}""")
   }
 
-  it("creates a JustBoostQuery") {
+  it("creates a BoostQuery") {
     assertQuery(
-      JustBoostQuery("the query").query(),
-      """{"multi_match":{"query":"the query","fields":["*","subjects*^4","genres*^4","title^3"],"type":"cross_fields"}}"""
+      BoostQuery("the query").query(),
+      """{"multi_match":{"query":"the query","fields":["*","subjects*^8","genres*^8","title^9","description*^5","contributors*^2"],"type":"cross_fields"}}"""
     )
   }
 
-  it("creates a BroaderBoostQuery") {
+  it("creates a MSMQuery") {
     assertQuery(
-      BroaderBoostQuery("the query").query(),
-      """{"multi_match":{"query":"the query","fields":["*","subjects*^8","genres*^8","title^5","description*^2","lettering*^2","contributors*^2"],"type":"cross_fields"}}"""
-    )
+      MSMQuery("the query").query(),
+      """{"multi_match":{"query":"the query","fields":["*"],"type":"cross_fields","minimum_should_match":"60%"}}""")
   }
-
-  it("creates a SlopQuery") {
+  
+  it("creates a MSMBoostQuery") {
     assertQuery(
-      SlopQuery("the query").query(),
-      """{"multi_match":{"query":"the query","fields":["subjects","genres","title","description","lettering","contributors"],"type":"phrase","slop":3}}"""
-    )
-  }
-
-  it("creates a MinimumMatchQuery") {
-    assertQuery(
-      MinimumMatchQuery("the query").query(),
-      """{"multi_match":{"query":"the query","fields":["*"],"type":"cross_fields","minimum_should_match":"70%"}}""")
+      MSMBoostQuery("the query").query(),
+      """{"multi_match":{"query":"the query","fields":["*","subjects*^8","genres*^8","title^9","description*^5","contributors*^2"],"type":"cross_fields","minimum_should_match":"60%"}}""")
   }
 
   private def assertQuery(query: Query, expectedJsonQuery: String): Any = {

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -358,13 +358,13 @@ class ElasticsearchServiceTest
         val results =
           searchResults(index = index, workQuery = MSMBoostQuery("Text that contains Aegean"))
 
-        results should have length 8
+        results should have length 10
 
         results.slice(0, 2) shouldBe List(matchingTitle100, matchingTitle75)
         results.slice(2, 4) should contain theSameElementsAs List(matchingGenre100, matchingSubject100)
         results.slice(4, 6) should contain theSameElementsAs List(matchingGenre75, matchingSubject75)
         results.slice(6, 8) shouldBe List(matchingDescription100, matchingDescription75)
-
+        results.slice(8, 10) should contain theSameElementsAs List(matchingDescription25, matchingTitle25)
 
       }
     }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -242,7 +242,26 @@ class ElasticsearchServiceTest
     val noMatch =
       createIdentifiedWorkWith(title = "Before a Bengal")
 
-    it("finds results for a JustBoostQuery search") {
+    it("finds results for a MSMQuery search") {
+      withLocalWorksIndex { index =>
+        val matching100 =
+          createIdentifiedWorkWith(title = "Title text contains Aegean")
+        val matching75 =
+          createIdentifiedWorkWith(title = "Title text contains")
+        val matching25 =
+          createIdentifiedWorkWith(title = "Title")
+
+        insertIntoElasticsearch(index, matching25, matching100, matching75)
+
+        val results = searchResults(
+          index = index,
+          workQuery = MSMQuery("Title text contains Aegean"))
+
+        results shouldBe List(matching100, matching75)
+      }
+    }
+
+    it("finds results for a BoostQuery search") {
       withLocalWorksIndex { index =>
         // Longer text used to ensure signal in TF/IDF
         val text = "Text that contains Aegean"
@@ -270,108 +289,83 @@ class ElasticsearchServiceTest
           matchingGenre)
 
         val results =
-          searchResults(index = index, workQuery = JustBoostQuery("Aegean"))
+          searchResults(index = index, workQuery = BoostQuery("Aegean"))
 
         results should have length 5
 
         results.head shouldBe exactMatchingTitle
-        results.slice(1, 3) should contain theSameElementsAs List(
+        results(1) shouldBe matchingTitle
+        results.slice(2, 4) should contain theSameElementsAs List(
           matchingSubject,
           matchingGenre)
-        results(3) shouldBe matchingTitle
         results(4) shouldBe matchingDescription
       }
     }
 
-    it("finds results for a BroaderBoostQuery search") {
+    it("finds results for a MSMBoostQuery search") {
       withLocalWorksIndex { index =>
         // Longer text used to ensure signal in TF/IDF
-        val text = "Text that contains Aegean"
+        val matchingTitle100 =
+          createIdentifiedWorkWith(title = "Title text that contains Aegean")
+        val matchingTitle75 =
+          createIdentifiedWorkWith(title = "Title text that contains")
+        val matchingTitle25 =
+          createIdentifiedWorkWith(title = "Title text")
 
-        val matchingTitle =
-          createIdentifiedWorkWith(title = s"$text title")
-        val matchingSubject =
+        val matchingSubject100 =
           createIdentifiedWorkWith(
-            subjects = List(createSubjectWith(s"$text subject")))
-        val matchingGenre =
+            subjects = List(createSubjectWith(s"Subject text that contains Aegean")))
+        val matchingSubject75 =
           createIdentifiedWorkWith(
-            genres = List(createGenreWith(s"$text genre")))
-        val matchingDescription =
-          createIdentifiedWorkWith(description = Some(s"$text description"))
-        val matchingLettering =
-          createIdentifiedWorkWith(lettering = Some(s"$text lettering"))
-        val matchingContributor =
+            subjects = List(createSubjectWith(s"Subject text that contains")))
+        val matchingSubject25 =
           createIdentifiedWorkWith(
-            contributors =
-              List(createPersonContributorWith(s"$text contributor")))
+            subjects = List(createSubjectWith(s"Subject text")))
+
+        val matchingGenre100 =
+          createIdentifiedWorkWith(
+            genres = List(createGenreWith(s"Genre text that contains Aegean")))
+        val matchingGenre75 =
+          createIdentifiedWorkWith(
+            genres = List(createGenreWith(s"Genre text that contains")))
+        val matchingGenre25 =
+          createIdentifiedWorkWith(
+            genres = List(createGenreWith(s"Genre text")))
+
+        val matchingDescription100 =
+          createIdentifiedWorkWith(description = Some(s"Description text that contains Aegean"))
+        val matchingDescription75 =
+          createIdentifiedWorkWith(description = Some(s"Description text that contains"))
+        val matchingDescription25 =
+        createIdentifiedWorkWith(description = Some(s"Description text"))
 
         insertIntoElasticsearch(
           index,
           noMatch,
-          matchingTitle,
-          matchingSubject,
-          matchingGenre,
-          matchingDescription,
-          matchingLettering,
-          matchingContributor)
+          matchingTitle100,
+          matchingTitle75,
+          matchingTitle25,
+          matchingSubject100,
+          matchingSubject75,
+          matchingSubject25,
+          matchingGenre100,
+          matchingGenre75,
+          matchingGenre25,
+          matchingDescription100,
+          matchingDescription75,
+          matchingDescription25)
 
         val results =
-          searchResults(index = index, workQuery = BroaderBoostQuery("Aegean"))
+          searchResults(index = index, workQuery = MSMBoostQuery("Text that contains Aegean"))
 
-        results should have length 6
+        results should have length 8
 
-        results.slice(0, 2) should contain theSameElementsAs List(
-          matchingSubject,
-          matchingGenre)
+        results.slice(0, 2) shouldBe List(matchingTitle100, matchingTitle75)
+        results.slice(2, 4) should contain theSameElementsAs List(matchingGenre100, matchingSubject100)
+        results.slice(4, 6) should contain theSameElementsAs List(matchingGenre75, matchingSubject75)
+        results.slice(6, 8) shouldBe List(matchingDescription100, matchingDescription75)
 
-        results(2) shouldBe matchingTitle
 
-        results.slice(3, 6) should contain theSameElementsAs List(
-          matchingDescription,
-          matchingLettering,
-          matchingContributor
-        )
-
-      }
-    }
-
-    it("finds results for a SlopQuery search") {
-      withLocalWorksIndex { index =>
-        val exactMatch = createIdentifiedWorkWith(title = "Text Aegean")
-        val matchingSlop =
-          createIdentifiedWorkWith(title = "Text that contains Aegean")
-        val notMatchingSlop = createIdentifiedWorkWith(
-          title = "Text that has too much slop but contains Aegean")
-
-        insertIntoElasticsearch(
-          index,
-          matchingSlop,
-          exactMatch,
-          notMatchingSlop)
-
-        val results =
-          searchResults(index = index, workQuery = SlopQuery("Text Aegean"))
-
-        results shouldBe List(exactMatch, matchingSlop)
-      }
-    }
-
-    it("finds results for a MinimumMatchQuery search") {
-      withLocalWorksIndex { index =>
-        val matching100 =
-          createIdentifiedWorkWith(title = "Title text contains Aegean")
-        val matching75 =
-          createIdentifiedWorkWith(title = "Title text contains")
-        val matching25 =
-          createIdentifiedWorkWith(title = "Title")
-
-        insertIntoElasticsearch(index, matching25, matching100, matching75)
-
-        val results = searchResults(
-          index = index,
-          workQuery = MinimumMatchQuery("Title text contains Aegean"))
-
-        results shouldBe List(matching100, matching75)
       }
     }
   }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -375,12 +375,12 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
           title = "Working with wombats")
         val work2 = createIdentifiedWorkWith(
           canonicalId = "2",
-          title = "Working with much too sloppy wombats")
+          title = "Working with boosted wombats")
         insertIntoElasticsearch(indexV2, work1, work2)
 
         eventually {
           server.httpGet(
-            path = s"/$apiPrefix/works?query=Working+wombats&_queryType=slop",
+            path = s"/$apiPrefix/works?query=boosting+wombats&_queryType=boost",
             andExpect = Status.Ok,
             withJsonBody = s"""
                               |{

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -380,17 +380,12 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
 
         eventually {
           server.httpGet(
-            path = s"/$apiPrefix/works?query=boosting+wombats&_queryType=boost",
+            path = s"/$apiPrefix/works?query=boosted&_queryType=boost",
             andExpect = Status.Ok,
             withJsonBody = s"""
                               |{
                               |  ${resultList(apiPrefix)},
                               |  "results": [
-                              |   {
-                              |     "type": "Work",
-                              |     "id": "${work1.canonicalId}",
-                              |     "title": "${work1.title}"
-                              |   },
                               |   {
                               |     "type": "Work",
                               |     "id": "${work2.canonicalId}",

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -390,6 +390,11 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
                               |     "type": "Work",
                               |     "id": "${work1.canonicalId}",
                               |     "title": "${work1.title}"
+                              |   },
+                              |   {
+                              |     "type": "Work",
+                              |     "id": "${work2.canonicalId}",
+                              |     "title": "${work2.title}"
                               |   }
                               |  ]
                               |}


### PR DESCRIPTION
replaces the initial set of query types with three new offspring candidates, based on the feedback we got in the internal testing