### PR TITLE
parse dates on production period

### DIFF
--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AbstractRootConcept.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AbstractRootConcept.scala
@@ -7,7 +7,7 @@ import java.time.temporal.ChronoField
 import uk.ac.wellcome.models.work.text.TextNormalisation._
 
 import scala.annotation.tailrec
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 sealed trait AbstractRootConcept {
   val label: String
@@ -88,9 +88,11 @@ object InstantRange {
         val tryLocalDateTime = Try(
           LocalDateTime.parse(label, formatterWithDefaults(pattern)))
 
-        if (tryLocalDateTime.isSuccess)
-          tryLocalDateTime.toOption.map(ldt => getInstantRange(label, ldt))
-        else findParser(label, tail)
+        tryLocalDateTime match {
+          case Success(localDateTime) =>
+            Some(getInstantRange(label, localDateTime))
+          case Failure(_) => findParser(label, tail)
+        }
 
       case _ => None
     }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AbstractRootConcept.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AbstractRootConcept.scala
@@ -26,7 +26,10 @@ case class InstantRange(label: String,
                         from: Instant,
                         to: Instant,
                         inferred: Boolean)
-    extends AbstractConcept
+// We're not extending this yet, as we don't
+// actually want it to be part of the Display
+// model as yet before we've started testing.
+// extends AbstractConcept
 object InstantRange {
   // We use this apply as it's easier to work with date math on LocalDateTime than it is on Instant
   def apply(label: String,

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AbstractRootConcept.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AbstractRootConcept.scala
@@ -64,7 +64,7 @@ object DateRange {
       .toFormatter()
 
   def parse(label: String): Option[DateRange] = {
-    parsers map {
+    parsers.toStream.map {
       case (pattern, getDateRange) =>
         Try(LocalDateTime.parse(label, formatterWithDefaults(pattern)))
           .map(getDateRange(label, _))

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AbstractRootConcept.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AbstractRootConcept.scala
@@ -21,31 +21,31 @@ object Concept {
   }
 }
 
-case class DateRange(label: String,
-                     from: Instant,
-                     to: Instant,
-                     inferred: Boolean)
+case class InstantRange(label: String,
+                        from: Instant,
+                        to: Instant,
+                        inferred: Boolean)
     extends AbstractConcept
-object DateRange {
+object InstantRange {
   // We use this apply as it's easier to work with date math on LocalDateTime than it is on Instant
   def apply(label: String,
             from: LocalDateTime,
             to: LocalDateTime,
-            inferred: Boolean): DateRange =
-    DateRange(
+            inferred: Boolean): InstantRange =
+    InstantRange(
       label = label,
       from = from.toInstant(ZoneOffset.UTC),
       to = to.toInstant(ZoneOffset.UTC),
       inferred = inferred)
 
-  type GetDateRange = (String, LocalDateTime) => DateRange
-  type DateRangeParser = (DateTimeFormatter, GetDateRange)
+  type GetInstantRange = (String, LocalDateTime) => InstantRange
+  type InstantRangeParser = (DateTimeFormatter, GetInstantRange)
 
-  val parsers: List[(String, GetDateRange)] = List(
+  val parsers: List[(String, GetInstantRange)] = List(
     (
       "yyyy",
       (label: String, from: LocalDateTime) =>
-        DateRange(
+        InstantRange(
           label,
           from,
           to = from.plusYears(1).minusNanos(1),
@@ -54,7 +54,7 @@ object DateRange {
     (
       "'['yyyy']'",
       (label: String, from: LocalDateTime) =>
-        DateRange(
+        InstantRange(
           label,
           from = from,
           to = from.plusYears(1).minusNanos(1),
@@ -75,7 +75,7 @@ object DateRange {
       .parseDefaulting(ChronoField.YEAR_OF_ERA, Year.now().getValue())
       .toFormatter()
 
-  def parse(label: String): Option[DateRange] = {
+  def parse(label: String): Option[InstantRange] = {
     parsers.toStream.map {
       case (pattern, getDateRange) => {
         Try(

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AbstractRootConcept.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AbstractRootConcept.scala
@@ -22,8 +22,8 @@ object Concept {
 }
 
 case class DateRange(label: String,
-                     start: LocalDateTime,
-                     end: LocalDateTime,
+                     from: LocalDateTime,
+                     to: LocalDateTime,
                      inferred: Boolean)
     extends AbstractConcept
 object DateRange {
@@ -33,20 +33,20 @@ object DateRange {
   val parsers: List[(String, GetDateRange)] = List(
     (
       "yyyy",
-      (label: String, start: LocalDateTime) =>
+      (label: String, from: LocalDateTime) =>
         DateRange(
           label,
-          start,
-          end = start.plusYears(1).minusNanos(1),
+          from,
+          to = from.plusYears(1).minusNanos(1),
           inferred = false)
     ),
     (
       "'['yyyy']'",
-      (label: String, start: LocalDateTime) =>
+      (label: String, from: LocalDateTime) =>
         DateRange(
           label,
-          start,
-          end = start.plusYears(1).minusNanos(1),
+          from,
+          to = from.plusYears(1).minusNanos(1),
           inferred = true)
     )
   )

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AbstractRootConcept.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AbstractRootConcept.scala
@@ -39,11 +39,10 @@ object InstantRange {
       to = to.toInstant(ZoneOffset.UTC),
       inferred = inferred)
 
-  type GetInstantRange = (String, LocalDateTime) => InstantRange
-  type InstantRangeParser = (DateTimeFormatter, GetInstantRange)
+  type ParseDateTimeToInstantRange = (String, LocalDateTime) => InstantRange
   type DatePattern = String
 
-  val parsers: List[(DatePattern, GetInstantRange)] = List(
+  val parsers: List[(DatePattern, ParseDateTimeToInstantRange)] = List(
     (
       "yyyy",
       (label: String, from: LocalDateTime) =>
@@ -81,10 +80,11 @@ object InstantRange {
   @tailrec
   private def findParser(
     label: String,
-    parsers: List[(DatePattern, GetInstantRange)]): Option[InstantRange] = {
+    parsers: List[(DatePattern, ParseDateTimeToInstantRange)])
+    : Option[InstantRange] = {
 
     parsers match {
-      case (pattern: DatePattern, getInstantRange: GetInstantRange) :: tail =>
+      case (pattern: DatePattern, getInstantRange: ParseDateTimeToInstantRange) :: tail =>
         val tryLocalDateTime = Try(
           LocalDateTime.parse(label, formatterWithDefaults(pattern)))
 

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/InstantRangeGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/InstantRangeGenerators.scala
@@ -1,0 +1,19 @@
+package uk.ac.wellcome.models.work.generators
+
+import java.time.{LocalDateTime, ZoneOffset}
+
+import uk.ac.wellcome.models.work.internal._
+
+trait InstantRangeGenerators {
+  // This is used to make the tests more readable.
+  def createInstantRangeWith(label: String,
+                             from: String,
+                             to: String,
+                             inferred: Boolean) =
+    InstantRange(
+      label,
+      from = LocalDateTime.parse(from).toInstant(ZoneOffset.UTC),
+      to = LocalDateTime.parse(to).toInstant(ZoneOffset.UTC),
+      inferred = inferred
+    )
+}

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/InstantRangeGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/InstantRangeGenerators.scala
@@ -5,7 +5,6 @@ import java.time.{LocalDateTime, ZoneOffset}
 import uk.ac.wellcome.models.work.internal._
 
 trait InstantRangeGenerators {
-  // This is used to make the tests more readable.
   def createInstantRangeWith(label: String,
                              from: String,
                              to: String,

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/DateRangeTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/DateRangeTest.scala
@@ -26,8 +26,8 @@ class DateRangeTest extends FunSpec with Matchers {
       val label = "[1918]"
       val expected = DateRange(
         label = "[1918]",
-        start = LocalDateTime.parse("1909-01-01T00:00"),
-        end = LocalDateTime.parse("1909-12-31T23:59:59.999999999"),
+        start = LocalDateTime.parse("1918-01-01T00:00"),
+        end = LocalDateTime.parse("1918-12-31T23:59:59.999999999"),
         inferred = true
       )
 

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/DateRangeTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/DateRangeTest.scala
@@ -12,8 +12,8 @@ class DateRangeTest extends FunSpec with Matchers {
       val label = "1909"
       val expected = DateRange(
         label = "1909",
-        start = LocalDateTime.parse("1909-01-01T00:00"),
-        end = LocalDateTime.parse("1909-12-31T23:59:59.999999999"),
+        from = LocalDateTime.parse("1909-01-01T00:00"),
+        to = LocalDateTime.parse("1909-12-31T23:59:59.999999999"),
         inferred = false
       )
 
@@ -26,8 +26,8 @@ class DateRangeTest extends FunSpec with Matchers {
       val label = "[1918]"
       val expected = DateRange(
         label = "[1918]",
-        start = LocalDateTime.parse("1918-01-01T00:00"),
-        end = LocalDateTime.parse("1918-12-31T23:59:59.999999999"),
+        from = LocalDateTime.parse("1918-01-01T00:00"),
+        to = LocalDateTime.parse("1918-12-31T23:59:59.999999999"),
         inferred = true
       )
 

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/DateRangeTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/DateRangeTest.scala
@@ -20,7 +20,6 @@ class DateRangeTest extends FunSpec with Matchers {
       )
 
       DateRange.parse(label) shouldBe Some(expected)
-
     }
 
     it(
@@ -36,7 +35,11 @@ class DateRangeTest extends FunSpec with Matchers {
       )
 
       DateRange.parse(label) shouldBe Some(expected)
+    }
 
+    it("Should return None if we don't understand the label") {
+      val label = "nineteen sixty what, nineteen sixty who"
+      DateRange.parse(label) shouldBe None
     }
   }
 }

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/DateRangeTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/DateRangeTest.scala
@@ -1,0 +1,38 @@
+package uk.ac.wellcome.models.work.internal
+
+import java.time.LocalDateTime
+
+import org.scalatest.{FunSpec, Matchers}
+
+class DateRangeTest extends FunSpec with Matchers {
+
+  describe("parse") {
+    it(
+      "parses a year like 1909 into a range of the beginning and end of that year") {
+      val label = "1909"
+      val expected = DateRange(
+        label = "1909",
+        start = LocalDateTime.parse("1909-01-01T00:00"),
+        end = LocalDateTime.parse("1909-12-31T23:59:59.999999999"),
+        inferred = false
+      )
+
+      DateRange.parse(label) shouldBe Some(expected)
+
+    }
+
+    it(
+      "parses a year like [1918] into a range of the beginning and end of that year and marks it as inferred") {
+      val label = "[1918]"
+      val expected = DateRange(
+        label = "[1918]",
+        start = LocalDateTime.parse("1909-01-01T00:00"),
+        end = LocalDateTime.parse("1909-12-31T23:59:59.999999999"),
+        inferred = true
+      )
+
+      DateRange.parse(label) shouldBe Some(expected)
+
+    }
+  }
+}

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/DateRangeTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/DateRangeTest.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.models.work.internal
 
-import java.time.LocalDateTime
+import java.time.{LocalDateTime, ZoneOffset}
 
 import org.scalatest.{FunSpec, Matchers}
 
@@ -12,8 +12,10 @@ class DateRangeTest extends FunSpec with Matchers {
       val label = "1909"
       val expected = DateRange(
         label = "1909",
-        from = LocalDateTime.parse("1909-01-01T00:00"),
-        to = LocalDateTime.parse("1909-12-31T23:59:59.999999999"),
+        from = LocalDateTime.parse("1909-01-01T00:00").toInstant(ZoneOffset.UTC),
+        to = LocalDateTime
+          .parse("1909-12-31T23:59:59.999999999")
+          .toInstant(ZoneOffset.UTC),
         inferred = false
       )
 
@@ -26,8 +28,10 @@ class DateRangeTest extends FunSpec with Matchers {
       val label = "[1918]"
       val expected = DateRange(
         label = "[1918]",
-        from = LocalDateTime.parse("1918-01-01T00:00"),
-        to = LocalDateTime.parse("1918-12-31T23:59:59.999999999"),
+        from = LocalDateTime.parse("1918-01-01T00:00").toInstant(ZoneOffset.UTC),
+        to = LocalDateTime
+          .parse("1918-12-31T23:59:59.999999999")
+          .toInstant(ZoneOffset.UTC),
         inferred = true
       )
 

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/InstantRangeTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/InstantRangeTest.scala
@@ -1,44 +1,44 @@
 package uk.ac.wellcome.models.work.internal
 
-import java.time.{LocalDateTime, ZoneOffset}
-
+import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.work.generators.InstantRangeGenerators
 
-class InstantRangeTest extends FunSpec with Matchers {
+class InstantRangeTest
+    extends FunSpec
+    with Matchers
+    with InstantRangeGenerators {
 
-  describe("parse") {
-    it(
-      "parses a year like 1909 into a range of the beginning and end of that year") {
-      val label = "1909"
-      val expected = InstantRange(
-        label = "1909",
-        from = LocalDateTime.parse("1909-01-01T00:00").toInstant(ZoneOffset.UTC),
-        to = LocalDateTime
-          .parse("1909-12-31T23:59:59.999999999")
-          .toInstant(ZoneOffset.UTC),
-        inferred = false
-      )
+  it("parses valid date labels") {
+    val instantRange = createInstantRangeWith(
+      "1909",
+      "1909-01-01T00:00",
+      "1909-12-31T23:59:59.999999999",
+      inferred = false)
 
-      InstantRange.parse(label) shouldBe Some(expected)
+    val inferredInstantRange = createInstantRangeWith(
+      "[2123]",
+      "2123-01-01T00:00",
+      "2123-12-31T23:59:59.999999999",
+      inferred = true)
+
+    forAll(
+      Table(
+        ("label", "parsedInstantRange"),
+        ("1909", instantRange),
+        ("[2123]", inferredInstantRange),
+      )) { (label, parsedInstantRange) =>
+      InstantRange.parse(label) shouldBe Some(parsedInstantRange)
     }
+  }
 
-    it(
-      "parses a year like [1918] into a range of the beginning and end of that year and marks it as inferred") {
-      val label = "[1918]"
-      val expected = InstantRange(
-        label = "[1918]",
-        from = LocalDateTime.parse("1918-01-01T00:00").toInstant(ZoneOffset.UTC),
-        to = LocalDateTime
-          .parse("1918-12-31T23:59:59.999999999")
-          .toInstant(ZoneOffset.UTC),
-        inferred = true
-      )
-
-      InstantRange.parse(label) shouldBe Some(expected)
-    }
-
-    it("Should return None if we don't understand the label") {
-      val label = "nineteen sixty what, nineteen sixty who"
+  it("does not parse invalid date labels") {
+    forAll(
+      Table(
+        "label",
+        "nineteen sixty what, nineteen sixty who",
+        "[21233]",
+      )) { label =>
       InstantRange.parse(label) shouldBe None
     }
   }

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/InstantRangeTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/InstantRangeTest.scala
@@ -37,7 +37,12 @@ class InstantRangeTest
       Table(
         "label",
         "nineteen sixty what, nineteen sixty who",
+        "123",
+        "23Y5",
         "[21233]",
+        "[21u6]",
+        "[^216]",
+        "[216]",
       )) { label =>
       InstantRange.parse(label) shouldBe None
     }

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/InstantRangeTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/InstantRangeTest.scala
@@ -4,13 +4,13 @@ import java.time.{LocalDateTime, ZoneOffset}
 
 import org.scalatest.{FunSpec, Matchers}
 
-class DateRangeTest extends FunSpec with Matchers {
+class InstantRangeTest extends FunSpec with Matchers {
 
   describe("parse") {
     it(
       "parses a year like 1909 into a range of the beginning and end of that year") {
       val label = "1909"
-      val expected = DateRange(
+      val expected = InstantRange(
         label = "1909",
         from = LocalDateTime.parse("1909-01-01T00:00").toInstant(ZoneOffset.UTC),
         to = LocalDateTime
@@ -19,13 +19,13 @@ class DateRangeTest extends FunSpec with Matchers {
         inferred = false
       )
 
-      DateRange.parse(label) shouldBe Some(expected)
+      InstantRange.parse(label) shouldBe Some(expected)
     }
 
     it(
       "parses a year like [1918] into a range of the beginning and end of that year and marks it as inferred") {
       val label = "[1918]"
-      val expected = DateRange(
+      val expected = InstantRange(
         label = "[1918]",
         from = LocalDateTime.parse("1918-01-01T00:00").toInstant(ZoneOffset.UTC),
         to = LocalDateTime
@@ -34,12 +34,12 @@ class DateRangeTest extends FunSpec with Matchers {
         inferred = true
       )
 
-      DateRange.parse(label) shouldBe Some(expected)
+      InstantRange.parse(label) shouldBe Some(expected)
     }
 
     it("Should return None if we don't understand the label") {
       val label = "nineteen sixty what, nineteen sixty who"
-      DateRange.parse(label) shouldBe None
+      InstantRange.parse(label) shouldBe None
     }
   }
 }

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -5,9 +5,8 @@ object Common {
   val settings: Seq[Def.Setting[_]] = Seq(
     scalaVersion := "2.12.6",
     organization := "uk.ac.wellcome",
-
-    resolvers ++= Seq("S3 releases" at "s3://releases.mvn-repo.wellcomecollection.org/"),
-
+    resolvers ++= Seq(
+      "S3 releases" at "s3://releases.mvn-repo.wellcomecollection.org/"),
     scalacOptions ++= Seq(
       "-deprecation",
       "-unchecked",


### PR DESCRIPTION
We need to be able to take a label (free string) - parse that into a `from` `Instant` and then parse that into an `InstantRange` with an associate parser (as we add things like `inferred` and might have different `to` values dependant on the pattern). 

This does that.