### PR TITLE
Filter works by date range in API

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V2WorksController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V2WorksController.scala
@@ -60,9 +60,9 @@ class V2WorksController @Inject()(
           WorkTypeFilter(workTypeIds)
         }
 
-    val maybeDateRangeFilter : Option[DateRangeFilter] =
+    val maybeDateRangeFilter: Option[DateRangeFilter] =
       (request._dateFrom, request._dateTo) match {
-        case (None, None) => None
+        case (None, None)       => None
         case (dateFrom, dateTo) => Some(DateRangeFilter(dateFrom, dateTo))
       }
 

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V2WorksController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V2WorksController.scala
@@ -60,7 +60,13 @@ class V2WorksController @Inject()(
           WorkTypeFilter(workTypeIds)
         }
 
-    List(maybeItemLocationTypeFilter, maybeWorkTypeFilter).flatten
+    val maybeDateRangeFilter : Option[DateRangeFilter] =
+      (request._dateFrom, request._dateTo) match {
+        case (None, None) => None
+        case (dateFrom, dateTo) => Some(DateRangeFilter(dateFrom, dateTo))
+      }
+
+    List(maybeItemLocationTypeFilter, maybeWorkTypeFilter, maybeDateRangeFilter).flatten
   }
 
   override def setupResultListSwaggerDocs[T <: DisplayWork](

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkFilter.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkFilter.scala
@@ -1,5 +1,7 @@
 package uk.ac.wellcome.platform.api.models
 
+import java.time.LocalDate
+
 sealed trait WorkFilter
 
 case class ItemLocationTypeFilter(locationTypeIds: Seq[String])
@@ -16,3 +18,6 @@ case object WorkTypeFilter {
   def apply(workTypeId: String): WorkTypeFilter =
     WorkTypeFilter(workTypeIds = Seq(workTypeId))
 }
+
+case class DateRangeFilter(fromDate: Option[LocalDate], toDate: Option[LocalDate])
+    extends WorkFilter

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkFilter.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkFilter.scala
@@ -19,5 +19,6 @@ case object WorkTypeFilter {
     WorkTypeFilter(workTypeIds = Seq(workTypeId))
 }
 
-case class DateRangeFilter(fromDate: Option[LocalDate], toDate: Option[LocalDate])
+case class DateRangeFilter(fromDate: Option[LocalDate],
+                           toDate: Option[LocalDate])
     extends WorkFilter

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/requests/Requests.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/requests/Requests.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.platform.api.requests
 
+import java.time.LocalDate
 import com.twitter.finagle.http.Request
 import com.twitter.finatra.request.{QueryParam, RouteParam}
 import com.twitter.finatra.validation.{Max, Min}
@@ -44,6 +45,8 @@ case class V2MultipleResultsRequest(
   @QueryParam("items.locations.locationType") itemLocationType: Option[String],
   @QueryParam _index: Option[String],
   @QueryParam _queryType: Option[String],
+  @QueryParam _dateFrom: Option[LocalDate],
+  @QueryParam _dateTo: Option[LocalDate],
   request: Request
 ) extends MultipleResultsRequest[V2WorksIncludes]
 

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -7,7 +7,7 @@ import com.sksamuel.elastic4s.http.get.GetResponse
 import com.sksamuel.elastic4s.http.search.SearchResponse
 import com.sksamuel.elastic4s.http.{ElasticClient, ElasticError, Response}
 import com.sksamuel.elastic4s.searches.SearchRequest
-import com.sksamuel.elastic4s.searches.queries.Query
+import com.sksamuel.elastic4s.searches.queries.{NoopQuery, Query}
 import com.sksamuel.elastic4s.searches.sort.{FieldSort, SortOrder}
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.api.models._
@@ -91,6 +91,7 @@ class ElasticsearchService @Inject()(elasticClient: ElasticClient)(
           values = itemLocationTypeIds)
       case WorkTypeFilter(workTypeIds) =>
         termsQuery(field = "workType.id", values = workTypeIds)
+      case DateRangeFilter(_, _) => NoopQuery // TODO: return date range query
     }
 
   private def buildFilteredQuery(maybeWorkQuery: Option[WorkQuery],

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.api.services
 
 import com.google.inject.{Inject, Singleton}
-import com.sksamuel.elastic4s.{Index, ElasticDate}
+import com.sksamuel.elastic4s.{ElasticDate, Index}
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.http.get.GetResponse
 import com.sksamuel.elastic4s.http.search.SearchResponse
@@ -92,8 +92,8 @@ class ElasticsearchService @Inject()(elasticClient: ElasticClient)(
       case WorkTypeFilter(workTypeIds) =>
         termsQuery(field = "workType.id", values = workTypeIds)
       case DateRangeFilter(fromDate, toDate) =>
-        val (gte, lte) = (fromDate map ElasticDate.apply,
-                          toDate map ElasticDate.apply)
+        val (gte, lte) =
+          (fromDate map ElasticDate.apply, toDate map ElasticDate.apply)
         boolQuery should (
           RangeQuery("production.dates.range.from", lte = lte, gte = gte),
           RangeQuery("production.dates.range.to", lte = lte, gte = gte)

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -8,7 +8,6 @@ import com.sksamuel.elastic4s.http.search.SearchResponse
 import com.sksamuel.elastic4s.http.{ElasticClient, ElasticError, Response}
 import com.sksamuel.elastic4s.searches.SearchRequest
 import com.sksamuel.elastic4s.searches.queries.Query
-import com.sksamuel.elastic4s.searches.queries.term.TermsQuery
 import com.sksamuel.elastic4s.searches.sort.{FieldSort, SortOrder}
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.api.models._
@@ -84,7 +83,7 @@ class ElasticsearchService @Inject()(elasticClient: ElasticClient)(
       .from(queryOptions.from)
   }
 
-  private def toTermQuery(workFilter: WorkFilter): TermsQuery[String] =
+  private def toQuery(workFilter: WorkFilter): Query =
     workFilter match {
       case ItemLocationTypeFilter(itemLocationTypeIds) =>
         termsQuery(
@@ -104,7 +103,7 @@ class ElasticsearchService @Inject()(elasticClient: ElasticClient)(
     }
 
     val filterDefinitions: List[Query] =
-      filters.map { toTermQuery } :+ termQuery(
+      filters.map { toQuery } :+ termQuery(
         field = "type",
         value = "IdentifiedWork")
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -5,11 +5,18 @@ import com.sksamuel.elastic4s.http.ElasticError
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
-import uk.ac.wellcome.models.work.generators.{ProductionEventGenerators, WorksGenerators}
+import uk.ac.wellcome.models.work.generators.{
+  ProductionEventGenerators,
+  WorksGenerators
+}
 import uk.ac.wellcome.models.work.internal.{IdentifiedBaseWork, WorkType}
 import uk.ac.wellcome.platform.api.generators.SearchOptionsGenerators
 import uk.ac.wellcome.platform.api.models.WorkQuery.SimpleQuery
-import uk.ac.wellcome.platform.api.models.{DateRangeFilter, ResultList, WorkTypeFilter}
+import uk.ac.wellcome.platform.api.models.{
+  DateRangeFilter,
+  ResultList,
+  WorkTypeFilter
+}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -10,7 +10,6 @@ import uk.ac.wellcome.models.work.internal.{IdentifiedBaseWork, WorkType}
 import uk.ac.wellcome.platform.api.generators.SearchOptionsGenerators
 import uk.ac.wellcome.platform.api.models.WorkQuery.SimpleQuery
 import uk.ac.wellcome.platform.api.models.{DateRangeFilter, ResultList, WorkTypeFilter}
-import uk.ac.wellcome.models.work.internal.IdentifiedWork
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -332,11 +331,6 @@ class WorksServiceTest
       }
     }
   }
-
-  private def createDatedWork(dateLabel: String): IdentifiedWork =
-    createIdentifiedWorkWith(
-      production = List(createProductionEventWith(dateLabel = Some(dateLabel)))
-    )
 
   private def assertListResultIsCorrect(
     allWorks: Seq[IdentifiedBaseWork],

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2FiltersTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2FiltersTest.scala
@@ -184,9 +184,9 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
   describe("filtering works by date") {
 
     val (work1, work2, work3) = (
-      createDatedWork("1709", canonicalId="a"),
-      createDatedWork("1950", canonicalId="b"),
-      createDatedWork("2000", canonicalId="c")
+      createDatedWork("1709", canonicalId = "a"),
+      createDatedWork("1950", canonicalId = "b"),
+      createDatedWork("2000", canonicalId = "c")
     )
 
     it("filters by date range") {
@@ -221,8 +221,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
           insertIntoElasticsearch(indexV2, work1, work2, work3)
           eventually {
             server.httpGet(
-              path =
-                s"/$apiPrefix/works?_dateFrom=1900-01-01",
+              path = s"/$apiPrefix/works?_dateFrom=1900-01-01",
               andExpect = Status.Ok,
               withJsonBody = s"""
                                 |{
@@ -252,8 +251,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
           insertIntoElasticsearch(indexV2, work1, work2, work3)
           eventually {
             server.httpGet(
-              path =
-                s"/$apiPrefix/works?_dateTo=1960-01-01",
+              path = s"/$apiPrefix/works?_dateTo=1960-01-01",
               andExpect = Status.Ok,
               withJsonBody = s"""
                                 |{
@@ -283,8 +281,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
           insertIntoElasticsearch(indexV2, work1, work2, work3)
           eventually {
             server.httpGet(
-              path =
-                s"/$apiPrefix/works?_dateFrom=1900-01-01&_dateTo=INVALID",
+              path = s"/$apiPrefix/works?_dateFrom=1900-01-01&_dateTo=INVALID",
               andExpect = Status.BadRequest,
             )
           }

--- a/common/display/src/main/scala/uk/ac/wellcome/display/modules/DisplayJacksonModule.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/modules/DisplayJacksonModule.scala
@@ -2,11 +2,15 @@ package uk.ac.wellcome.display.modules
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.twitter.finatra.json.modules.FinatraJacksonModule
-import uk.ac.wellcome.display.serialize.WorksIncludesDeserializerModule
+import uk.ac.wellcome.display.serialize.{
+  LocalDateDeserializerModule,
+  WorksIncludesDeserializerModule
+}
 
 object DisplayJacksonModule extends FinatraJacksonModule {
   override val propertyNamingStrategy = PropertyNamingStrategy.LOWER_CAMEL_CASE
   override val additionalJacksonModules = Seq(
-    new WorksIncludesDeserializerModule
+    new LocalDateDeserializerModule,
+    new WorksIncludesDeserializerModule,
   )
 }

--- a/common/display/src/main/scala/uk/ac/wellcome/display/serialize/LocalDateDeserializer.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/serialize/LocalDateDeserializer.scala
@@ -1,0 +1,26 @@
+package uk.ac.wellcome.display.serialize
+
+import java.time.LocalDate
+import java.time.format.DateTimeParseException
+import com.fasterxml.jackson.core.{JsonParser, JsonProcessingException}
+import com.fasterxml.jackson.databind.{DeserializationContext, JsonDeserializer}
+import com.fasterxml.jackson.databind.module.SimpleModule
+
+class LocalDateParsingException(msg: String)
+    extends JsonProcessingException(msg: String)
+
+class LocalDateDeserializer extends JsonDeserializer[LocalDate] {
+  override def deserialize(p: JsonParser,
+                           ctx: DeserializationContext): LocalDate = {
+    try {
+      LocalDate.parse(p.getText())
+    } catch {
+      case exc: DateTimeParseException =>
+        throw new LocalDateParsingException(exc.getMessage())
+    }
+  }
+}
+
+class LocalDateDeserializerModule extends SimpleModule {
+  addDeserializer(classOf[LocalDate], new LocalDateDeserializer())
+}

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ProductionEventGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ProductionEventGenerators.scala
@@ -4,13 +4,15 @@ import uk.ac.wellcome.models.generators.RandomStrings
 import uk.ac.wellcome.models.work.internal._
 
 trait ProductionEventGenerators extends RandomStrings {
-  def createProductionEventWith(function: Option[Concept] = None)
-    : ProductionEvent[Displayable[AbstractAgent]] =
+  def createProductionEventWith(
+    function: Option[Concept] = None,
+    dateLabel: Option[String] = None
+  ): ProductionEvent[Displayable[AbstractAgent]] =
     ProductionEvent(
       label = randomAlphanumeric(25),
       places = List(Place(randomAlphanumeric(10))),
       agents = List(Unidentifiable(Person(randomAlphanumeric(10)))),
-      dates = List(Period(randomAlphanumeric(5))),
+      dates = List(Period(dateLabel.getOrElse(randomAlphanumeric(5)))),
       function = function
     )
 

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
@@ -2,9 +2,7 @@ package uk.ac.wellcome.models.work.generators
 
 import uk.ac.wellcome.models.work.internal._
 
-trait WorksGenerators
-    extends ItemsGenerators
-    with ProductionEventGenerators {
+trait WorksGenerators extends ItemsGenerators with ProductionEventGenerators {
 
   private def createTitle: String = randomAlphanumeric(length = 100)
 
@@ -225,9 +223,9 @@ trait WorksGenerators
     List.fill(count)(createIsbnWork)
 
   def createDatedWork(
-      dateLabel: String,
-      canonicalId: String = createCanonicalId
-    ): IdentifiedWork =
+    dateLabel: String,
+    canonicalId: String = createCanonicalId
+  ): IdentifiedWork =
     createIdentifiedWorkWith(
       canonicalId = canonicalId,
       production = List(createProductionEventWith(dateLabel = Some(dateLabel)))

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
@@ -2,7 +2,10 @@ package uk.ac.wellcome.models.work.generators
 
 import uk.ac.wellcome.models.work.internal._
 
-trait WorksGenerators extends ItemsGenerators {
+trait WorksGenerators
+    extends ItemsGenerators
+    with ProductionEventGenerators {
+
   private def createTitle: String = randomAlphanumeric(length = 100)
 
   def createUnidentifiedRedirectedWork: UnidentifiedRedirectedWork =
@@ -220,4 +223,13 @@ trait WorksGenerators extends ItemsGenerators {
 
   def createIsbnWorks(count: Int): List[UnidentifiedWork] =
     List.fill(count)(createIsbnWork)
+
+  def createDatedWork(
+      dateLabel: String,
+      canonicalId: String = createCanonicalId
+    ): IdentifiedWork =
+    createIdentifiedWorkWith(
+      canonicalId = canonicalId,
+      production = List(createProductionEventWith(dateLabel = Some(dateLabel)))
+    )
 }


### PR DESCRIPTION
Issue: https://github.com/wellcometrust/platform/issues/3705

The API accepts two new query parameters, `_dateFrom` and `_dateTo`, both accepting ISO 8601 date format. This does not include the time stamp, date only e.g. `1905-05-19`