### PR TITLE
[TO DISCUSS] Parse dates with parboiled rather than fastparse

### DIFF
--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/parse/FreeformDateParser.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/parse/FreeformDateParser.scala
@@ -5,13 +5,13 @@ import org.parboiled2._
 import org.parboiled2.{Parser => ParboiledParser}
 
 class FreeformDateParser(val input: ParserInput)
-  extends ParboiledParser with DateHelpers {
+    extends ParboiledParser
+    with DateHelpers {
 
   def parser = rule(inferredTimePeriod | timePeriod ~ EOI)
 
   def inferredTimePeriod =
-    rule(
-      ("[".? ~ timePeriod ~ "]") ~> (_ withInferred true))
+    rule(("[".? ~ timePeriod ~ "]") ~> (_ withInferred true))
 
   def timePeriod =
     rule(
@@ -53,32 +53,35 @@ class FreeformDateParser(val input: ParserInput)
 
   def monthAndYear = () => rule(monthFollowedByYear | yearFollowedByMonth)
 
-  def monthFollowedByYear = rule((writtenMonth ~ ws ~ yearDigits) ~> (MonthAndYear(_, _)))
+  def monthFollowedByYear =
+    rule((writtenMonth ~ ws ~ yearDigits) ~> (MonthAndYear(_, _)))
 
   def yearFollowedByMonth =
     rule(
-      (yearDigits ~ ws ~ writtenMonth) ~> ((year, month) => MonthAndYear(month, year)))
+      (yearDigits ~ ws ~ writtenMonth) ~> ((year,
+                                            month) =>
+                                             MonthAndYear(month, year)))
 
-  def writtenMonth = rule(valueMap(monthMapping, ignoreCase=true))
+  def writtenMonth = rule(valueMap(monthMapping, ignoreCase = true))
 
   def writtenDay = rule(dayDigits ~ ordinalIndicator.?)
 
-  def yearDigits = rule(digits(from=4, to=4))
+  def yearDigits = rule(digits(from = 4, to = 4))
 
   def monthDigits =
     rule(
-      digits(from=1, to=2)
+      digits(from = 1, to = 2)
         ~> (month => test(month >= 1 && month <= 12) ~ push(month)))
 
   def dayDigits =
     rule(
-      digits(from=1, to=2)
+      digits(from = 1, to = 2)
         ~> (day => test(day >= 1 && day <= 31) ~ push(day)))
 
-  def digits(from: Int, to: Int) : Rule1[Int] =
+  def digits(from: Int, to: Int): Rule1[Int] =
     rule(
       capture(from.to(to).times(CharPredicate.Digit))
-        ~> ((_ : String).toInt))
+        ~> ((_: String).toInt))
 
   def ws = rule(oneOrMore(" "))
 
@@ -94,11 +97,11 @@ class FreeformDateParser(val input: ParserInput)
   implicit class ToInstantRangeParser[T <: TimePeriod](parser: Rule1[T]) {
     def toInstantRange(
       implicit toInstantRange: ToInstantRange[T]): Rule1[InstantRange] =
-        rule(
-          parser
-            ~> (toInstantRange.safeConvert(_))
-            ~> (instantRange => test(instantRange.nonEmpty) ~ push(instantRange))
-            ~> ((instantRange: Option[InstantRange]) => instantRange.get))
+      rule(
+        parser
+          ~> (toInstantRange.safeConvert(_))
+          ~> (instantRange => test(instantRange.nonEmpty) ~ push(instantRange))
+          ~> ((instantRange: Option[InstantRange]) => instantRange.get))
   }
 
   def monthMapping =
@@ -125,5 +128,6 @@ class FreeformDateParser(val input: ParserInput)
       "nov" -> 11,
       "november" -> 11,
       "dec" -> 12,
-      "december" -> 12)
+      "december" -> 12
+    )
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/parse/Parser.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/parse/Parser.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.models.parse
 
-import fastparse._
+import uk.ac.wellcome.models.work.internal.InstantRange
 
 /**
   *  Trait for parsing some input into T with the FastParse library
@@ -8,21 +8,12 @@ import fastparse._
 trait Parser[T] {
 
   /**
-    *  The FastParse parser combinator applied to the input
-    */
-  def parser[_: P]: P[T]
-
-  /**
-    *  Parse some input
-    *
-    *  @param input the input string
-    *  @return Some(output) if parse was successful, None otherwise
-    */
-  def apply(input: String): Option[T] =
-    parse(input, parser(_)) match {
-      case Parsed.Success(value, _) => Some(value)
-      case Parsed.Failure(_, _, _)  => None
-    }
+   *  Parse some input
+   *
+   *  @param input the input string
+   *  @return Some(output) if parse was successful, None otherwise
+   */
+  def apply(input: String) : Option[T]
 }
 
 /**
@@ -30,5 +21,8 @@ trait Parser[T] {
   */
 package object parsers {
 
-  implicit val DateParser = FreeformDateParser
+  implicit val DateParser = new Parser[InstantRange] {
+    def apply(input: String) : Option[InstantRange] =
+      new FreeformDateParser(input).parser.run().toOption
+    }
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/parse/Parser.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/parse/Parser.scala
@@ -8,12 +8,12 @@ import uk.ac.wellcome.models.work.internal.InstantRange
 trait Parser[T] {
 
   /**
-   *  Parse some input
-   *
-   *  @param input the input string
-   *  @return Some(output) if parse was successful, None otherwise
-   */
-  def apply(input: String) : Option[T]
+    *  Parse some input
+    *
+    *  @param input the input string
+    *  @return Some(output) if parse was successful, None otherwise
+    */
+  def apply(input: String): Option[T]
 }
 
 /**
@@ -22,7 +22,7 @@ trait Parser[T] {
 package object parsers {
 
   implicit val DateParser = new Parser[InstantRange] {
-    def apply(input: String) : Option[InstantRange] =
+    def apply(input: String): Option[InstantRange] =
       new FreeformDateParser(input).parser.run().toOption
-    }
+  }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -190,7 +190,7 @@ object ExternalDependencies {
   )
 
   val parseDependencies = Seq(
-    "com.lihaoyi" %% "fastparse" % versions.fastparse
+    "org.parboiled" %% "parboiled" % "2.1.7"
   )
 }
 


### PR DESCRIPTION
This contains a rewrite of the date parsing code using [parboiled2](https://github.com/sirthias/parboiled2) rather than [FastParse](https://www.lihaoyi.com/fastparse/).

Issue: https://github.com/wellcometrust/platform/issues/3755

# Comparison

## Rule definition

In FastParse we have to add `[_ : P]` everywhere to please the compiler, which makes the definitions a bit confusing.

FastParse:

https://github.com/wellcometrust/catalogue/blob/5cbcc1b06a35aba85a061c7f72d2c93c5a173cba/common/internal_model/src/main/scala/uk/ac/wellcome/models/parse/FreeformDateParser.scala#L13-L14

ParBoiled:

https://github.com/wellcometrust/catalogue/blob/b9df66bcd500c0179b218527bfaeba8472ea6fdc/common/internal_model/src/main/scala/uk/ac/wellcome/models/parse/FreeformDateParser.scala#L10

## Predicates

The way to specify a predicate in ParBoiled is slightly more involved, having to subsequently [push](https://github.com/sirthias/parboiled2#id33) the value onto the stack rather than just filtering:

FastParse:

https://github.com/wellcometrust/catalogue/blob/5cbcc1b06a35aba85a061c7f72d2c93c5a173cba/common/internal_model/src/main/scala/uk/ac/wellcome/models/parse/FreeformDateParser.scala#L160

Parboiled:

https://github.com/wellcometrust/catalogue/blob/b9df66bcd500c0179b218527bfaeba8472ea6fdc/common/internal_model/src/main/scala/uk/ac/wellcome/models/parse/FreeformDateParser.scala#L100

## Meta-rules

In Parboiled, when defining functions which take some rule and return another rule, we have to modify any rule we want to pass to be a `() => rule` and pass that rather than the rule itself (as documented [here](https://github.com/sirthias/parboiled2#meta-rules)):

https://github.com/wellcometrust/catalogue/blob/b9df66bcd500c0179b218527bfaeba8472ea6fdc/common/internal_model/src/main/scala/uk/ac/wellcome/models/parse/FreeformDateParser.scala#L48

This ends up with us having to write things like this :crying_cat_face::

https://github.com/wellcometrust/catalogue/blob/b9df66bcd500c0179b218527bfaeba8472ea6fdc/common/internal_model/src/main/scala/uk/ac/wellcome/models/parse/FreeformDateParser.scala#L18-L21

Rather than this:

https://github.com/wellcometrust/catalogue/blob/5cbcc1b06a35aba85a061c7f72d2c93c5a173cba/common/internal_model/src/main/scala/uk/ac/wellcome/models/parse/FreeformDateParser.scala#L20-L23

## Efficiency

According to metrics both are similar efficiency. See [here](https://www.lihaoyi.com/fastparse/#Performance).

## Project usage

Both projects appear to be approximately as popular as each other, and are relatively well maintained.