### PR TITLE
create new stack pointing to ES7 stack and deploy API

### DIFF
--- a/.wellcome_project
+++ b/.wellcome_project
@@ -1,5 +1,5 @@
 {
-    "catalogue_api": {
+    "catalogue_pipeline": {
 		"environments": [{
 				"id": "latest",
 				"name": "Latest"
@@ -9,30 +9,16 @@
 				"name": "Staging"
 			},
 			{
-				"id": "prod",
-				"name": "Production"
-			}
-		],
-		"name": "Catalogue API",
-		"profile": "platform-dev",
-		"github_repository": "wellcometrust/catalogue"
-	},
-	"catalogue_pipeline": {
-		"environments": [{
-				"id": "latest",
-				"name": "Latest"
-			},
-			{
-				"id": "stage",
-				"name": "Staging"
-			},
+                "id": "prod_es7",
+                "name": "Prod ES7"
+            },
 			{
 				"id": "prod",
 				"name": "Production"
 			}
 		],
 		"name": "Catalogue pipeline",
-		"profile": "platform-dev",
+		"profile": "default",
 		"github_repository": "wellcometrust/catalogue"
 	}
 }

--- a/api/terraform/locals.tf
+++ b/api/terraform/locals.tf
@@ -8,9 +8,9 @@ locals {
 
   # API pins
 
-  production_api     = "romulus"
+  production_api     = "remus"
   pinned_nginx       = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_api-gw:bad0dbfa548874938d16496e313b05adb71268b7"
-  pinned_remus_api   = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/api:9b55e2eee77188011ea5ce9609b2e169b821c5fc"
+  pinned_remus_api   = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/api:d1b4229f6e85c09dd7e5b0c94cffc898d11e23b9"
   pinned_romulus_api = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/api:61fca4d91d338ed9de7ef44b388d9dd64bfb069b"
   romulus_es_config = {
     index_v1 = "v1-2019-01-24-production-changes"

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -56,4 +56,4 @@ Inserts a work into our query index - Elasticsearch.
 
 ## Releasing
 We use the [Wellcome Release Tooling](https://github.com/wellcometrust/dockerfiles/tree/master/release_tooling),
-which has it's config defined in [`.wellcome_project`](../.wellcome_project).
+which has its config defined in [`.wellcome_project`](../.wellcome_project).

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -1,5 +1,7 @@
 # Catalogue pipeline
 
+## Structure
+
 All data comes from an external data source, e.g. [Sierra and it's adapter](../sierra_adapter),
 onto a queue for entering the pipeline, and finally makes it into out query index,
 [Elasticsearch](https://www.elastic.co/products/elasticsearch).
@@ -16,7 +18,7 @@ We use AWS SNS / SQS for this, there are talks of abstracting that out.
 SNS => Service => SQS
 ``` 
 
-## [Transformer](./transformer)
+### [Transformer](./transformer)
 
 Each data source will have their own transformer e.g. 
 * [Miro](./transformer/transformer_miro)
@@ -25,28 +27,33 @@ Each data source will have their own transformer e.g.
 These take the original source data from an adapter, and transform them into a Work (Unidentified).
 
 
-## [Recorder](./recorder)
+### [Recorder](./recorder)
 
 Each transformed work is stored into a
 [VHS store](https://stacks.wellcomecollection.org/creating-a-data-store-from-s3-and-dynamodb-8bb9ecce8fc1).
 
 
-## [Matcher](./matcher)
+### [Matcher](./matcher)
 
 Searches for potential merge candidates, and records them on the Work. 
 
 
-## [Merger](./merger)
+### [Merger](./merger)
 
 Runs some [rules](./merger/src/test/scala/uk/ac/wellcome/platform/merger/rules) on the merge candidates
 and decides if it is a valid merge.
 
 
-## [ID Minter](./id_minter)
+### [ID Minter](./id_minter)
 
 Each Unidentified Work has an ID minted for it, using a source ID and avoiding dupes. 
 
 
-## [Ingestor](./ingestor)
+### [Ingestor](./ingestor)
 
 Inserts a work into our query index - Elasticsearch.
+
+
+## Releasing
+We use the [Wellcome Release Tooling](https://github.com/wellcometrust/dockerfiles/tree/master/release_tooling),
+which has it's config defined in [`.wellcome_project`](../.wellcome_project).

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -35,3 +35,43 @@ module "catalogue_pipeline_20190426" {
   vhs_sierra_read_policy = "${local.vhs_sierra_read_policy}"
   vhs_miro_read_policy   = "${local.vhs_miro_read_policy}"
 }
+
+module "catalogue_pipeline_20190723" {
+  source = "stack"
+
+  namespace = "catalogue-20190723"
+
+  release_label = "prod_es7"
+
+  account_id = "${data.aws_caller_identity.current.account_id}"
+  aws_region = "${local.aws_region}"
+  vpc_id     = "${local.vpc_id}"
+  subnets    = ["${local.private_subnets}"]
+
+  dlq_alarm_arn = "${local.dlq_alarm_arn}"
+
+  # Transformer config
+  #
+  # If this pipeline is meant to be reindexed, remember to uncomment the
+  # reindexer topic names.
+
+  sierra_adapter_topic_names = [
+    "${local.sierra_reindexer_topic_name}",
+    "${local.sierra_merged_bibs_topic_name}",
+
+    "${local.sierra_merged_items_topic_name}",
+  ]
+  miro_adapter_topic_names = [
+    "${local.miro_reindexer_topic_name}",
+    "${local.miro_updates_topic_name}",
+  ]
+  # Elasticsearch
+  es_works_index = "v2-2019-04-26-contributors-label-from-multiple-subfields"
+  # RDS
+  rds_ids_access_security_group_id = "${local.rds_access_security_group_id}"
+  # Adapter VHS
+  vhs_sierra_read_policy = "${local.vhs_sierra_read_policy}"
+  vhs_miro_read_policy   = "${local.vhs_miro_read_policy}"
+
+  es_host_parameter_name = "catalogue/api/es_host_v7"
+}

--- a/pipeline/terraform/stack/service_ingestor.tf
+++ b/pipeline/terraform/stack/service_ingestor.tf
@@ -46,7 +46,7 @@ module "ingestor" {
   env_vars_length = 4
 
   secret_env_vars = {
-    es_host     = "catalogue/ingestor/es_host"
+    es_host     = "${var.es_host_parameter_name}"
     es_port     = "catalogue/ingestor/es_port"
     es_username = "catalogue/ingestor/es_username"
     es_password = "catalogue/ingestor/es_password"

--- a/pipeline/terraform/stack/variables.tf
+++ b/pipeline/terraform/stack/variables.tf
@@ -27,3 +27,7 @@ variable "sierra_adapter_topic_names" {
 
 variable "vhs_miro_read_policy" {}
 variable "vhs_sierra_read_policy" {}
+
+variable "es_host_parameter_name" {
+  default = "catalogue/ingestor/es_host"
+}


### PR DESCRIPTION
- Creates new stack pointing to ES7 deployment
- Points `api.` to remus i.e. ES7


## Next 
- Let this run for a bit and then remove all ES6 stuff