### PR TITLE
remove es6 from pipeline and API

### DIFF
--- a/api/terraform/catalogue_api/services/remus.tf
+++ b/api/terraform/catalogue_api/services/remus.tf
@@ -28,6 +28,4 @@ module "remus" {
   listener_port = "${var.remus_listener_port}"
 
   task_desired_count = "${var.remus_task_number}"
-
-  es_host_parameter_name = "catalogue/api/es_host_v7"
 }

--- a/api/terraform/catalogue_api/services/service/main.tf
+++ b/api/terraform/catalogue_api/services/service/main.tf
@@ -59,7 +59,7 @@ module "task" {
   sidecar_env_vars_length = 2
 
   secret_app_env_vars = {
-    es_host     = "${var.es_host_parameter_name}"
+    es_host     = "catalogue/api/es_host"
     es_port     = "catalogue/api/es_port"
     es_protocol = "catalogue/api/es_protocol"
     es_username = "catalogue/api/es_username"

--- a/api/terraform/catalogue_api/services/service/variables.tf
+++ b/api/terraform/catalogue_api/services/service/variables.tf
@@ -29,7 +29,3 @@ variable "lb_arn" {}
 variable "listener_port" {}
 
 variable "task_desired_count" {}
-
-variable "es_host_parameter_name" {
-  default = "catalogue/api/es_host"
-}

--- a/api/terraform/locals.tf
+++ b/api/terraform/locals.tf
@@ -10,8 +10,8 @@ locals {
 
   production_api     = "remus"
   pinned_nginx       = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_api-gw:bad0dbfa548874938d16496e313b05adb71268b7"
-  pinned_remus_api   = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/api:d1b4229f6e85c09dd7e5b0c94cffc898d11e23b9"
-  pinned_romulus_api = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/api:61fca4d91d338ed9de7ef44b388d9dd64bfb069b"
+  pinned_remus_api   = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/api:31d558140f900af7c996f2b7062471b823768f33main"
+  pinned_romulus_api = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/api:31d558140f900af7c996f2b7062471b823768f33"
   romulus_es_config = {
     index_v1 = "v1-2019-01-24-production-changes"
     index_v2 = "v2-2019-04-26-contributors-label-from-multiple-subfields"

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -1,47 +1,9 @@
-module "catalogue_pipeline_20190426" {
-  source = "stack"
-
-  namespace = "catalogue-20190426"
-
-  release_label = "prod"
-
-  account_id = "${data.aws_caller_identity.current.account_id}"
-  aws_region = "${local.aws_region}"
-  vpc_id     = "${local.vpc_id}"
-  subnets    = ["${local.private_subnets}"]
-
-  dlq_alarm_arn = "${local.dlq_alarm_arn}"
-
-  # Transformer config
-  #
-  # If this pipeline is meant to be reindexed, remember to uncomment the
-  # reindexer topic names.
-
-  sierra_adapter_topic_names = [
-    # "${local.sierra_reindexer_topic_name}",
-    "${local.sierra_merged_bibs_topic_name}",
-
-    "${local.sierra_merged_items_topic_name}",
-  ]
-  miro_adapter_topic_names = [
-    # "${local.miro_reindexer_topic_name}",
-    "${local.miro_updates_topic_name}",
-  ]
-  # Elasticsearch
-  es_works_index = "v2-2019-04-26-contributors-label-from-multiple-subfields"
-  # RDS
-  rds_ids_access_security_group_id = "${local.rds_access_security_group_id}"
-  # Adapter VHS
-  vhs_sierra_read_policy = "${local.vhs_sierra_read_policy}"
-  vhs_miro_read_policy   = "${local.vhs_miro_read_policy}"
-}
-
 module "catalogue_pipeline_20190723" {
   source = "stack"
 
   namespace = "catalogue-20190723"
 
-  release_label = "prod_es7"
+  release_label = "prod"
 
   account_id = "${data.aws_caller_identity.current.account_id}"
   aws_region = "${local.aws_region}"
@@ -72,6 +34,4 @@ module "catalogue_pipeline_20190723" {
   # Adapter VHS
   vhs_sierra_read_policy = "${local.vhs_sierra_read_policy}"
   vhs_miro_read_policy   = "${local.vhs_miro_read_policy}"
-
-  es_host_parameter_name = "catalogue/api/es_host_v7"
 }

--- a/pipeline/terraform/stack/service_ingestor.tf
+++ b/pipeline/terraform/stack/service_ingestor.tf
@@ -46,7 +46,7 @@ module "ingestor" {
   env_vars_length = 4
 
   secret_env_vars = {
-    es_host     = "${var.es_host_parameter_name}"
+    es_host     = "catalogue/ingestor/es_host"
     es_port     = "catalogue/ingestor/es_port"
     es_username = "catalogue/ingestor/es_username"
     es_password = "catalogue/ingestor/es_password"

--- a/pipeline/terraform/stack/variables.tf
+++ b/pipeline/terraform/stack/variables.tf
@@ -27,7 +27,3 @@ variable "sierra_adapter_topic_names" {
 
 variable "vhs_miro_read_policy" {}
 variable "vhs_sierra_read_policy" {}
-
-variable "es_host_parameter_name" {
-  default = "catalogue/ingestor/es_host"
-}


### PR DESCRIPTION
`api.` is now pointing to ES7. ✨ 
This removes references to ES6, and then we can delete the deployment.

https://api.wellcomecollection.org/catalogue/v2/works