### PR TITLE
Msmboost as default query

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -146,10 +146,7 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
     queryString: String,
     maybeQueryType: Option[String]): WorkQuery = {
     maybeQueryType.map(_.toLowerCase) match {
-      case Some("boost")    => BoostQuery(queryString)
-      case Some("msm")      => MSMQuery(queryString)
-      case Some("msmboost") => MSMBoostQuery(queryString)
-      case _                => SimpleQuery(queryString)
+      case _ => MSMBoostQuery(queryString)
     }
   }
 

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkQuery.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkQuery.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.platform.api.models
 
-import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.requests.searches.queries.{
   Query,
   SimpleStringQuery
@@ -26,32 +25,6 @@ object WorkQuery {
     ("description", Some(3.0)),
     ("contributors.*", Some(2.0))
   )
-
-  case class SimpleQuery(queryString: String) extends WorkQuery {
-    override def query(): SimpleStringQuery = {
-      simpleStringQuery(queryString)
-    }
-  }
-
-  case class MSMQuery(queryString: String) extends WorkQuery {
-    override def query(): SimpleStringQuery = {
-      SimpleStringQuery(
-        queryString,
-        fields = Seq(("*.*", Some(1.0))),
-        lenient = Some(true),
-        minimumShouldMatch = Some(defaultMSM))
-    }
-  }
-
-  case class BoostQuery(queryString: String) extends WorkQuery {
-    override def query(): SimpleStringQuery = {
-      SimpleStringQuery(
-        queryString,
-        fields = defaultBoostedFields,
-        lenient = Some(true)
-      )
-    }
-  }
 
   case class MSMBoostQuery(queryString: String) extends WorkQuery {
     override def query(): SimpleStringQuery = {

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/models/WorkQueryTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/models/WorkQueryTest.scala
@@ -8,26 +8,6 @@ import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.platform.api.models.WorkQuery._
 
 class WorkQueryTest extends FunSpec with ElasticsearchFixtures {
-  it("creates a SimpleQuery") {
-    assertQuery(
-      SimpleQuery("the query").query(),
-      """{"simple_query_string":{"query":"the query"}}""")
-  }
-
-  it("creates a BoostQuery") {
-    assertQuery(
-      BoostQuery("the query").query(),
-      """{"query":{"simple_query_string":{"lenient":"true","fields":["*.*","title^9.0","subjects.*^8.0","genres.label^8.0","description^3.0","contributors.*^2.0"],"query":"the query"}}}"""
-    )
-  }
-
-  it("creates a MSMQuery") {
-    assertQuery(
-      MSMQuery("the query").query(),
-      """{"query":{"simple_query_string":{"lenient":"true","minimum_should_match":"60%","fields":["*.*^1.0"],"query":"the query"}}}"""
-    )
-  }
-
   it("creates a MSMBoostQuery") {
     assertQuery(
       MSMBoostQuery("the query").query(),

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -590,7 +590,7 @@ class ElasticsearchServiceTest
   private def assertSearchResultsAreCorrect(
     index: Index,
     workQuery: WorkQuery,
-    queryOptions: ElasticsearchQueryOptions = createElasticsearchQueryOptions,
+    queryOptions: ElasticsearchQueryOptions,
     expectedWorks: List[IdentifiedWork]) = {
     searchResults(index, workQuery, queryOptions) should contain theSameElementsAs expectedWorks
   }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -44,21 +44,6 @@ class ElasticsearchServiceTest
     createElasticsearchQueryOptions
 
   describe("simpleStringQueryResults") {
-    it("finds results for a simpleStringQuery search") {
-      withLocalWorksIndex { index =>
-        val work1 = createIdentifiedWorkWith(title = "Amid an Aegean")
-        val work2 = createIdentifiedWorkWith(title = "Before a Bengal")
-        val work3 = createIdentifiedWorkWith(title = "Circling a Cheetah")
-
-        insertIntoElasticsearch(index, work1, work2, work3)
-
-        assertSearchResultsAreCorrect(
-          index = index,
-          workQuery = SimpleQuery("Aegean"),
-          expectedWorks = List(work1))
-      }
-    }
-
     it("filters search results by workType") {
       withLocalWorksIndex { index =>
         val workWithCorrectWorkType = createIdentifiedWorkWith(
@@ -82,7 +67,7 @@ class ElasticsearchServiceTest
 
         assertSearchResultsAreCorrect(
           index = index,
-          workQuery = SimpleQuery("artichokes"),
+          workQuery = MSMBoostQuery("artichokes"),
           queryOptions = createElasticsearchQueryOptionsWith(
             filters = List(WorkTypeFilter(workTypeId = "b"))
           ),
@@ -119,7 +104,7 @@ class ElasticsearchServiceTest
 
         assertSearchResultsAreCorrect(
           index = index,
-          workQuery = SimpleQuery("artichokes"),
+          workQuery = MSMBoostQuery("artichokes"),
           queryOptions = createElasticsearchQueryOptionsWith(
             filters = List(WorkTypeFilter(List("b", "m")))
           ),
@@ -149,7 +134,7 @@ class ElasticsearchServiceTest
 
         assertSearchResultsAreCorrect(
           index = index,
-          workQuery = SimpleQuery("tangerines"),
+          workQuery = MSMBoostQuery("tangerines"),
           queryOptions = createElasticsearchQueryOptionsWith(
             filters =
               List(ItemLocationTypeFilter(locationTypeId = "iiif-image"))
@@ -187,7 +172,7 @@ class ElasticsearchServiceTest
 
         assertSearchResultsAreCorrect(
           index = index,
-          workQuery = SimpleQuery("tangerines"),
+          workQuery = MSMBoostQuery("tangerines"),
           queryOptions = createElasticsearchQueryOptionsWith(
             filters = List(
               ItemLocationTypeFilter(
@@ -216,7 +201,7 @@ class ElasticsearchServiceTest
 
         (1 to 10).foreach { _ =>
           val searchResponseFuture = searchService
-            .queryResults(SimpleQuery("A"))(index, defaultQueryOptions)
+            .queryResults(MSMBoostQuery("A"))(index, defaultQueryOptions)
 
           whenReady(searchResponseFuture) { response =>
             searchResponseToWorks(response) shouldBe works
@@ -227,7 +212,7 @@ class ElasticsearchServiceTest
 
     it("returns a Left[ElasticError] if Elasticsearch returns an error") {
       val future = searchService
-        .queryResults(SimpleQuery("cat"))(
+        .queryResults(MSMBoostQuery("cat"))(
           Index("doesnotexist"),
           defaultQueryOptions)
 
@@ -241,78 +226,6 @@ class ElasticsearchServiceTest
   describe("searches using Selectable queries") {
     val noMatch =
       createIdentifiedWorkWith(title = "Before a Bengal")
-
-    it("finds results for a MSMQuery search") {
-      withLocalWorksIndex { index =>
-        val matching100 =
-          createIdentifiedWorkWith(title = "Title text contains Aegean")
-        val matching75 =
-          createIdentifiedWorkWith(title = "Title text contains")
-        val matching25 =
-          createIdentifiedWorkWith(title = "Title")
-
-        insertIntoElasticsearch(index, matching25, matching100, matching75)
-
-        val results = searchResults(
-          index = index,
-          workQuery = MSMQuery("Title text contains Aegean"))
-
-        results shouldBe List(matching100, matching75)
-      }
-    }
-
-    it("finds results for a BoostQuery search") {
-      withLocalWorksIndex { index =>
-        // Longer text used to ensure signal in TF/IDF
-        val text = "Text that contains Aegean"
-
-        val matchingTitle =
-          createIdentifiedWorkWith(title = s"$text title")
-        val exactMatchingTitle =
-          createIdentifiedWorkWith(title = s"Aegean title")
-        val matchingSubject =
-          createIdentifiedWorkWith(
-            subjects = List(createSubjectWith(s"$text subject")))
-        val matchingGenre =
-          createIdentifiedWorkWith(
-            genres = List(createGenreWith(s"$text genre")))
-        val matchingDescription =
-          createIdentifiedWorkWith(description = Some(s"$text description"))
-
-        insertIntoElasticsearch(
-          index,
-          matchingTitle,
-          noMatch,
-          matchingSubject,
-          exactMatchingTitle,
-          matchingGenre,
-          matchingDescription
-        )
-
-        val results =
-          searchResults(index = index, workQuery = BoostQuery("Aegean"))
-
-        withClue("Results size should be 5") { results should have length 5 }
-
-        withClue("(0) should be exact matching title") {
-          results.head shouldBe exactMatchingTitle
-        }
-
-        withClue("(1) should be matching title") {
-          results(1) shouldBe matchingTitle
-        }
-
-        withClue("(2, 3) should be the subject and genre matches") {
-          results.slice(2, 4) should contain theSameElementsAs List(
-            matchingSubject,
-            matchingGenre)
-        }
-
-        withClue("(4) should be matching description") {
-          results(4) shouldBe matchingDescription
-        }
-      }
-    }
 
     it("finds results for a MSMBoostQuery search") {
       withLocalWorksIndex { index =>

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -251,10 +251,11 @@ class WorksServiceTest
       val workEmu = createIdentifiedWorkWith(
         title = "An etching of an emu"
       )
-
+      
+      // unmatched quotes are a lexical error in the Elasticsearch parser
       assertSearchResultIsCorrect(
         query =
-          "emu \"unmatched quotes are a lexical error in the Elasticsearch parser"
+          "emu \""
       )(
         allWorks = List(workEmu),
         expectedWorks = List(workEmu),

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -5,23 +5,17 @@ import com.sksamuel.elastic4s.ElasticError
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
-import uk.ac.wellcome.models.work.generators.{
-  ProductionEventGenerators,
-  WorksGenerators
-}
+import uk.ac.wellcome.models.work.generators.{ProductionEventGenerators, WorksGenerators}
 import uk.ac.wellcome.models.work.internal.{IdentifiedBaseWork, WorkType}
 import uk.ac.wellcome.platform.api.generators.SearchOptionsGenerators
-import uk.ac.wellcome.platform.api.models.WorkQuery.SimpleQuery
-import uk.ac.wellcome.platform.api.models.{
-  DateRangeFilter,
-  ResultList,
-  WorkTypeFilter
-}
+import uk.ac.wellcome.platform.api.models.{DateRangeFilter, ResultList, WorkTypeFilter}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
+
+import uk.ac.wellcome.platform.api.models.WorkQuery.MSMBoostQuery
 
 class WorksServiceTest
     extends FunSpec
@@ -326,7 +320,7 @@ class WorksServiceTest
 
     it("returns a Left[ElasticError] if there's an Elasticsearch error") {
       val future = worksService.searchWorks(
-        workQuery = SimpleQuery("cat")
+        workQuery = MSMBoostQuery("cat")
       )(
         index = Index("doesnotexist"),
         worksSearchOptions = defaultWorksSearchOptions
@@ -356,7 +350,7 @@ class WorksServiceTest
     worksSearchOptions: WorksSearchOptions = createWorksSearchOptions
   ): Assertion =
     assertResultIsCorrect(
-      worksService.searchWorks(SimpleQuery(query))
+      worksService.searchWorks(MSMBoostQuery(query))
     )(allWorks, expectedWorks, expectedTotalResults, worksSearchOptions)
 
   private def assertResultIsCorrect(

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -258,11 +258,10 @@ class WorksServiceTest
       val workEmu = createIdentifiedWorkWith(
         title = "An etching of an emu"
       )
-      
+
       // unmatched quotes are a lexical error in the Elasticsearch parser
       assertSearchResultIsCorrect(
-        query =
-          "emu \""
+        query = "emu \""
       )(
         allWorks = List(workEmu),
         expectedWorks = List(workEmu),


### PR DESCRIPTION
Just sets MSMBoost as the only query.

When reimplementing some new ones I will pair with @harrisonpim to make sure it's done in a way that is easier (or leave the same).