### PR TITLE
Edition field from Marc 250

### DIFF
--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
@@ -170,6 +170,7 @@ object WorksIndex {
       language,
       location("thumbnail"),
       textField("dimensions"),
+      textField("edition"),
       objectField("redirect")
         .fields(sourceIdentifier, keywordField("canonicalId")),
       keywordField("type"),

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -31,6 +31,7 @@ sealed trait Work extends BaseWork with MultipleSourceIdentifiers {
   val production: List[ProductionEvent[IdentityState[AbstractAgent]]]
   val language: Option[Language]
   val dimensions: Option[String]
+  val edition: Option[String]
 
   val items: List[IdentityState[Item]]
   val itemsV1: List[IdentityState[Item]]
@@ -60,6 +61,7 @@ case class UnidentifiedWork(
   production: List[ProductionEvent[MaybeDisplayable[AbstractAgent]]],
   language: Option[Language],
   dimensions: Option[String],
+  edition: Option[String],
   items: List[MaybeDisplayable[Item]],
   itemsV1: List[Identifiable[Item]],
   version: Int,
@@ -89,6 +91,7 @@ case class IdentifiedWork(
   production: List[ProductionEvent[Displayable[AbstractAgent]]],
   language: Option[Language],
   dimensions: Option[String],
+  edition: Option[String],
   items: List[Displayable[Item]],
   itemsV1: List[Identified[Item]],
   version: Int,

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
@@ -104,6 +104,7 @@ trait WorksGenerators extends ItemsGenerators with ProductionEventGenerators {
       production = production,
       language = None,
       dimensions = None,
+      edition = None,
       items = items,
       itemsV1 = itemsV1,
       version = version
@@ -159,6 +160,7 @@ trait WorksGenerators extends ItemsGenerators with ProductionEventGenerators {
       production = production,
       language = language,
       dimensions = None,
+      edition = None,
       items = items,
       itemsV1 = itemsV1,
       version = version,

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroRecordTransformer.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroRecordTransformer.scala
@@ -86,6 +86,7 @@ class MiroRecordTransformer
         production = List(),
         language = None,
         dimensions = None,
+        edition = None,
         items = getItems(miroRecord),
         itemsV1 = getItemsV1(miroRecord),
         version = version

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
@@ -36,6 +36,7 @@ class SierraTransformableTransformer
     with SierraLocation
     with SierraProduction
     with SierraDimensions
+    with SierraEdition
     with SierraGenres
     with SierraMergeCandidates
     with SierraSubjects {
@@ -96,7 +97,7 @@ class SierraTransformableTransformer
                 production = getProduction(bibId, sierraBibData),
                 language = getLanguage(sierraBibData),
                 dimensions = getDimensions(sierraBibData),
-                edition = None,
+                edition = getEdition(sierraBibData),
                 items = getItems(
                   bibId = bibId,
                   bibData = sierraBibData,

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
@@ -96,6 +96,7 @@ class SierraTransformableTransformer
                 production = getProduction(bibId, sierraBibData),
                 language = getLanguage(sierraBibData),
                 dimensions = getDimensions(sierraBibData),
+                edition = None,
                 items = getItems(
                   bibId = bibId,
                   bibData = sierraBibData,

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraEdition.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraEdition.scala
@@ -1,0 +1,11 @@
+package uk.ac.wellcome.platform.transformer.sierra.transformers
+
+import uk.ac.wellcome.platform.transformer.sierra.source.SierraBibData
+
+trait SierraEdition extends MarcUtils {
+
+  def getEdition(bibData: SierraBibData): Option[String] =
+    getMatchingVarFields(bibData, "250").flatMap {
+      getSubfieldContents(_, Some("a"))
+    }.headOption
+}

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraEdition.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraEdition.scala
@@ -4,8 +4,17 @@ import uk.ac.wellcome.platform.transformer.sierra.source.SierraBibData
 
 trait SierraEdition extends MarcUtils {
 
-  def getEdition(bibData: SierraBibData): Option[String] =
-    getMatchingVarFields(bibData, "250").flatMap {
+  // Populate work:edition
+  //
+  // Field 250 is used for this. In the very rare case where multiple 250 fields
+  // are found, they are concatenated into a single string
+  def getEdition(bibData: SierraBibData): Option[String] = {
+    val editions = getMatchingVarFields(bibData, "250").flatMap {
       getSubfieldContents(_, Some("a"))
-    }.headOption
+    }
+    editions match {
+      case Nil => None
+      case editions => Some(editions.mkString(" "))
+    }
+  }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraEdition.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraEdition.scala
@@ -13,7 +13,7 @@ trait SierraEdition extends MarcUtils {
       getSubfieldContents(_, Some("a"))
     }
     editions match {
-      case Nil => None
+      case Nil      => None
       case editions => Some(editions.mkString(" "))
     }
   }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraEditionTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraEditionTest.scala
@@ -1,0 +1,57 @@
+package uk.ac.wellcome.platform.transformer.sierra.transformers
+
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  MarcSubfield,
+  VarField
+}
+import uk.ac.wellcome.platform.transformer.sierra.generators.{
+  MarcGenerators,
+  SierraDataGenerators
+}
+
+class SierraEditionTest
+    extends FunSpec
+    with Matchers
+    with MarcGenerators
+    with SierraDataGenerators {
+
+  val edition = "1st edition"
+
+  val altEdition = "2nd edition"
+
+  it("should extract edition when there is 250 data") {
+    val varFields = createVarField(edition) :: Nil
+    getEdition(varFields) shouldBe Some(edition)
+  }
+
+  it("should not extract edition when there no 250") {
+    val varFields = createVarField(edition, tag = "251") :: Nil
+    getEdition(varFields) shouldBe None
+  }
+
+  it("should not extract edition when there no 'a' subfield in 250") {
+    val varFields = createVarField(edition, contentTag = "b") :: Nil
+    getEdition(varFields) shouldBe None
+  }
+
+  it("should use first varfields content when multiple 250s defined") {
+    val varFields = List(createVarField(edition), createVarField(altEdition))
+    getEdition(varFields) shouldBe Some(edition)
+  }
+
+  val transformer = new SierraEdition {}
+
+  private def getEdition(varFields: List[VarField]) =
+    transformer getEdition (createSierraBibDataWith(varFields = varFields))
+
+  private def createVarField(
+    content: String,
+    tag: String = "250",
+    contentTag: String = "a"
+  ) =
+    createVarFieldWith(
+      tag,
+      "1",
+      MarcSubfield(tag = contentTag, content = content) :: Nil)
+}

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraEditionTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraEditionTest.scala
@@ -16,9 +16,9 @@ class SierraEditionTest
     with MarcGenerators
     with SierraDataGenerators {
 
-  val edition = "1st edition"
+  val edition = "1st edition."
 
-  val altEdition = "2nd edition"
+  val altEdition = "2nd edition."
 
   it("should extract edition when there is 250 data") {
     val varFields = createVarField(edition) :: Nil
@@ -35,9 +35,9 @@ class SierraEditionTest
     getEdition(varFields) shouldBe None
   }
 
-  it("should use first varfields content when multiple 250s defined") {
+  it("should combine varfields contents when multiple 250s defined") {
     val varFields = List(createVarField(edition), createVarField(altEdition))
-    getEdition(varFields) shouldBe Some(edition)
+    getEdition(varFields) shouldBe Some("1st edition. 2nd edition.")
   }
 
   val transformer = new SierraEdition {}

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
@@ -432,6 +432,36 @@ class SierraTransformableTransformerTest
     work.alternativeTitles shouldBe List(alternativeTitle)
   }
 
+  it("includes the edition, if present") {
+    val id = createSierraBibNumber
+    val edition = "3rd edition"
+
+    val data =
+      s"""
+        | {
+        |   "id": "$id",
+        |   "title": "Title",
+        |   "varFields": [
+        |     {
+        |       "fieldTag": "a",
+        |       "marcTag": "250",
+        |       "ind1": " ",
+        |       "ind2": " ",
+        |       "subfields": [
+        |         {
+        |           "tag": "a",
+        |           "content": "$edition"
+        |         }
+        |       ]
+        |     }
+        |   ]
+        | }
+      """.stripMargin
+
+    val work = transformDataToUnidentifiedWork(id = id, data = data)
+    work.edition shouldBe Some(edition)
+  }
+
   it("uses the full Sierra system number as the source identifier") {
     val id = createSierraBibNumber
     val data = s"""{"id": "$id", "title": "A title"}"""


### PR DESCRIPTION
### Issue

https://github.com/wellcometrust/platform/issues/3588

~Waiting on #84 #94~

### Description

Adds a new `edition` field which is populated from marc 250. In the very rare case where multiple 250 fields are found, they are concatenated into a single string.