### PR TITLE
Include part number and part name from 245

### DIFF
--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
@@ -171,6 +171,8 @@ object WorksIndex {
       location("thumbnail"),
       textField("dimensions"),
       textField("edition"),
+      textField("partNumber"),
+      textField("partName"),
       objectField("redirect")
         .fields(sourceIdentifier, keywordField("canonicalId")),
       keywordField("type"),

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -32,6 +32,8 @@ sealed trait Work extends BaseWork with MultipleSourceIdentifiers {
   val language: Option[Language]
   val dimensions: Option[String]
   val edition: Option[String]
+  val partNumber: Option[String]
+  val partName: Option[String]
 
   val items: List[IdentityState[Item]]
   val itemsV1: List[IdentityState[Item]]
@@ -62,6 +64,8 @@ case class UnidentifiedWork(
   language: Option[Language],
   dimensions: Option[String],
   edition: Option[String],
+  partNumber: Option[String],
+  partName: Option[String],
   items: List[MaybeDisplayable[Item]],
   itemsV1: List[Identifiable[Item]],
   version: Int,
@@ -92,6 +96,8 @@ case class IdentifiedWork(
   language: Option[Language],
   dimensions: Option[String],
   edition: Option[String],
+  partNumber: Option[String],
+  partName: Option[String],
   items: List[Displayable[Item]],
   itemsV1: List[Identified[Item]],
   version: Int,

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
@@ -105,6 +105,8 @@ trait WorksGenerators extends ItemsGenerators with ProductionEventGenerators {
       language = None,
       dimensions = None,
       edition = None,
+      partNumber = None,
+      partName = None,
       items = items,
       itemsV1 = itemsV1,
       version = version
@@ -161,6 +163,8 @@ trait WorksGenerators extends ItemsGenerators with ProductionEventGenerators {
       language = language,
       dimensions = None,
       edition = None,
+      partNumber = None,
+      partName = None,
       items = items,
       itemsV1 = itemsV1,
       version = version,

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroRecordTransformer.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroRecordTransformer.scala
@@ -87,6 +87,8 @@ class MiroRecordTransformer
         language = None,
         dimensions = None,
         edition = None,
+        partNumber = None,
+        partName = None,
         items = getItems(miroRecord),
         itemsV1 = getItemsV1(miroRecord),
         version = version

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
@@ -37,6 +37,8 @@ class SierraTransformableTransformer
     with SierraProduction
     with SierraDimensions
     with SierraEdition
+    with SierraPartNumber
+    with SierraPartName
     with SierraGenres
     with SierraMergeCandidates
     with SierraSubjects {
@@ -100,6 +102,8 @@ class SierraTransformableTransformer
                 edition = getEdition(sierraBibData),
                 partNumber = None,
                 partName = None,
+                partNumber = getPartNumber(sierraBibData),
+                partName = getPartName(sierraBibData),
                 items = getItems(
                   bibId = bibId,
                   bibData = sierraBibData,

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
@@ -98,6 +98,8 @@ class SierraTransformableTransformer
                 language = getLanguage(sierraBibData),
                 dimensions = getDimensions(sierraBibData),
                 edition = getEdition(sierraBibData),
+                partNumber = None,
+                partName = None,
                 items = getItems(
                   bibId = bibId,
                   bibData = sierraBibData,

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPartName.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPartName.scala
@@ -1,0 +1,11 @@
+package uk.ac.wellcome.platform.transformer.sierra.transformers
+
+import uk.ac.wellcome.platform.transformer.sierra.source.SierraBibData
+
+trait SierraPartName extends MarcUtils {
+
+  def getPartName(bibData: SierraBibData): Option[String] =
+    getMatchingVarFields(bibData, "245").flatMap {
+      getSubfieldContents(_, Some("p"))
+    }.headOption
+}

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPartNumber.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPartNumber.scala
@@ -1,0 +1,11 @@
+package uk.ac.wellcome.platform.transformer.sierra.transformers
+
+import uk.ac.wellcome.platform.transformer.sierra.source.SierraBibData
+
+trait SierraPartNumber extends MarcUtils {
+
+  def getPartNumber(bibData: SierraBibData): Option[String] =
+    getMatchingVarFields(bibData, "245").flatMap {
+      getSubfieldContents(_, Some("n"))
+    }.headOption
+}

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPartNameTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPartNameTest.scala
@@ -36,8 +36,7 @@ class SierraPartNameTest
   val transformer = new SierraPartName {}
 
   private def getPartName(varFields: List[VarField]) =
-    transformer getPartName (createSierraBibDataWith(
-      varFields = varFields))
+    transformer getPartName (createSierraBibDataWith(varFields = varFields))
 
   private def createVarField(
     content: String,

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPartNameTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPartNameTest.scala
@@ -1,0 +1,51 @@
+package uk.ac.wellcome.platform.transformer.sierra.transformers
+
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  MarcSubfield,
+  VarField
+}
+import uk.ac.wellcome.platform.transformer.sierra.generators.{
+  MarcGenerators,
+  SierraDataGenerators
+}
+
+class SierraPartNameTest
+    extends FunSpec
+    with Matchers
+    with MarcGenerators
+    with SierraDataGenerators {
+
+  val partName = "Part Name"
+
+  it("should extract partName from 245") {
+    val varFields = List(createVarField(partName))
+    getPartName(varFields) shouldBe Some(partName)
+  }
+
+  it("should extract first partName from 245 when multiple defined") {
+    val varFields = List(createVarField(partName), createVarField("another"))
+    getPartName(varFields) shouldBe Some(partName)
+  }
+
+  it("should not extract partName from 245 when incorrect contentTag") {
+    val varFields = List(createVarField(partName, contentTag = "n"))
+    getPartName(varFields) shouldBe None
+  }
+
+  val transformer = new SierraPartName {}
+
+  private def getPartName(varFields: List[VarField]) =
+    transformer getPartName (createSierraBibDataWith(
+      varFields = varFields))
+
+  private def createVarField(
+    content: String,
+    tag: String = "245",
+    contentTag: String = "p"
+  ) =
+    createVarFieldWith(
+      tag,
+      "1",
+      MarcSubfield(tag = contentTag, content = content) :: Nil)
+}

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPartNumberTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPartNumberTest.scala
@@ -36,8 +36,7 @@ class SierraPartNumberTest
   val transformer = new SierraPartNumber {}
 
   private def getPartNumber(varFields: List[VarField]) =
-    transformer getPartNumber (createSierraBibDataWith(
-      varFields = varFields))
+    transformer getPartNumber (createSierraBibDataWith(varFields = varFields))
 
   private def createVarField(
     content: String,

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPartNumberTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPartNumberTest.scala
@@ -1,0 +1,51 @@
+package uk.ac.wellcome.platform.transformer.sierra.transformers
+
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  MarcSubfield,
+  VarField
+}
+import uk.ac.wellcome.platform.transformer.sierra.generators.{
+  MarcGenerators,
+  SierraDataGenerators
+}
+
+class SierraPartNumberTest
+    extends FunSpec
+    with Matchers
+    with MarcGenerators
+    with SierraDataGenerators {
+
+  val partNumber = "Part Number"
+
+  it("should extract partNumber from 245") {
+    val varFields = List(createVarField(partNumber))
+    getPartNumber(varFields) shouldBe Some(partNumber)
+  }
+
+  it("should extract first partNumber from 245 when multiple defined") {
+    val varFields = List(createVarField(partNumber), createVarField("another"))
+    getPartNumber(varFields) shouldBe Some(partNumber)
+  }
+
+  it("should not extract partNumber from 245 when incorrect contentTag") {
+    val varFields = List(createVarField(partNumber, contentTag = "a"))
+    getPartNumber(varFields) shouldBe None
+  }
+
+  val transformer = new SierraPartNumber {}
+
+  private def getPartNumber(varFields: List[VarField]) =
+    transformer getPartNumber (createSierraBibDataWith(
+      varFields = varFields))
+
+  private def createVarField(
+    content: String,
+    tag: String = "245",
+    contentTag: String = "n"
+  ) =
+    createVarFieldWith(
+      tag,
+      "1",
+      MarcSubfield(tag = contentTag, content = content) :: Nil)
+}

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
@@ -462,6 +462,42 @@ class SierraTransformableTransformerTest
     work.edition shouldBe Some(edition)
   }
 
+  it("includes the part number and part name if present") {
+    val id = createSierraBibNumber
+    val partNumber = "Part Number"
+    val partName = "Part Name"
+
+    val data =
+      s"""
+        | {
+        |   "id": "$id",
+        |   "title": "Title",
+        |   "varFields": [
+        |     {
+        |       "fieldTag": "a",
+        |       "marcTag": "250",
+        |       "ind1": " ",
+        |       "ind2": " ",
+        |       "subfields": [
+        |         {
+        |           "tag": "n",
+        |           "content": "$partNumber"
+        |         },
+        |         {
+        |           "tag": "p",
+        |           "content": "$partName"
+        |         }
+        |       ]
+        |     }
+        |   ]
+        | }
+      """.stripMargin
+
+    val work = transformDataToUnidentifiedWork(id = id, data = data)
+    work.partNumber shouldBe Some(partNumber)
+    work.partName shouldBe Some(partName)
+  }
+
   it("uses the full Sierra system number as the source identifier") {
     val id = createSierraBibNumber
     val data = s"""{"id": "$id", "title": "A title"}"""


### PR DESCRIPTION
### Issue

https://github.com/wellcometrust/platform/issues/3587

### Description

Here we add `partNumber` and `partName` fields to the work model and extract them from Marc field 245 if they are present.