### PR TITLE
[WIP] Log results of transformers

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
@@ -34,7 +34,6 @@ class SierraTransformableTransformer
     with SierraTitle
     with SierraAlternativeTitles
     with SierraLocation
-    with SierraProduction
     with SierraDimensions
     with SierraEdition
     with SierraGenres
@@ -94,7 +93,7 @@ class SierraTransformableTransformer
                 genres = getGenres(sierraBibData),
                 contributors = getContributors(sierraBibData),
                 thumbnail = None,
-                production = getProduction(bibId, sierraBibData),
+                production = SierraProduction(bibId, sierraBibData),
                 language = getLanguage(sierraBibData),
                 dimensions = getDimensions(sierraBibData),
                 edition = getEdition(sierraBibData),

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
@@ -15,16 +15,20 @@ trait SierraTransformer extends Logging {
 
   type TransformInfo <: Info
 
-  lazy val transformerName = this.getClass.getSimpleName.dropRight(1)
-
-  def apply(bibId: SierraBibNumber, bibData: SierraBibData): Output = {
-    val (output, transformInfo) = transform(bibId, bibData)
-    info(
+  case class Log(bibId: SierraBibNumber, transformerName: String, transformInfo: TransformInfo, output: Output) {
+    override def toString: String =
       "DATA TRANSFORMED: " +
         s"BibID=${bibId}, " +
         s"Transformer=${transformerName}, " +
         s"Info=${transformInfo.info}, " +
-        s"Output=${output}")
+        s"Output=${output}"
+  }
+
+  lazy val transformerName = this.getClass.getSimpleName.dropRight(1)
+
+  def apply(bibId: SierraBibNumber, bibData: SierraBibData): Output = {
+    val (output, transformInfo) = transform(bibId, bibData)
+    info(Log(bibId, transformerName, transformInfo, output))
     output
   }
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
@@ -5,17 +5,28 @@ import grizzled.slf4j.Logging
 import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 import uk.ac.wellcome.platform.transformer.sierra.source.SierraBibData
 
+trait Info {
+  def info: String
+}
+
 trait SierraTransformer extends Logging {
 
   type Output
 
+  type TransformInfo <: Info
+
   lazy val transformerName = this.getClass.getSimpleName.dropRight(1)
 
   def apply(bibId: SierraBibNumber, bibData: SierraBibData): Output = {
-    val output = transform(bibId, bibData)
-    info(s"DATA TRANSFORMED: BibID=${bibId}, Transformer=${transformerName}, Output=${output}")
+    val (output, transformInfo) = transform(bibId, bibData)
+    info(
+      "DATA TRANSFORMED: " +
+        s"BibID=${bibId}, " +
+        s"Transformer=${transformerName}, " +
+        s"Info=${transformInfo.info}, " +
+        s"Output=${output}")
     output
   }
 
-  def transform(bibId: SierraBibNumber, bibData: SierraBibData): Output
+  def transform(bibId: SierraBibNumber, bibData: SierraBibData): (Output, TransformInfo)
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
@@ -1,0 +1,21 @@
+package uk.ac.wellcome.platform.transformer.sierra
+
+import grizzled.slf4j.Logging
+
+import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
+import uk.ac.wellcome.platform.transformer.sierra.source.SierraBibData
+
+trait SierraTransformer extends Logging {
+
+  type Output
+
+  lazy val transformerName = this.getClass.getSimpleName.dropRight(1)
+
+  def apply(bibId: SierraBibNumber, bibData: SierraBibData): Output = {
+    val output = transform(bibId, bibData)
+    info(s"DATA TRANSFORMED: BibID=${bibId}, Transformer=${transformerName}, Output=${output}")
+    output
+  }
+
+  def transform(bibId: SierraBibNumber, bibData: SierraBibData): Output
+}

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraProduction.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraProduction.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers
 import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.sierra.exceptions.CataloguingException
+import uk.ac.wellcome.platform.transformer.sierra.SierraTransformer
 import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
   SierraBibData,
@@ -10,7 +11,9 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
 }
 import uk.ac.wellcome.models.parse.Marc008Parser
 
-trait SierraProduction extends MarcUtils {
+object SierraProduction extends SierraTransformer with MarcUtils {
+
+  type Output = List[ProductionEvent[MaybeDisplayable[AbstractAgent]]]
 
   // Populate wwork:production.
   //
@@ -29,8 +32,7 @@ trait SierraProduction extends MarcUtils {
   // but it would be a cataloguing error -- we should reject it, and flag it
   // to the librarians.
   //
-  def getProduction(bibId: SierraBibNumber, bibData: SierraBibData)
-    : List[ProductionEvent[MaybeDisplayable[AbstractAgent]]] = {
+  def transform(bibId: SierraBibNumber, bibData: SierraBibData): Output = {
 
     val maybeMarc260fields = getMatchingVarFields(bibData, "260")
     val maybeMarc264fields = getMatchingVarFields(bibData, "264")

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraProductionTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraProductionTest.scala
@@ -293,7 +293,7 @@ class SierraProductionTest
         val bibId = createSierraBibNumber
 
         val caught = intercept[CataloguingException] {
-          transformer.getProduction(bibId, bibData)
+          SierraProduction(bibId, bibData)
         }
 
         caught.getMessage should startWith("Problem in the Sierra data")
@@ -459,7 +459,7 @@ class SierraProductionTest
       val bibId = createSierraBibNumber
 
       val caught = intercept[CataloguingException] {
-        transformer.getProduction(bibId, bibData)
+        SierraProduction(bibId, bibData)
       }
 
       caught.getMessage should startWith("Problem in the Sierra data")
@@ -683,8 +683,6 @@ class SierraProductionTest
   private def transformToProduction(varFields: List[VarField])
     : List[ProductionEvent[MaybeDisplayable[AbstractAgent]]] = {
     val bibData = createSierraBibDataWith(varFields = varFields)
-    transformer.getProduction(bibId = createSierraBibNumber, bibData)
+    SierraProduction(bibId = createSierraBibNumber, bibData)
   }
-
-  val transformer = new SierraProduction {}
 }


### PR DESCRIPTION
### Issue

https://github.com/wellcometrust/platform/issues/3784

### Description

This PR adds logging so it is possible to see the results of the transformer. For relevant fields it adds logging output, as displayed below.

*This is still a work in progress, and may need some discussion.*

### Example log output

The following has been split across multiple lines to make it easier to read:

```
14:53:48.463 [pool-77-thread-10-ScalaTest-running-SierraProductionTest] INFO  u.a.w.p.t.s.t.SierraProduction$ -
DATA TRANSFORMED:
BibID=6988525
Transformer=SierraProduction
Info=Production events extracted from field 260 (dates not extractable, used 008 for dates), 
Output=List(ProductionEvent(London,List(Place(London)),List(),List(Period(1757,Some(InstantRange(1757-01-01T00:00:00Z,1757-12-31T23:59:59.999999999Z,1757,false)))),None,ProductionEvent))
```