### PR TITLE
add order to the logback XML

### DIFF
--- a/pipeline/id_minter/src/main/resources/logback.xml
+++ b/pipeline/id_minter/src/main/resources/logback.xml
@@ -5,11 +5,6 @@
     </encoder>
   </appender>
 
-  <root level="${log_level:-INFO}">
-    <appender-ref ref="STDOUT"/>
-    <appender-ref ref="LOGSTASH"/>
-  </root>
-
   <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashUdpSocketAppender">
     <layout class="net.logstash.logback.layout.LogstashLayout">
       <customFields>
@@ -20,6 +15,11 @@
     <host>${logstash_host}</host>
     <port>514</port>
   </appender>
+
+  <root level="${log_level:-INFO}">
+    <appender-ref ref="STDOUT"/>
+    <appender-ref ref="LOGSTASH"/>
+  </root>
 
   <!-- reduce external logging -->
   <logger name="org.apache.http" level="ERROR"/>

--- a/pipeline/ingestor/src/main/resources/logback.xml
+++ b/pipeline/ingestor/src/main/resources/logback.xml
@@ -5,11 +5,6 @@
     </encoder>
   </appender>
 
-  <root level="${log_level:-INFO}">
-    <appender-ref ref="STDOUT"/>
-    <appender-ref ref="LOGSTASH"/>
-  </root>
-
   <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashUdpSocketAppender">
     <layout class="net.logstash.logback.layout.LogstashLayout">
       <customFields>
@@ -20,6 +15,11 @@
     <host>${logstash_host}</host>
     <port>514</port>
   </appender>
+
+  <root level="${log_level:-INFO}">
+    <appender-ref ref="STDOUT"/>
+    <appender-ref ref="LOGSTASH"/>
+  </root>
 
   <!-- reduce external logging -->
   <logger name="org.apache.http" level="ERROR"/>

--- a/pipeline/matcher/src/main/resources/logback.xml
+++ b/pipeline/matcher/src/main/resources/logback.xml
@@ -5,11 +5,6 @@
     </encoder>
   </appender>
 
-  <root level="${log_level:-INFO}">
-    <appender-ref ref="STDOUT"/>
-    <appender-ref ref="LOGSTASH"/>
-  </root>
-
   <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashUdpSocketAppender">
     <layout class="net.logstash.logback.layout.LogstashLayout">
       <customFields>
@@ -20,6 +15,11 @@
     <host>${logstash_host}</host>
     <port>514</port>
   </appender>
+
+  <root level="${log_level:-INFO}">
+    <appender-ref ref="STDOUT"/>
+    <appender-ref ref="LOGSTASH"/>
+  </root>
 
   <!-- reduce external logging -->
   <logger name="org.apache.http" level="ERROR"/>

--- a/pipeline/merger/src/main/resources/logback.xml
+++ b/pipeline/merger/src/main/resources/logback.xml
@@ -5,11 +5,6 @@
     </encoder>
   </appender>
 
-  <root level="${log_level:-INFO}">
-    <appender-ref ref="STDOUT"/>
-    <appender-ref ref="LOGSTASH"/>
-  </root>
-
   <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashUdpSocketAppender">
     <layout class="net.logstash.logback.layout.LogstashLayout">
       <customFields>
@@ -20,6 +15,11 @@
     <host>${logstash_host}</host>
     <port>514</port>
   </appender>
+
+  <root level="${log_level:-INFO}">
+    <appender-ref ref="STDOUT"/>
+    <appender-ref ref="LOGSTASH"/>
+  </root>
 
   <!-- reduce external logging -->
   <logger name="org.apache.http" level="ERROR"/>

--- a/pipeline/recorder/src/main/resources/logback.xml
+++ b/pipeline/recorder/src/main/resources/logback.xml
@@ -5,11 +5,6 @@
     </encoder>
   </appender>
 
-  <root level="${log_level:-INFO}">
-    <appender-ref ref="STDOUT"/>
-    <appender-ref ref="LOGSTASH"/>
-  </root>
-
   <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashUdpSocketAppender">
     <layout class="net.logstash.logback.layout.LogstashLayout">
       <customFields>
@@ -20,6 +15,11 @@
     <host>${logstash_host}</host>
     <port>514</port>
   </appender>
+
+  <root level="${log_level:-INFO}">
+    <appender-ref ref="STDOUT"/>
+    <appender-ref ref="LOGSTASH"/>
+  </root>
 
   <!-- reduce external logging -->
   <logger name="org.apache.http" level="ERROR"/>

--- a/pipeline/transformer/transformer_miro/src/main/resources/logback.xml
+++ b/pipeline/transformer/transformer_miro/src/main/resources/logback.xml
@@ -5,11 +5,6 @@
     </encoder>
   </appender>
 
-  <root level="${log_level:-INFO}">
-    <appender-ref ref="STDOUT"/>
-    <appender-ref ref="LOGSTASH"/>
-  </root>
-
   <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashUdpSocketAppender">
     <layout class="net.logstash.logback.layout.LogstashLayout">
       <customFields>
@@ -20,6 +15,11 @@
     <host>${logstash_host}</host>
     <port>514</port>
   </appender>
+
+  <root level="${log_level:-INFO}">
+    <appender-ref ref="STDOUT"/>
+    <appender-ref ref="LOGSTASH"/>
+  </root>
 
   <!-- reduce external logging -->
   <logger name="org.apache.http" level="ERROR"/>

--- a/pipeline/transformer/transformer_sierra/src/main/resources/logback.xml
+++ b/pipeline/transformer/transformer_sierra/src/main/resources/logback.xml
@@ -5,11 +5,6 @@
     </encoder>
   </appender>
 
-  <root level="${log_level:-INFO}">
-    <appender-ref ref="STDOUT"/>
-    <appender-ref ref="LOGSTASH"/>
-  </root>
-
   <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashUdpSocketAppender">
     <layout class="net.logstash.logback.layout.LogstashLayout">
       <customFields>
@@ -20,6 +15,11 @@
     <host>${logstash_host}</host>
     <port>514</port>
   </appender>
+
+  <root level="${log_level:-INFO}">
+    <appender-ref ref="STDOUT"/>
+    <appender-ref ref="LOGSTASH"/>
+  </root>
 
   <!-- reduce external logging -->
   <logger name="org.apache.http" level="ERROR"/>


### PR DESCRIPTION
Who would have thought:
`Could not find an appender named [LOGSTASH]. Did you define it below instead of above in the configuration file?`

