### PR TITLE
Correct the env vars length in the ingestor and recorder

### DIFF
--- a/pipeline/terraform/stack/service_ingestor.tf
+++ b/pipeline/terraform/stack/service_ingestor.tf
@@ -45,7 +45,7 @@ module "ingestor" {
     ingest_queue_id   = "${module.ingestor_queue.url}"
   }
 
-  env_vars_length = 4
+  env_vars_length = 3
 
   secret_env_vars = {
     es_host     = "catalogue/ingestor/es_host"

--- a/pipeline/terraform/stack/service_recorder.tf
+++ b/pipeline/terraform/stack/service_recorder.tf
@@ -50,7 +50,7 @@ module "recorder" {
     sns_topic = "${module.recorder_topic.arn}"
   }
 
-  env_vars_length = 6
+  env_vars_length = 5
 
   secret_env_vars = {}
 


### PR DESCRIPTION
I suspect this is why Terraform wants to keep rebuilding them – it’s looking for a 4th/6th env var that never comes.

Possible fix for https://github.com/wellcometrust/platform/issues/3811?