### PR TITLE
add logging to when a case class can't be deserialised

### DIFF
--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageStream.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/messaging/message/MessageStream.scala
@@ -25,7 +25,8 @@ class MessageStream[T](sqsClient: AmazonSQSAsync,
   actorSystem: ActorSystem,
   decoderT: Decoder[T],
   objectStoreT: ObjectStore[T],
-  ec: ExecutionContext) extends Logging {
+  ec: ExecutionContext)
+    extends Logging {
 
   private val bigMessageReader = new BigMessageReader[T] {
     override val objectStore: ObjectStore[T] = objectStoreT


### PR DESCRIPTION
Thoughts on this might give us clarity?
Points out we need to think of the different states of the `BigMessaging` lib