### PR TITLE
Fix conversion of maxConnections config variable to Int

### DIFF
--- a/pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/config/builders/RDSBuilder.scala
+++ b/pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/config/builders/RDSBuilder.scala
@@ -42,20 +42,24 @@ object RDSBuilder {
     )
   }
 
-  def intFromConfig(config: Config, path: String, default: Option[Int] = None): Int =
+  def intFromConfig(config: Config,
+                    path: String,
+                    default: Option[Int] = None): Int =
     Try(config.getAnyRef(path))
       .map {
         _ match {
           case value: String  => value.toInt
           case value: Integer => value.asInstanceOf[Int]
-          case obj => throw new RuntimeException(
-            s"$path is invalid type: got $obj (type ${obj.getClass}), expected Int")
+          case obj =>
+            throw new RuntimeException(
+              s"$path is invalid type: got $obj (type ${obj.getClass}), expected Int")
         }
       }
       .recover {
-        case exc: ConfigException.Missing => default getOrElse {
-          throw new RuntimeException(s"${path} not defined in Config")
-        }
+        case exc: ConfigException.Missing =>
+          default getOrElse {
+            throw new RuntimeException(s"${path} not defined in Config")
+          }
       }
       .get
 }


### PR DESCRIPTION
# Issue

https://github.com/wellcometrust/platform/issues/3824

# Description

This is currently broken when it comes from an environment variable:

```
Exception in thread "main" java.lang.ClassCastException: class java.lang.String cannot be cast to class java.lang.Integer (java.lang.String and java.lang.Integer are in module java.base of loader 'bootstrap')
at scala.runtime.BoxesRunTime.unboxToInt(BoxesRunTime.java:103)
at uk.ac.wellcome.platform.idminter.config.builders.RDSBuilder$.buildDB(RDSBuilder.scala:10)
at uk.ac.wellcome.platform.idminter.Main$.$anonfun$new$1(Main.scala:34)
at uk.ac.wellcome.typesafe.WellcomeTypesafeApp.runWithConfig(WellcomeTypesafeApp.scala:8)
at uk.ac.wellcome.typesafe.WellcomeTypesafeApp.runWithConfig$(WellcomeTypesafeApp.scala:6)
at uk.ac.wellcome.platform.idminter.Main$.runWithConfig(Main.scala:21)
at uk.ac.wellcome.platform.idminter.Main$.delayedEndpoint$uk$ac$wellcome$platform$idminter$Main$1(Main.scala:22)
at uk.ac.wellcome.platform.idminter.Main$delayedInit$body.apply(Main.scala:21)
at scala.Function0.apply$mcV$sp(Function0.scala:39)
at scala.Function0.apply$mcV$sp$(Function0.scala:39)
at scala.runtime.AbstractFunction0.apply$mcV$sp(AbstractFunction0.scala:17)
at scala.App.$anonfun$main$1$adapted(App.scala:80)
at scala.collection.immutable.List.foreach(List.scala:392)
at scala.App.main(App.scala:80)
at scala.App.main$(App.scala:78)
at uk.ac.wellcome.platform.idminter.Main$.main(Main.scala:21)
at uk.ac.wellcome.platform.idminter.Main.main(Main.scala)
```