### PR TITLE
Fix remove work script setup.py

### DIFF
--- a/scripts/remove_work/setup.py
+++ b/scripts/remove_work/setup.py
@@ -1,4 +1,4 @@
-from setuptools import find_packages, setup
+from setuptools import setup
 
 setup(
     name="Wellcome Collection catalogue scripts: remove_work",


### PR DESCRIPTION
Travis is currently failing as this has an unused import:

```
./scripts/remove_work/setup.py:1:1: F401 'setuptools.find_packages' imported but unused
make[1]: *** [lint-python] Error 1
make[1]: Leaving directory `/home/travis/build/wellcometrust/catalogue'
Command '['make', 'lint']' returned non-zero exit status 2
make: *** [travis-format] Error 2
Command '['make', 'travis-format']' returned non-zero exit status 2
/home/travis/.travis/functions: line 524:  3938 Terminated              travis_jigger "${!}" "${timeout}" "${cmd[@]}"
The command "travis_wait 45 ./.travis/run_job.py" exited with 2.
```