### PR TITLE
put bigmessaging in it's own package

### DIFF
--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/BigMessageReader.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/BigMessageReader.scala
@@ -1,11 +1,15 @@
-package uk.ac.wellcome.messaging
+package uk.ac.wellcome.bigmessaging
 
 import grizzled.slf4j.Logging
 import io.circe.Decoder
-import uk.ac.wellcome.json.JsonUtil.fromJson
-import uk.ac.wellcome.messaging.message.{
+import uk.ac.wellcome.bigmessaging.message.{
   InlineNotification,
   MessageNotification,
+  RemoteNotification
+}
+import uk.ac.wellcome.json.JsonUtil.fromJson
+import uk.ac.wellcome.bigmessaging.message.{
+  InlineNotification,
   RemoteNotification
 }
 import uk.ac.wellcome.storage.ObjectStore

--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/BigMessageSender.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/BigMessageSender.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.messaging
+package uk.ac.wellcome.bigmessaging
 
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -6,11 +6,8 @@ import java.util.Date
 import grizzled.slf4j.Logging
 import io.circe.Encoder
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.message.{
-  InlineNotification,
-  MessageNotification,
-  RemoteNotification
-}
+import uk.ac.wellcome.messaging.MessageSender
+import uk.ac.wellcome.bigmessaging.message.{InlineNotification, MessageNotification, RemoteNotification}
 import uk.ac.wellcome.storage.{KeyPrefix, ObjectStore}
 
 import scala.util.{Failure, Success, Try}

--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/BigMessageSender.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/BigMessageSender.scala
@@ -7,7 +7,11 @@ import grizzled.slf4j.Logging
 import io.circe.Encoder
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.MessageSender
-import uk.ac.wellcome.bigmessaging.message.{InlineNotification, MessageNotification, RemoteNotification}
+import uk.ac.wellcome.bigmessaging.message.{
+  InlineNotification,
+  MessageNotification,
+  RemoteNotification
+}
 import uk.ac.wellcome.storage.{KeyPrefix, ObjectStore}
 
 import scala.util.{Failure, Success, Try}

--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/memory/MemoryBigMessageSender.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/memory/MemoryBigMessageSender.scala
@@ -1,9 +1,10 @@
-package uk.ac.wellcome.messaging.memory
+package uk.ac.wellcome.bigmessaging.memory
 
 import io.circe.{Decoder, Encoder}
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.BigMessageSender
-import uk.ac.wellcome.messaging.message.InlineNotification
+import uk.ac.wellcome.bigmessaging.BigMessageSender
+import uk.ac.wellcome.messaging.memory.MemoryMessageSender
+import uk.ac.wellcome.bigmessaging.message.InlineNotification
 import uk.ac.wellcome.storage.ObjectStore
 import uk.ac.wellcome.storage.memory.MemoryObjectStore
 import uk.ac.wellcome.storage.streaming.Codec

--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/message/MessageNotification.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/message/MessageNotification.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.messaging.message
+package uk.ac.wellcome.bigmessaging.message
 
 import uk.ac.wellcome.storage.ObjectLocation
 

--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/message/MessageStream.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/message/MessageStream.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.messaging.message
+package uk.ac.wellcome.bigmessaging.message
 
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.Source
@@ -7,8 +7,8 @@ import com.amazonaws.services.cloudwatch.model.StandardUnit
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.amazonaws.services.sqs.model.Message
 import io.circe.Decoder
+import uk.ac.wellcome.bigmessaging.BigMessageReader
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.BigMessageReader
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.sqs.{SQSConfig, SQSStream}
 import uk.ac.wellcome.monitoring.Metrics

--- a/common/big_messaging/src/test/scala/uk/ac/wellcome/messaging/BigMessageIntegrationTest.scala
+++ b/common/big_messaging/src/test/scala/uk/ac/wellcome/messaging/BigMessageIntegrationTest.scala
@@ -2,9 +2,13 @@ package uk.ac.wellcome.messaging
 
 import io.circe.Decoder
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.bigmessaging.BigMessageReader
+import uk.ac.wellcome.bigmessaging.memory.MemoryBigMessageSender
+import uk.ac.wellcome.bigmessaging.message.{
+  InlineNotification,
+  RemoteNotification
+}
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.memory.MemoryBigMessageSender
-import uk.ac.wellcome.messaging.message.{InlineNotification, RemoteNotification}
 import uk.ac.wellcome.storage.ObjectStore
 import uk.ac.wellcome.storage.streaming.CodecInstances._
 

--- a/common/big_messaging/src/test/scala/uk/ac/wellcome/messaging/BigMessageReaderTest.scala
+++ b/common/big_messaging/src/test/scala/uk/ac/wellcome/messaging/BigMessageReaderTest.scala
@@ -2,9 +2,13 @@ package uk.ac.wellcome.messaging
 
 import io.circe.Decoder
 import org.scalatest.{EitherValues, FunSpec, Matchers}
+import uk.ac.wellcome.bigmessaging.BigMessageReader
+import uk.ac.wellcome.bigmessaging.message.{
+  InlineNotification,
+  RemoteNotification
+}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.json.exceptions.JsonDecodingError
-import uk.ac.wellcome.messaging.message.{InlineNotification, RemoteNotification}
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectStore}
 import uk.ac.wellcome.storage.memory.MemoryObjectStore
 import uk.ac.wellcome.storage.streaming.CodecInstances._

--- a/common/big_messaging/src/test/scala/uk/ac/wellcome/messaging/BigMessageSenderTest.scala
+++ b/common/big_messaging/src/test/scala/uk/ac/wellcome/messaging/BigMessageSenderTest.scala
@@ -2,16 +2,14 @@ package uk.ac.wellcome.messaging
 
 import io.circe.Encoder
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.memory.{
-  MemoryBigMessageSender,
-  MemoryMessageSender
-}
-import uk.ac.wellcome.messaging.message.{
+import uk.ac.wellcome.bigmessaging.memory.MemoryBigMessageSender
+import uk.ac.wellcome.bigmessaging.message.{
   InlineNotification,
   MessageNotification,
   RemoteNotification
 }
+import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.storage._
 import uk.ac.wellcome.storage.memory.MemoryObjectStore
 import uk.ac.wellcome.storage.streaming.CodecInstances._

--- a/common/big_messaging/src/test/scala/uk/ac/wellcome/messaging/fixtures/Messaging.scala
+++ b/common/big_messaging/src/test/scala/uk/ac/wellcome/messaging/fixtures/Messaging.scala
@@ -6,10 +6,10 @@ import com.amazonaws.services.sqs.model.SendMessageResult
 import io.circe.{Decoder, Encoder}
 import org.scalatest.Matchers
 import uk.ac.wellcome.akka.fixtures.Akka
+import uk.ac.wellcome.bigmessaging.message._
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
-import uk.ac.wellcome.messaging.message._
 import uk.ac.wellcome.monitoring.memory.MemoryMetrics
 import uk.ac.wellcome.storage.ObjectStore
 import uk.ac.wellcome.storage.fixtures.S3

--- a/common/big_messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageStreamTest.scala
+++ b/common/big_messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessageStreamTest.scala
@@ -6,6 +6,12 @@ import akka.stream.scaladsl.Flow
 import com.amazonaws.services.cloudwatch.model.StandardUnit
 import io.circe.Decoder
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.bigmessaging.message.{
+  InlineNotification,
+  MessageNotification,
+  MessageStream,
+  RemoteNotification
+}
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.Messaging

--- a/common/big_messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessagingIntegrationTest.scala
+++ b/common/big_messaging/src/test/scala/uk/ac/wellcome/messaging/message/MessagingIntegrationTest.scala
@@ -12,9 +12,11 @@ import com.amazonaws.services.sns.model.{
 import io.circe.Encoder
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.{Assertion, FunSpec, Matchers}
+import uk.ac.wellcome.bigmessaging.BigMessageSender
+import uk.ac.wellcome.bigmessaging.message.MessageStream
 import uk.ac.wellcome.fixtures.{fixture, Fixture, TestWith}
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.{BigMessageSender, MessageSender}
+import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.fixtures.Messaging
 import uk.ac.wellcome.messaging.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue

--- a/common/big_messaging_typesafe/src/main/scala/uk/ac/wellcome/bigmessaging/typesafe/BigMessagingBuilder.scala
+++ b/common/big_messaging_typesafe/src/main/scala/uk/ac/wellcome/bigmessaging/typesafe/BigMessagingBuilder.scala
@@ -1,12 +1,14 @@
-package uk.ac.wellcome.messaging.typesafe
+package uk.ac.wellcome.bigmessaging.typesafe
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.Config
 import io.circe.{Decoder, Encoder}
-import uk.ac.wellcome.messaging.message.MessageStream
+import uk.ac.wellcome.bigmessaging.BigMessageSender
+import uk.ac.wellcome.bigmessaging.message.MessageStream
 import uk.ac.wellcome.messaging.sns.SNSConfig
-import uk.ac.wellcome.messaging.{BigMessageSender, MessageSender}
+import uk.ac.wellcome.messaging.typesafe.{SNSBuilder, SQSBuilder}
+import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.monitoring.typesafe.MetricsBuilder
 import uk.ac.wellcome.storage.ObjectStore
 import uk.ac.wellcome.storage.s3.{S3Config, S3StorageBackend}

--- a/pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/Main.scala
+++ b/pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/Main.scala
@@ -5,7 +5,7 @@ import akka.stream.ActorMaterializer
 import com.typesafe.config.Config
 import uk.ac.wellcome.elasticsearch.typesafe.ElasticBuilder
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.typesafe.BigMessagingBuilder
+import uk.ac.wellcome.bigmessaging.typesafe.BigMessagingBuilder
 import uk.ac.wellcome.models.work.internal.IdentifiedBaseWork
 import uk.ac.wellcome.platform.ingestor.config.builders.IngestorConfigBuilder
 import uk.ac.wellcome.platform.ingestor.services.IngestorWorkerService

--- a/pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
+++ b/pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
@@ -5,7 +5,7 @@ import com.amazonaws.services.sqs.model.Message
 import com.sksamuel.elastic4s.ElasticClient
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.elasticsearch.{ElasticsearchIndexCreator, WorksIndex}
-import uk.ac.wellcome.messaging.message.MessageStream
+import uk.ac.wellcome.bigmessaging.message.MessageStream
 import uk.ac.wellcome.models.work.internal.IdentifiedBaseWork
 import uk.ac.wellcome.platform.ingestor.config.models.IngestorConfig
 import uk.ac.wellcome.typesafe.Runnable


### PR DESCRIPTION
To avoid confusion of the different libs.
Big messaging depends on new messaging / new storage.