### PR TITLE
Only use PHRASE simple syntax in query

### DIFF
--- a/api/api/docker-compose.yml
+++ b/api/api/docker-compose.yml
@@ -1,5 +1,5 @@
 elasticsearch:
-  image: "docker.elastic.co/elasticsearch/elasticsearch:7.2.0"
+  image: "docker.elastic.co/elasticsearch/elasticsearch:7.3.0"
   ports:
     - "9200:9200"
     - "9300:9300"

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkQuery.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkQuery.scala
@@ -34,6 +34,9 @@ object WorkQuery {
         fields = defaultBoostedFields,
         lenient = Some(true),
         minimumShouldMatch = Some(defaultMSM),
+        // PHRASE is the only syntax that researchers know and understand, so we use this exclusively
+        // so as not to have unexpected results returned when using simple query string syntax.
+        // See: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html#simple-query-string-syntax
         flags = Seq(SimpleQueryStringFlag.PHRASE)
       )
     }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkQuery.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkQuery.scala
@@ -2,6 +2,7 @@ package uk.ac.wellcome.platform.api.models
 
 import com.sksamuel.elastic4s.requests.searches.queries.{
   Query,
+  SimpleQueryStringFlag,
   SimpleStringQuery
 }
 
@@ -32,7 +33,8 @@ object WorkQuery {
         queryString,
         fields = defaultBoostedFields,
         lenient = Some(true),
-        minimumShouldMatch = Some(defaultMSM)
+        minimumShouldMatch = Some(defaultMSM),
+        flags = Seq(SimpleQueryStringFlag.PHRASE)
       )
     }
   }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/models/WorkQueryTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/models/WorkQueryTest.scala
@@ -11,7 +11,7 @@ class WorkQueryTest extends FunSpec with ElasticsearchFixtures {
   it("creates a MSMBoostQuery") {
     assertQuery(
       MSMBoostQuery("the query").query(),
-      """{"query":{"simple_query_string":{"lenient":"true","minimum_should_match":"60%","fields":["*.*","title^9.0","subjects.*^8.0","genres.label^8.0","description^3.0","contributors.*^2.0"],"query":"the query"}}}"""
+      """{"query":{"simple_query_string":{"lenient":"true","minimum_should_match":"60%","fields":["*.*","title^9.0","subjects.*^8.0","genres.label^8.0","description^3.0","contributors.*^2.0"],"flags":"PHRASE","query":"the query"}}}"""
     )
   }
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -305,9 +305,7 @@ class ElasticsearchServiceTest
             index = index,
             workQuery = MSMBoostQuery("Text that contains Aegean"))
 
-        results should have length 8
-
-        results.foreach(r => println(r.canonicalId))
+        results should have length 10
 
         withClue("(0, 1) should be title matches") {
           results.slice(0, 2) shouldBe List(matchingTitle100, matchingTitle75)
@@ -319,14 +317,19 @@ class ElasticsearchServiceTest
             matchingSubject100)
         }
 
-        withClue("(4,5) should be 75 genre / subject matches") {
-          results.slice(4, 6) should contain theSameElementsAs List(
+        withClue("(4) should be 25 title match matches") {
+          results.slice(4, 5) should contain theSameElementsAs List(
+            matchingTitle25)
+        }
+
+        withClue("(5, 6) should be 75 genre / subject matches") {
+          results.slice(5, 7) should contain theSameElementsAs List(
             matchingGenre75,
             matchingSubject75)
         }
 
-        withClue("(6, 7) should be 100 / 75 description matches") {
-          results.slice(6, 8) shouldBe List(
+        withClue("(7, 8) should be 100 / 75 description matches") {
+          results.slice(7, 9) shouldBe List(
             matchingDescription100,
             matchingDescription75)
         }
@@ -581,8 +584,6 @@ class ElasticsearchServiceTest
     val searchResponseFuture =
       searchService.queryResults(workQuery)(index, queryOptions)
     whenReady(searchResponseFuture) { response =>
-      response.right.map(r =>
-        r.hits.hits.foreach(h => println(s"${h.id}/${h.score}")))
       searchResponseToWorks(response)
     }
   }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -376,12 +376,12 @@ class WorksServiceTest
         )
 
         val workLooseTitle = createIdentifiedWorkWith(
-          title = "An loose match of a title"
+          title = "A loose match of a title"
         )
 
         // Should return both
         assertSearchResultIsCorrect(
-          query = "A exact match of a title"
+          query = "An exact match of a title"
         )(
           allWorks = List(workExactTitle, workLooseTitle),
           expectedWorks = List(workExactTitle, workLooseTitle),
@@ -390,7 +390,7 @@ class WorksServiceTest
 
         // Should return only the exact match
         assertSearchResultIsCorrect(
-          query = "\"A exact match of a title\""
+          query = "\"An exact match of a title\""
         )(
           allWorks = List(workExactTitle, workLooseTitle),
           expectedWorks = List(workExactTitle),

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -269,6 +269,49 @@ class WorksServiceTest
       )
     }
 
+    it("Should simple_query_syntax into account and not fail when it's invalid") {
+      val workEmu = createIdentifiedWorkWith(
+        title = "a b c"
+      )
+
+      // This would land up with a too_many_clauses error due to the precedence syntax
+      assertSearchResultIsCorrect(
+        query = "(a b c d e) h"
+      )(
+        allWorks = List(workEmu),
+        expectedWorks = List(workEmu),
+        expectedTotalResults = 1
+      )
+    }
+
+    it("Should work with simple_query_syntax PHRASE syntax (\"term\")") {
+      val workExactTitle = createIdentifiedWorkWith(
+        title = "An exact match of a title"
+      )
+
+      val workLooseTitle = createIdentifiedWorkWith(
+        title = "An loose match of a title"
+      )
+
+      // Should return both
+      assertSearchResultIsCorrect(
+        query = "A exact match of a title"
+      )(
+        allWorks = List(workExactTitle, workLooseTitle),
+        expectedWorks = List(workExactTitle, workLooseTitle),
+        expectedTotalResults = 2
+      )
+
+      // Should return only the exact match
+      assertSearchResultIsCorrect(
+        query = "\"A exact match of a title\""
+      )(
+        allWorks = List(workExactTitle, workLooseTitle),
+        expectedWorks = List(workExactTitle),
+        expectedTotalResults = 1
+      )
+    }
+
     it("filters searches by workType") {
       val matchingWork = createIdentifiedWorkWith(
         title = "Animated artichokes",

--- a/api/terraform/locals.tf
+++ b/api/terraform/locals.tf
@@ -10,7 +10,7 @@ locals {
 
   production_api     = "romulus"
   pinned_nginx       = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_api-gw:bad0dbfa548874938d16496e313b05adb71268b7"
-  pinned_remus_api   = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/api:31d558140f900af7c996f2b7062471b823768f33"
+  pinned_remus_api   = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/api:837a9a819942204aeb0a30d07f0a506b0a7ea633"
   pinned_romulus_api = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/api:27dd3d98c61b247c56842639f9b3b2b31e1463e1"
   romulus_es_config = {
     index_v1 = "v1-2019-01-24-production-changes"

--- a/common/elasticsearch/docker-compose.yml
+++ b/common/elasticsearch/docker-compose.yml
@@ -1,5 +1,5 @@
 elasticsearch:
-  image: "docker.elastic.co/elasticsearch/elasticsearch:7.2.0"
+  image: "docker.elastic.co/elasticsearch/elasticsearch:7.3.0"
   ports:
     - "9200:9200"
     - "9300:9300"

--- a/makefiles/functions.Makefile
+++ b/makefiles/functions.Makefile
@@ -1,6 +1,11 @@
 ROOT = $(shell git rev-parse --show-toplevel)
 INFRA_BUCKET = wellcomecollection-platform-infra
 
+ifneq ($(TRAVIS),true)
+DEV_ROLE_ARN := arn:aws:iam::760097843905:role/platform-developer
+endif
+
+
 
 include $(ROOT)/makefiles/terraform.Makefile
 
@@ -76,15 +81,15 @@ endef
 #
 define publish_service_ssm
 	$(ROOT)/docker_run.py \
-	    --aws --dind -- \
-	    wellcome/publish_service:55 \
-	    	--service_id="$(1)" \
-	        --project_id=$(2) \
-	        --account_id=$(3) \
-	        --region_id=eu-west-1 \
-	        --namespace=uk.ac.wellcome \
-	        --label=latest \
-
+    	    --aws --dind -- \
+    	    wellcome/publish_service:86 \
+    	    	--service_id="$(1)" \
+    	        --project_id=$(2) \
+    	        --account_id=$(3) \
+    	        --region_id=eu-west-1 \
+    	        --namespace=uk.ac.wellcome \
+    	        --role_arn="$(DEV_ROLE_ARN)" \
+    	        --label=latest
 endef
 
 

--- a/pipeline/ingestor/docker-compose.yml
+++ b/pipeline/ingestor/docker-compose.yml
@@ -3,7 +3,7 @@ sqs:
   ports:
     - "9324:9324"
 elasticsearch:
-  image: "docker.elastic.co/elasticsearch/elasticsearch:7.2.0"
+  image: "docker.elastic.co/elasticsearch/elasticsearch:7.3.0"
   ports:
     - "9200:9200"
     - "9300:9300"

--- a/snapshots/snapshot_generator/docker-compose.yml
+++ b/snapshots/snapshot_generator/docker-compose.yml
@@ -11,7 +11,7 @@ s3:
   ports:
     - "33333:8000"
 elasticsearch:
-  image: "docker.elastic.co/elasticsearch/elasticsearch:7.2.0"
+  image: "docker.elastic.co/elasticsearch/elasticsearch:7.3.0"
   ports:
     - "9200:9200"
     - "9300:9300"


### PR DESCRIPTION
The syntax uses a whole bunch of stuff researches might be looking for.
We also don't make this clear anywhere.

https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html#simple-query-string-syntax

We could do something like Kibana if we wanted to add special syntax.
![screenshot-8cf19dece3804980bc0ad36afe28c7f6 eu-west-1 aws found io_9243-2019 08 16-14_58_26](https://user-images.githubusercontent.com/31692/63172822-767a3c00-c036-11e9-9409-36506eaaa0bc.png)
