### PR TITLE
add new stack and index for alternativeTitles

### DIFF
--- a/api/terraform/locals.tf
+++ b/api/terraform/locals.tf
@@ -10,7 +10,7 @@ locals {
 
   production_api     = "romulus"
   pinned_nginx       = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_api-gw:bad0dbfa548874938d16496e313b05adb71268b7"
-  pinned_remus_api   = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/api:31d558140f900af7c996f2b7062471b823768f33"
+  pinned_remus_api   = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/api:837a9a819942204aeb0a30d07f0a506b0a7ea633"
   pinned_romulus_api = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/api:27dd3d98c61b247c56842639f9b3b2b31e1463e1"
   romulus_es_config = {
     index_v1 = "v1-2019-01-24-production-changes"
@@ -19,7 +19,7 @@ locals {
   }
   remus_es_config = {
     index_v1 = "v1-2019-01-24-production-changes"
-    index_v2 = "v2-2019-04-26-contributors-label-from-multiple-subfields"
+    index_v2 = "v2-20190816-alternative-titles"
     doc_type = "work"
   }
 

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -1,9 +1,9 @@
-module "catalogue_pipeline_20190808" {
+module "catalogue_pipeline_20190816" {
   source = "stack"
 
-  namespace = "catalogue-20190808"
+  namespace = "catalogue-20190816"
 
-  release_label = "prod"
+  release_label = "latest"
 
   account_id      = "${data.aws_caller_identity.current.account_id}"
   aws_region      = "${local.aws_region}"
@@ -19,20 +19,19 @@ module "catalogue_pipeline_20190808" {
   # reindexer topic names.
 
   sierra_adapter_topic_names = [
-    # "${local.sierra_reindexer_topic_name}",
+    "${local.sierra_reindexer_topic_name}",
     "${local.sierra_merged_bibs_topic_name}",
     "${local.sierra_merged_items_topic_name}",
   ]
   miro_adapter_topic_names = [
-    # "${local.miro_reindexer_topic_name}",
+    "${local.miro_reindexer_topic_name}",
     "${local.miro_updates_topic_name}",
   ]
   # Elasticsearch
-  es_works_index = "v2-2019-04-26-contributors-label-from-multiple-subfields"
+  es_works_index = "v2-20190816-alternative-titles"
   # RDS
   rds_ids_access_security_group_id = "${local.rds_access_security_group_id}"
   # Adapter VHS
   vhs_sierra_read_policy = "${local.vhs_sierra_read_policy}"
   vhs_miro_read_policy   = "${local.vhs_miro_read_policy}"
 }
-


### PR DESCRIPTION
Steps for this (will document):
- [x] Create new stack, with new deployment (`stage`), new index name, and reindex queues attached
- [x] Reindex the lot into the new index
- [x] Point staging API to new index
- [x] Test
- [x] Remove old stack
- [ ] Update `production_api`
- [ ] Point non-prod API to new index
- [ ] Delete old index

Arguably we could keep the old indexes around, but I'd like to hear the reasons, if any, people think we should.

We could also just create romulus / remus indexes, but then make sure, when clearing up before a reindex (probably through scripting) we don't empty the production index. <= thinking aloud.

Another reason not to reindex into old indexes is it slows the index down considerably.