### PR TITLE
allow genre to be root concept

### DIFF
--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
@@ -50,13 +50,13 @@ object WorksIndex {
 
   val period = Seq(
     textField("label"),
+    keywordField("ontologyType"),
     objectField("range").fields(
       textField("label"),
       dateField("from"),
       dateField("to"),
       booleanField("inferred")
-    ),
-    keywordField("ontologyType")
+    )
   )
 
   val concept = Seq(
@@ -95,7 +95,7 @@ object WorksIndex {
   def genre(fieldName: String) = objectField(fieldName).fields(
     textField("label"),
     keywordField("ontologyType"),
-    identified("concepts", concept)
+    identified("concepts", rootConcept)
   )
 
   def labelledTextField(fieldName: String) = objectField(fieldName).fields(


### PR DESCRIPTION
Not immediately obvious how the hierarchy works here (root seems to imply that that's all the shapes a concept can be in).

Related to some talk here:
https://github.com/wellcometrust/platform/issues/3754

Will relook at this once it's in to close of the things it's blocking.

Probably need to find a way to test data against this, although I am sure I have seem 1 somewhere. The problem arises when not producing data that is parsed into structural data. https://github.com/wellcometrust/catalogue/issues/126