### PR TITLE
[MEGA-WIP] pipeline steps

### DIFF
--- a/pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/models/PipelineStep.scala
+++ b/pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/models/PipelineStep.scala
@@ -1,0 +1,62 @@
+package uk.ac.wellcome.platform.ingestor.models
+
+import scala.concurrent.Future
+import scala.util.{Failure, Success, Try}
+
+sealed trait PipelineResult
+case class PipelineSucceeded() extends PipelineResult
+case class PipelineFailedDetermanistically() extends PipelineResult
+case class PipelineFailedUndetermanistically() extends PipelineResult
+case class PipelineGetError() extends PipelineResult
+
+sealed trait PipelineStepState[+DataIn]
+case class PipelineStepStarted extends PipelineStepState
+case class PipelineStepWorking[DataIn] extends PipelineStepState
+case class PipelineStepStopped[DataIn, PipelineDetermanisticError]
+    extends PipelineStepState
+case class PipelineStepSucceeded[DataIn, DataOut] extends PipelineStepState
+case class PipelineStepFailed[DataIn, PipelineUndetermanisticError]
+    extends PipelineStepState
+
+trait PipelineStepGetter[DataType] {
+  def get(): Try[Future[DataType]]
+}
+
+trait PipelineStep[DataIn, DataOut] {
+  def get(): Try[Future[DataIn]]
+  def runProcess() =
+    get match {
+      case Failure(e) => PipelineGetError(e)
+      case Success(f) => f map process
+    }
+
+  def process(data: DataIn): Try[Future[DataOut]]
+}
+
+trait PipelineLogger
+
+object BigMessaging extends PipelineStepGetter[CatalogueWork] {
+  def get(): Try[Future[CatalogueWork]] = {
+    // Get work from BM
+    Success(Future.successful(CatalogueWork("Title")))
+  }
+}
+
+case class ElasticResult(msg: String)
+case class CatalogueWork(title: String)
+
+class IngestPipelineStep extends PipelineStep[CatalogueWork, ElasticResult] {
+
+  def get() = {
+    BigMessaging.get()
+  }
+  def process(work: CatalogueWork) = {
+    Success(Future.successful(ElasticResult("Made it!")))
+  }
+}
+
+object App {
+  def run(): Unit = {
+    new IngestPipelineStep()
+  }
+}


### PR DESCRIPTION
Thought being a `PipelineStep` knows only about the `DataType`s of what will come in from somewhere, and then what will go out.

Then you might have a `PipelineLogger` that is more aware of the `PipelineStates` varying states.
Then you might have a `PipelineMetrics` that is more aware of the `PipelineStates` varying states.

The PipelineStates I would like to be able to keep the `DataIn` available to them, as well as some contextual information relating to the step itself.

Still loads to think about - but putting it here for 👀 
The implementation of the thinking is a little behind.