### PR TITLE
Update recorder messaging and storage libs

### DIFF
--- a/.sbt_metadata/recorder.json
+++ b/.sbt_metadata/recorder.json
@@ -2,6 +2,7 @@
   "id" : "recorder",
   "folder" : "pipeline/recorder",
   "dependencyIds" : [
-    "internal_model"
+    "internal_model",
+    "big_messaging_typesafe"
   ]
 }

--- a/build.sbt
+++ b/build.sbt
@@ -99,7 +99,7 @@ lazy val merger = setupProject(project, "pipeline/merger",
 )
 
 lazy val recorder = setupProject(project, "pipeline/recorder",
-  localDependencies = Seq(internal_model),
+  localDependencies = Seq(internal_model, big_messaging_typesafe),
   externalDependencies = CatalogueDependencies.recorderDependencies
 )
 

--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/message/BigMessageStream.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/message/BigMessageStream.scala
@@ -18,9 +18,10 @@ import uk.ac.wellcome.storage.store.TypedStore
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
-class MessageStream[T](sqsClient: AmazonSQSAsync,
-                       sqsConfig: SQSConfig,
-                       metrics: Metrics[Future, StandardUnit])(
+class BigMessageStream[T](
+  sqsClient: AmazonSQSAsync,
+  sqsConfig: SQSConfig,
+  metrics: Metrics[Future, StandardUnit])(
   implicit
   actorSystem: ActorSystem,
   decoderT: Decoder[T],

--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/message/BigMessageStream.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/message/BigMessageStream.scala
@@ -18,10 +18,9 @@ import uk.ac.wellcome.storage.store.TypedStore
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
-class BigMessageStream[T](
-  sqsClient: AmazonSQSAsync,
-  sqsConfig: SQSConfig,
-  metrics: Metrics[Future, StandardUnit])(
+class BigMessageStream[T](sqsClient: AmazonSQSAsync,
+                          sqsConfig: SQSConfig,
+                          metrics: Metrics[Future, StandardUnit])(
   implicit
   actorSystem: ActorSystem,
   decoderT: Decoder[T],

--- a/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/fixtures/BigMessagingFixture.scala
+++ b/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/fixtures/BigMessagingFixture.scala
@@ -46,15 +46,15 @@ trait BigMessagingFixture
 
   case class ExampleObject(name: String)
 
-  def withMessageStream[T, R](queue: SQS.Queue,
+  def withBigMessageStream[T, R](queue: SQS.Queue,
                               metrics: MemoryMetrics[StandardUnit] =
                                 new MemoryMetrics[StandardUnit]())(
-    testWith: TestWith[MessageStream[T], R])(
+    testWith: TestWith[BigMessageStream[T], R])(
     implicit
     actorSystem: ActorSystem,
     decoderT: Decoder[T],
     typedStoreT: TypedStore[ObjectLocation, T]): R = {
-    val stream = new MessageStream[T](
+    val stream = new BigMessageStream[T](
       sqsClient = asyncSqsClient,
       sqsConfig = createSQSConfigWith(queue),
       metrics = metrics

--- a/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/fixtures/BigMessagingFixture.scala
+++ b/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/fixtures/BigMessagingFixture.scala
@@ -47,8 +47,8 @@ trait BigMessagingFixture
   case class ExampleObject(name: String)
 
   def withBigMessageStream[T, R](queue: SQS.Queue,
-                              metrics: MemoryMetrics[StandardUnit] =
-                                new MemoryMetrics[StandardUnit]())(
+                                 metrics: MemoryMetrics[StandardUnit] =
+                                   new MemoryMetrics[StandardUnit]())(
     testWith: TestWith[BigMessageStream[T], R])(
     implicit
     actorSystem: ActorSystem,

--- a/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/message/BigMessageStreamTest.scala
+++ b/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/message/BigMessageStreamTest.scala
@@ -19,7 +19,7 @@ import scala.collection.immutable.Map
 import scala.concurrent.Future
 import scala.util.Random
 
-class MessageStreamTest extends FunSpec with Matchers with BigMessagingFixture {
+class BigMessageStreamTest extends FunSpec with Matchers with BigMessagingFixture {
 
   def process(list: ConcurrentLinkedQueue[ExampleObject])(o: ExampleObject) = {
     list.add(o)
@@ -313,7 +313,7 @@ class MessageStreamTest extends FunSpec with Matchers with BigMessagingFixture {
   }
 
   private def withMessageStreamFixtures[R](
-    testWith: TestWith[(MessageStream[ExampleObject],
+    testWith: TestWith[(BigMessageStream[ExampleObject],
                         QueuePair,
                         MemoryMetrics[StandardUnit]),
                        R]
@@ -325,7 +325,7 @@ class MessageStreamTest extends FunSpec with Matchers with BigMessagingFixture {
       withLocalSqsQueueAndDlq {
         case queuePair @ QueuePair(queue, _) =>
           val metrics = new MemoryMetrics[StandardUnit]()
-          withMessageStream[ExampleObject, R](queue, metrics) { stream =>
+          withBigMessageStream[ExampleObject, R](queue, metrics) { stream =>
             testWith((stream, queuePair, metrics))
           }
       }

--- a/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/message/BigMessageStreamTest.scala
+++ b/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/message/BigMessageStreamTest.scala
@@ -19,7 +19,10 @@ import scala.collection.immutable.Map
 import scala.concurrent.Future
 import scala.util.Random
 
-class BigMessageStreamTest extends FunSpec with Matchers with BigMessagingFixture {
+class BigMessageStreamTest
+    extends FunSpec
+    with Matchers
+    with BigMessagingFixture {
 
   def process(list: ConcurrentLinkedQueue[ExampleObject])(o: ExampleObject) = {
     list.add(o)

--- a/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/message/BigMessagingFixtureIntegrationTest.scala
+++ b/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/message/BigMessagingFixtureIntegrationTest.scala
@@ -26,7 +26,7 @@ import uk.ac.wellcome.storage.streaming.Codec._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class MessagingFixtureIntegrationTest
+class BigMessagingFixtureIntegrationTest
     extends FunSpec
     with Matchers
     with BigMessagingFixture
@@ -90,7 +90,7 @@ class MessagingFixtureIntegrationTest
     )
 
   private def withLocalStackBigMessageSenderMessageStream[R](
-    testWith: TestWith[(MessageStream[ExampleObject],
+    testWith: TestWith[(BigMessageStream[ExampleObject],
                         BigMessageSender[SNSConfig, ExampleObject]),
                        R]): R = {
     withLocalStackMessageStreamFixtures[R] {
@@ -113,7 +113,7 @@ class MessagingFixtureIntegrationTest
 
   def withLocalStackMessageStreamFixtures[R](
     testWith: TestWith[(Queue,
-                        MessageStream[ExampleObject],
+                        BigMessageStream[ExampleObject],
                         MemoryTypedStore[ObjectLocation, ExampleObject]),
                        R]): R =
     withActorSystem { implicit actorSystem =>
@@ -122,7 +122,7 @@ class MessagingFixtureIntegrationTest
         MemoryTypedStoreCompanion[ObjectLocation, ExampleObject]()
 
       withLocalStackSqsQueue { queue =>
-        withMessageStream[ExampleObject, R](queue, metrics) { messageStream =>
+        withBigMessageStream[ExampleObject, R](queue, metrics) { messageStream =>
           testWith((queue, messageStream, typedStoreT))
         }
       }

--- a/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/message/BigMessagingFixtureIntegrationTest.scala
+++ b/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/message/BigMessagingFixtureIntegrationTest.scala
@@ -122,8 +122,9 @@ class BigMessagingFixtureIntegrationTest
         MemoryTypedStoreCompanion[ObjectLocation, ExampleObject]()
 
       withLocalStackSqsQueue { queue =>
-        withBigMessageStream[ExampleObject, R](queue, metrics) { messageStream =>
-          testWith((queue, messageStream, typedStoreT))
+        withBigMessageStream[ExampleObject, R](queue, metrics) {
+          messageStream =>
+            testWith((queue, messageStream, typedStoreT))
         }
       }
     }

--- a/common/big_messaging_typesafe/src/main/scala/uk/ac/wellcome/bigmessaging/typesafe/BigMessagingBuilder.scala
+++ b/common/big_messaging_typesafe/src/main/scala/uk/ac/wellcome/bigmessaging/typesafe/BigMessagingBuilder.scala
@@ -6,7 +6,7 @@ import com.amazonaws.services.s3.AmazonS3
 import com.typesafe.config.Config
 import io.circe.{Decoder, Encoder}
 import uk.ac.wellcome.bigmessaging.BigMessageSender
-import uk.ac.wellcome.bigmessaging.message.MessageStream
+import uk.ac.wellcome.bigmessaging.message.BigMessageStream
 import uk.ac.wellcome.messaging.sns.SNSConfig
 import uk.ac.wellcome.messaging.typesafe.{SNSBuilder, SQSBuilder}
 import uk.ac.wellcome.messaging.MessageSender
@@ -26,7 +26,7 @@ object BigMessagingBuilder {
     implicit actorSystem: ActorSystem,
     decoderT: Decoder[T],
     materializer: ActorMaterializer,
-    codecT: Codec[T]): MessageStream[T] = {
+    codecT: Codec[T]): BigMessageStream[T] = {
 
     implicit val executionContext: ExecutionContext =
       AkkaBuilder.buildExecutionContext()
@@ -35,7 +35,7 @@ object BigMessagingBuilder {
 
     implicit val typedStore: S3TypedStore[T] = S3TypedStore[T]
 
-    new MessageStream[T](
+    new BigMessageStream[T](
       sqsClient = SQSBuilder.buildSQSAsyncClient(config),
       sqsConfig =
         SQSBuilder.buildSQSConfig(config, namespace = "message.reader"),

--- a/common/big_messaging_typesafe/src/main/scala/uk/ac/wellcome/bigmessaging/typesafe/VHS.scala
+++ b/common/big_messaging_typesafe/src/main/scala/uk/ac/wellcome/bigmessaging/typesafe/VHS.scala
@@ -38,7 +38,7 @@ trait GetLocation {
   def getLocation(key: Version[String, Int]): Try[ObjectLocation]
 }
 
-class VHS[T](hybridStore: VHSInternalStore[T])
+class VHS[T](val hybridStore: VHSInternalStore[T])
     extends VersionedHybridStore[
       String,
       Int,
@@ -91,9 +91,7 @@ object VHSBuilder {
 
   def build[T](config: Config)(implicit codec: Codec[T]): VHS[T] =
     VHSBuilder.build(
-      ObjectLocationPrefix(
-        path = config.getOrElse("aws.vhs.s3.globalPrefix")(default = ""),
-        namespace = "vhs"),
+      buildObjectLocationPrefix(config),
       DynamoBuilder.buildDynamoConfig(config, namespace = "vhs"),
       DynamoBuilder.buildDynamoClient(config),
       S3Builder.buildS3Client(config)
@@ -117,4 +115,9 @@ object VHSBuilder {
       )
     )
   }
+
+  private def buildObjectLocationPrefix(config: Config) =
+    ObjectLocationPrefix(
+      path = config.getOrElse("aws.vhs.s3.globalPrefix")(default = ""),
+      namespace = config.getOrElse("aws.vhs.s3.bucketName")(default = ""))
 }

--- a/common/big_messaging_typesafe/src/main/scala/uk/ac/wellcome/bigmessaging/typesafe/VHS.scala
+++ b/common/big_messaging_typesafe/src/main/scala/uk/ac/wellcome/bigmessaging/typesafe/VHS.scala
@@ -89,10 +89,10 @@ object VHSBuilder {
         DynamoValue.fromMap(Map.empty)
     }
 
-  def build[T](config: Config)(implicit codec: Codec[T]): VHS[T] =
+  def build[T](config: Config, namespace: String = "vhs")(implicit codec: Codec[T]): VHS[T] =
     VHSBuilder.build(
-      buildObjectLocationPrefix(config),
-      DynamoBuilder.buildDynamoConfig(config, namespace = "vhs"),
+      buildObjectLocationPrefix(config, namespace = namespace),
+      DynamoBuilder.buildDynamoConfig(config, namespace = namespace),
       DynamoBuilder.buildDynamoClient(config),
       S3Builder.buildS3Client(config)
     )
@@ -116,8 +116,8 @@ object VHSBuilder {
     )
   }
 
-  private def buildObjectLocationPrefix(config: Config) =
+  private def buildObjectLocationPrefix(config: Config, namespace: String) =
     ObjectLocationPrefix(
-      path = config.getOrElse("aws.vhs.s3.globalPrefix")(default = ""),
-      namespace = config.getOrElse("aws.vhs.s3.bucketName")(default = ""))
+      namespace = config.required(s"aws.${namespace}.s3.bucketName"),
+      path = config.getOrElse(s"aws.${namespace}.s3.globalPrefix")(default = ""))
 }

--- a/common/big_messaging_typesafe/src/main/scala/uk/ac/wellcome/bigmessaging/typesafe/VHS.scala
+++ b/common/big_messaging_typesafe/src/main/scala/uk/ac/wellcome/bigmessaging/typesafe/VHS.scala
@@ -13,13 +13,13 @@ import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
 
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.store.dynamo.DynamoHashStore
-import uk.ac.wellcome.storage.dynamo.DynamoConfig 
+import uk.ac.wellcome.storage.dynamo.DynamoConfig
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.store.{
-  Store,
-  TypedStore,
   HybridIndexedStoreEntry,
   HybridStoreWithMaxima,
+  Store,
+  TypedStore,
   VersionedHybridStore
 }
 import uk.ac.wellcome.storage.{
@@ -62,12 +62,7 @@ class VHSInternalStore[T](
     HybridIndexedStoreEntry[ObjectLocation, EmptyMetadata]
   ] with Maxima[String, Int],
   dataStore: TypedStore[ObjectLocation, T]
-) extends HybridStoreWithMaxima[
-      String,
-      Int,
-      ObjectLocation,
-      T,
-      EmptyMetadata] {
+) extends HybridStoreWithMaxima[String, Int, ObjectLocation, T, EmptyMetadata] {
 
   override val indexedStore = indexStore;
   override val typedStore = dataStore;
@@ -101,21 +96,20 @@ object VHSBuilder {
         namespace = "vhs"),
       DynamoBuilder.buildDynamoConfig(config, namespace = "vhs"),
       DynamoBuilder.buildDynamoClient(config),
-      S3Builder.buildS3Client(config))
+      S3Builder.buildS3Client(config)
+    )
 
-  def build[T](
-    objectLocationPrefix: ObjectLocationPrefix,
-    dynamoConfig: DynamoConfig,
-    dynamoClient: AmazonDynamoDB,
-    s3Client: AmazonS3)(
-    implicit codec: Codec[T]): VHS[T] = {
+  def build[T](objectLocationPrefix: ObjectLocationPrefix,
+               dynamoConfig: DynamoConfig,
+               dynamoClient: AmazonDynamoDB,
+               s3Client: AmazonS3)(implicit codec: Codec[T]): VHS[T] = {
     implicit val s3 = s3Client;
     implicit val dynamo = dynamoClient;
     new VHS(
       new VHSInternalStore(
         objectLocationPrefix,
         new DynamoHashStore[
-          String, 
+          String,
           Int,
           HybridIndexedStoreEntry[ObjectLocation, EmptyMetadata]
         ](dynamoConfig),

--- a/common/big_messaging_typesafe/src/main/scala/uk/ac/wellcome/bigmessaging/typesafe/VHS.scala
+++ b/common/big_messaging_typesafe/src/main/scala/uk/ac/wellcome/bigmessaging/typesafe/VHS.scala
@@ -89,7 +89,8 @@ object VHSBuilder {
         DynamoValue.fromMap(Map.empty)
     }
 
-  def build[T](config: Config, namespace: String = "vhs")(implicit codec: Codec[T]): VHS[T] =
+  def build[T](config: Config, namespace: String = "vhs")(
+    implicit codec: Codec[T]): VHS[T] =
     VHSBuilder.build(
       buildObjectLocationPrefix(config, namespace = namespace),
       DynamoBuilder.buildDynamoConfig(config, namespace = namespace),

--- a/pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/services/IdMinterWorkerService.scala
+++ b/pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/services/IdMinterWorkerService.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.idminter.services
 import akka.Done
 import io.circe.Json
 import uk.ac.wellcome.bigmessaging.BigMessageSender
-import uk.ac.wellcome.bigmessaging.message.MessageStream
+import uk.ac.wellcome.bigmessaging.message.BigMessageStream
 import uk.ac.wellcome.platform.idminter.config.models.{
   IdentifiersTableConfig,
   RDSClientConfig
@@ -17,7 +17,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class IdMinterWorkerService[Destination](
   idEmbedder: IdEmbedder,
   sender: BigMessageSender[Destination, Json],
-  messageStream: MessageStream[Json],
+  messageStream: BigMessageStream[Json],
   rdsClientConfig: RDSClientConfig,
   identifiersTableConfig: IdentifiersTableConfig
 )(implicit ec: ExecutionContext)

--- a/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/fixtures/WorkerServiceFixture.scala
+++ b/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/fixtures/WorkerServiceFixture.scala
@@ -33,7 +33,7 @@ trait WorkerServiceFixture
         {
           implicit val typedStoreT =
             MemoryTypedStoreCompanion[ObjectLocation, Json]()
-          withMessageStream[Json, R](queue) { messageStream =>
+          withBigMessageStream[Json, R](queue) { messageStream =>
             val workerService = new IdMinterWorkerService(
               idEmbedder = new IdEmbedder(
                 identifierGenerator = new IdentifierGenerator(

--- a/pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
+++ b/pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
@@ -5,7 +5,7 @@ import com.amazonaws.services.sqs.model.Message
 import com.sksamuel.elastic4s.ElasticClient
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.elasticsearch.{ElasticsearchIndexCreator, WorksIndex}
-import uk.ac.wellcome.bigmessaging.message.MessageStream
+import uk.ac.wellcome.bigmessaging.message.BigMessageStream
 import uk.ac.wellcome.models.work.internal.IdentifiedBaseWork
 import uk.ac.wellcome.platform.ingestor.config.models.IngestorConfig
 import uk.ac.wellcome.typesafe.Runnable
@@ -15,7 +15,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class IngestorWorkerService(
   elasticClient: ElasticClient,
   ingestorConfig: IngestorConfig,
-  messageStream: MessageStream[IdentifiedBaseWork]
+  messageStream: BigMessageStream[IdentifiedBaseWork]
 )(implicit
   ec: ExecutionContext)
     extends Runnable

--- a/pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkerServiceFixture.scala
+++ b/pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/fixtures/WorkerServiceFixture.scala
@@ -29,7 +29,7 @@ trait WorkerServiceFixture
       {
         implicit val typedStoreT =
           MemoryTypedStoreCompanion[ObjectLocation, IdentifiedBaseWork]()
-        withMessageStream[IdentifiedBaseWork, R](queue) { messageStream =>
+        withBigMessageStream[IdentifiedBaseWork, R](queue) { messageStream =>
           val ingestorConfig = IngestorConfig(
             batchSize = 100,
             flushInterval = 5 seconds,

--- a/pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
+++ b/pipeline/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerServiceTest.scala
@@ -139,7 +139,7 @@ class IngestorWorkerServiceTest
           {
             implicit val typedStoreT =
               MemoryTypedStoreCompanion[ObjectLocation, IdentifiedBaseWork]()
-            withMessageStream[IdentifiedBaseWork, Assertion](queue) {
+            withBigMessageStream[IdentifiedBaseWork, Assertion](queue) {
               messageStream =>
                 import scala.concurrent.duration._
 

--- a/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/Main.scala
+++ b/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/Main.scala
@@ -25,10 +25,8 @@ object Main extends WellcomeTypesafeApp {
       store = RecorderVhs.build(config),
       messageStream =
         BigMessagingBuilder.buildMessageStream[TransformedBaseWork](config),
-      msgSender = SNSBuilder.buildSNSMessageSender(
-        config,
-        namespace = "dunno",
-        subject = "dunno")
+      msgSender = SNSBuilder
+        .buildSNSMessageSender(config, namespace = "dunno", subject = "dunno")
     )
   }
 }

--- a/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/Main.scala
+++ b/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/Main.scala
@@ -1,90 +1,28 @@
 package uk.ac.wellcome.platform.recorder
 
-import java.util.UUID
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.Config
-import org.scanamo.DynamoFormat
 
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
-import uk.ac.wellcome.platform.recorder.services.{RecorderWorkerService, EmptyMetadata}
+import uk.ac.wellcome.platform.recorder.services.RecorderWorkerService
 import uk.ac.wellcome.models.Implicits._
 
 import uk.ac.wellcome.messaging.typesafe.SNSBuilder
 import uk.ac.wellcome.bigmessaging.typesafe.BigMessagingBuilder
 
-import uk.ac.wellcome.storage.store.dynamo.DynamoHashStore
-import uk.ac.wellcome.storage.store.s3.S3TypedStore
-import uk.ac.wellcome.storage.store.{HybridIndexedStoreEntry, HybridStoreWithMaxima, VersionedHybridStore}
-import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
-import uk.ac.wellcome.storage.typesafe.{DynamoBuilder, S3Builder}
-import uk.ac.wellcome.storage.dynamo.DynamoHashEntry
-import uk.ac.wellcome.storage.streaming.Codec._
-import uk.ac.wellcome.storage.Version
-
-
-class DynamoSingleVersionedHybridStore[Id, V, T, Metadata](
-  store: DynamoSingleVersionHybridStoreWithMaxima[Id, V, T, Metadata])(
-  implicit N: Numeric[V])
-    extends VersionedHybridStore[Id, V, ObjectLocation, T, Metadata](store)
-
-class DynamoSingleVersionHybridStoreWithMaxima[Id, V, T, Metadata](
-  prefix: ObjectLocationPrefix)(
-  implicit
-  val indexedStore: DynamoHashStore[
-    Id,
-    V,
-    HybridIndexedStoreEntry[ObjectLocation, Metadata]],
-  val typedStore: S3TypedStore[T]
-) extends HybridStoreWithMaxima[Id, V, ObjectLocation, T, Metadata] {
-
-  override protected def createTypeStoreId(id: Version[Id, V]): ObjectLocation =
-    prefix.asLocation(
-      id.id.toString,
-      id.version.toString,
-      UUID.randomUUID().toString)
-}
-
 object Main extends WellcomeTypesafeApp {
 
-  type IndexEntry = HybridIndexedStoreEntry[ObjectLocation, EmptyMetadata]
-
-  type HashEntry = DynamoHashEntry[String, Int, IndexEntry]
-
   runWithConfig { config: Config =>
-    // TODO: from where do we get the correct values for this?
-    val objectLocationPrefix = ObjectLocationPrefix("namespace", "path")
-    val dynamoConfig =
-      DynamoBuilder.buildDynamoConfig(config, namespace = "namespace")
-
-    // For some reason these dont get derived with scanamo auto derivation
-    implicit def indexEntryFormat: DynamoFormat[IndexEntry] =
-      DynamoFormat[IndexEntry]
-    implicit def hashEntryFormat: DynamoFormat[HashEntry] =
-      DynamoFormat[HashEntry]
-
     implicit val actorSystem: ActorSystem =
       AkkaBuilder.buildActorSystem()
     implicit val materializer: ActorMaterializer =
       AkkaBuilder.buildActorMaterializer()
 
-    implicit val s3Client =
-      S3Builder.buildS3Client(config)
-    implicit val dynamoClient =
-      DynamoBuilder.buildDynamoClient(config)
-    implicit val s3Store =
-      S3TypedStore[TransformedBaseWork]
-    implicit val dynamoIndexStore =
-      new DynamoHashStore[String, Int, IndexEntry](dynamoConfig)
-    
-    val dynamoHybridStore =
-      new DynamoSingleVersionHybridStoreWithMaxima[String, Int, TransformedBaseWork, EmptyMetadata](
-        objectLocationPrefix)
-
     new RecorderWorkerService(
-      store = new DynamoSingleVersionedHybridStore(dynamoHybridStore),
+      store = RecorderVhs.build(config),
       messageStream =
         BigMessagingBuilder.buildMessageStream[TransformedBaseWork](config),
       msgSender = SNSBuilder.buildSNSMessageSender(

--- a/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/Main.scala
+++ b/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/Main.scala
@@ -26,7 +26,7 @@ object Main extends WellcomeTypesafeApp {
       messageStream =
         BigMessagingBuilder.buildMessageStream[TransformedBaseWork](config),
       msgSender = SNSBuilder
-        .buildSNSMessageSender(config, namespace = "dunno", subject = "dunno")
+        .buildSNSMessageSender(config, subject = "Sent from the recorder")
     )
   }
 }

--- a/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/Main.scala
+++ b/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/Main.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.platform.recorder.services.RecorderWorkerService
 import uk.ac.wellcome.models.Implicits._
 
 import uk.ac.wellcome.messaging.typesafe.SNSBuilder
-import uk.ac.wellcome.bigmessaging.typesafe.BigMessagingBuilder
+import uk.ac.wellcome.bigmessaging.typesafe.{BigMessagingBuilder, VHSBuilder}
 
 object Main extends WellcomeTypesafeApp {
 
@@ -22,7 +22,7 @@ object Main extends WellcomeTypesafeApp {
       AkkaBuilder.buildActorMaterializer()
 
     new RecorderWorkerService(
-      store = RecorderVhs.build(config),
+      store = VHSBuilder.build[TransformedBaseWork](config),
       messageStream =
         BigMessagingBuilder.buildMessageStream[TransformedBaseWork](config),
       msgSender = SNSBuilder

--- a/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/Main.scala
+++ b/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/Main.scala
@@ -3,32 +3,75 @@ package uk.ac.wellcome.platform.recorder
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.Config
-import uk.ac.wellcome.messaging.typesafe.{MessagingBuilder, SNSBuilder}
-import uk.ac.wellcome.models.work.internal.TransformedBaseWork
-import uk.ac.wellcome.platform.recorder.services.RecorderWorkerService
-import uk.ac.wellcome.storage.typesafe.VHSBuilder
-import uk.ac.wellcome.storage.vhs.EmptyMetadata
+import org.scanamo.DynamoFormat
+
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
+import uk.ac.wellcome.models.work.internal.TransformedBaseWork
+import uk.ac.wellcome.platform.recorder.services.{RecorderWorkerService, EmptyMetadata}
 import uk.ac.wellcome.models.Implicits._
 
-import scala.concurrent.ExecutionContext
+import uk.ac.wellcome.messaging.typesafe.SNSBuilder
+import uk.ac.wellcome.bigmessaging.typesafe.BigMessagingBuilder
+
+import uk.ac.wellcome.storage.store.dynamo.{
+  DynamoVersionedHybridStore,
+  DynamoHashRangeStore,
+  DynamoHybridStoreWithMaxima
+}
+import uk.ac.wellcome.storage.store.s3.S3TypedStore
+import uk.ac.wellcome.storage.store.HybridIndexedStoreEntry
+import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
+import uk.ac.wellcome.storage.typesafe.{DynamoBuilder, S3Builder}
+import uk.ac.wellcome.storage.dynamo.DynamoHashRangeEntry
+import uk.ac.wellcome.storage.streaming.Codec._
 
 object Main extends WellcomeTypesafeApp {
+
+  type IndexEntry = HybridIndexedStoreEntry[ObjectLocation, EmptyMetadata]
+
+  type HashEntry = DynamoHashRangeEntry[String, Int, IndexEntry]
+
   runWithConfig { config: Config =>
+    // TODO: from where do we get the correct values for this?
+    val objectLocationPrefix = ObjectLocationPrefix("namespace", "path")
+    val dynamoConfig =
+      DynamoBuilder.buildDynamoConfig(config, namespace = "namespace")
+
+    // For some reason these dont get derived with scanamo auto derivation
+    implicit def indexEntryFormat: DynamoFormat[IndexEntry] =
+      DynamoFormat[IndexEntry]
+    implicit def hashEntryFormat: DynamoFormat[HashEntry] =
+      DynamoFormat[HashEntry]
+
     implicit val actorSystem: ActorSystem =
       AkkaBuilder.buildActorSystem()
-    implicit val executionContext: ExecutionContext =
-      AkkaBuilder.buildExecutionContext()
     implicit val materializer: ActorMaterializer =
       AkkaBuilder.buildActorMaterializer()
 
+    implicit val s3Client =
+      S3Builder.buildS3Client(config)
+    implicit val dynamoClient =
+      DynamoBuilder.buildDynamoClient(config)
+    implicit val s3Store =
+      S3TypedStore[TransformedBaseWork]
+    implicit val dynamoIndexStore =
+      new DynamoHashRangeStore[String, Int, IndexEntry](dynamoConfig)
+    
+    val dynamoHybridStore =
+      new DynamoHybridStoreWithMaxima[String, Int, TransformedBaseWork, EmptyMetadata](
+        objectLocationPrefix)
+
     new RecorderWorkerService(
-      versionedHybridStore =
-        VHSBuilder.buildVHS[TransformedBaseWork, EmptyMetadata](config),
+      // TODO: bad implementation as will keep old versions lying around (with
+      // hash range stores the product of both keys defines unqiquness)
+      store = new DynamoVersionedHybridStore(dynamoHybridStore),
       messageStream =
-        MessagingBuilder.buildMessageStream[TransformedBaseWork](config),
-      snsWriter = SNSBuilder.buildSNSWriter(config)
+        BigMessagingBuilder.buildMessageStream[TransformedBaseWork](config),
+      msgSender = SNSBuilder.buildSNSMessageSender(
+        config,
+        namespace = "dunno",
+        subject = "dunno")
     )
   }
 }

--- a/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/RecorderVhs.scala
+++ b/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/RecorderVhs.scala
@@ -11,6 +11,7 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
 
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.store.dynamo.DynamoHashStore
@@ -93,17 +94,13 @@ object RecorderVhs {
     }
 
   def build(config: Config): RecorderVhs = {
-    // TODO: from where do we get the correct values for this?
-    val objectLocationPrefix = ObjectLocationPrefix("namespace", "path")
-    val dynamoConfig =
-      DynamoBuilder.buildDynamoConfig(config, namespace = "namespace")
-    implicit val s3Client = S3Builder.buildS3Client(config)
-    implicit val dynamoClient = DynamoBuilder.buildDynamoClient(config)
     RecorderVhs.build(
-      objectLocationPrefix,
-      dynamoConfig,
-      dynamoClient,
-      s3Client)
+      ObjectLocationPrefix(
+        path = config.getOrElse("aws.vhs.s3.globalPrefix")(default = ""),
+        namespace = "vhs"),
+      DynamoBuilder.buildDynamoConfig(config, namespace = "vhs"),
+      DynamoBuilder.buildDynamoClient(config),
+      S3Builder.buildS3Client(config))
   }
 
   def build(objectLocationPrefix: ObjectLocationPrefix,

--- a/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/RecorderVhs.scala
+++ b/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/RecorderVhs.scala
@@ -4,13 +4,15 @@ import java.util.UUID
 import scala.util.{Failure, Success, Try}
 import org.scanamo.DynamoFormat
 import com.typesafe.config.Config
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.json.JsonUtil._
 
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.store.dynamo.DynamoHashStore
-import uk.ac.wellcome.storage.dynamo.DynamoHashEntry
+import uk.ac.wellcome.storage.dynamo.{DynamoHashEntry, DynamoConfig}
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.store.{
   HybridIndexedStoreEntry,
@@ -76,34 +78,40 @@ class RecorderHybridStore(
 
 object RecorderVhs {
 
-  type IndexEntry = HybridIndexedStoreEntry[ObjectLocation, EmptyMetadata]
-
-  type HashEntry = DynamoHashEntry[String, Int, IndexEntry]
-
   def build(config: Config): RecorderVhs = {
     // TODO: from where do we get the correct values for this?
     val objectLocationPrefix = ObjectLocationPrefix("namespace", "path")
-    val dynamoConfig =
-      DynamoBuilder.buildDynamoConfig(config, namespace = "namespace")
+    val dynamoConfig = DynamoBuilder.buildDynamoConfig(config, namespace = "namespace")
+    implicit val s3Client = S3Builder.buildS3Client(config)
+    implicit val dynamoClient = DynamoBuilder.buildDynamoClient(config)
+    RecorderVhs.build(objectLocationPrefix, dynamoConfig, dynamoClient, s3Client)
+  }
 
-    // For some reason these dont get derived with scanamo auto derivation
-    implicit def indexEntryFormat: DynamoFormat[IndexEntry] =
-      DynamoFormat[IndexEntry]
-    implicit def hashEntryFormat: DynamoFormat[HashEntry] =
-      DynamoFormat[HashEntry]
-
-    implicit val s3Client =
-      S3Builder.buildS3Client(config)
-    implicit val dynamoClient =
-      DynamoBuilder.buildDynamoClient(config)
-
-    val s3Store =
-      S3TypedStore[TransformedBaseWork]
-    val dynamoIndexStore =
-      new DynamoHashStore[String, Int, IndexEntry](dynamoConfig)
-
+  def build(
+    objectLocationPrefix: ObjectLocationPrefix,
+    dynamoConfig: DynamoConfig,
+    dynamoClient: AmazonDynamoDB,
+    s3Client: AmazonS3): RecorderVhs = {
     new RecorderVhs(
-      new RecorderHybridStore(objectLocationPrefix, dynamoIndexStore, s3Store)
+      new RecorderHybridStore(
+        objectLocationPrefix,
+        RecorderVhs.buildIndexStore(dynamoClient, dynamoConfig),
+        RecorderVhs.buildTypedStore(s3Client)
+      )
     )
+  }
+
+  def buildIndexStore(dynamoClient: AmazonDynamoDB, dynamoConfig: DynamoConfig) = {
+    type IndexEntry = HybridIndexedStoreEntry[ObjectLocation, EmptyMetadata]
+    type HashEntry = DynamoHashEntry[String, Int, IndexEntry]
+    implicit val client = dynamoClient
+    implicit def idxFormat: DynamoFormat[IndexEntry] = DynamoFormat[IndexEntry]
+    implicit def hashFormat: DynamoFormat[HashEntry] = DynamoFormat[HashEntry]
+    new DynamoHashStore[String, Int, IndexEntry](dynamoConfig)
+  }
+
+  def buildTypedStore(s3Client: AmazonS3) = {
+    implicit val client = s3Client
+    S3TypedStore[TransformedBaseWork]
   }
 }

--- a/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/RecorderVhs.scala
+++ b/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/RecorderVhs.scala
@@ -1,0 +1,89 @@
+package uk.ac.wellcome.platform.recorder
+
+import java.util.UUID
+import scala.util.{Try, Success, Failure}
+import org.scanamo.DynamoFormat
+import com.typesafe.config.Config
+
+import uk.ac.wellcome.models.work.internal.TransformedBaseWork
+import uk.ac.wellcome.json.JsonUtil._
+
+import uk.ac.wellcome.storage.store.s3.S3TypedStore
+import uk.ac.wellcome.storage.store.dynamo.DynamoHashStore
+import uk.ac.wellcome.storage.dynamo.DynamoHashEntry
+import uk.ac.wellcome.storage.store.s3.S3TypedStore
+import uk.ac.wellcome.storage.store.{HybridIndexedStoreEntry, HybridStoreWithMaxima, VersionedHybridStore}
+import uk.ac.wellcome.storage.{Version, Identified, ObjectLocation, ObjectLocationPrefix}
+import uk.ac.wellcome.storage.typesafe.{DynamoBuilder, S3Builder}
+import uk.ac.wellcome.storage.streaming.Codec._
+
+case class EmptyMetadata()
+
+trait GetLocation {
+  def getLocation(key: Version[String, Int]): Try[ObjectLocation]
+}
+
+class RecorderVhs(hybridStore: RecorderHybridStore) extends
+  VersionedHybridStore[
+    String,
+    Int,
+    ObjectLocation,
+    TransformedBaseWork,
+    EmptyMetadata
+  ](hybridStore) with GetLocation {
+
+  def getLocation(key: Version[String, Int]): Try[ObjectLocation] =
+    hybridStore.indexedStore.get(key) match {
+      case Right(Identified(_, entry)) => Success(entry.typedStoreId)
+      case Left(error) => Failure(error.e)
+    }
+}
+
+class RecorderHybridStore(prefix: ObjectLocationPrefix)(
+  implicit
+  val indexedStore: DynamoHashStore[
+    String,
+    Int,
+    HybridIndexedStoreEntry[ObjectLocation, EmptyMetadata]],
+  val typedStore: S3TypedStore[TransformedBaseWork]
+) extends HybridStoreWithMaxima[String, Int, ObjectLocation, TransformedBaseWork, EmptyMetadata] {
+
+  override protected def createTypeStoreId(id: Version[String, Int]): ObjectLocation =
+    prefix.asLocation(
+      id.id.toString,
+      id.version.toString,
+      UUID.randomUUID().toString)
+}
+
+object RecorderVhs {
+
+  type IndexEntry = HybridIndexedStoreEntry[ObjectLocation, EmptyMetadata]
+
+  type HashEntry = DynamoHashEntry[String, Int, IndexEntry]
+
+  def build(config: Config): RecorderVhs = {
+    // TODO: from where do we get the correct values for this?
+    val objectLocationPrefix = ObjectLocationPrefix("namespace", "path")
+    val dynamoConfig =
+      DynamoBuilder.buildDynamoConfig(config, namespace = "namespace")
+
+    // For some reason these dont get derived with scanamo auto derivation
+    implicit def indexEntryFormat: DynamoFormat[IndexEntry] =
+      DynamoFormat[IndexEntry]
+    implicit def hashEntryFormat: DynamoFormat[HashEntry] =
+      DynamoFormat[HashEntry]
+
+    implicit val s3Client =
+      S3Builder.buildS3Client(config)
+    implicit val dynamoClient =
+      DynamoBuilder.buildDynamoClient(config)
+    implicit val s3Store =
+      S3TypedStore[TransformedBaseWork]
+    implicit val dynamoIndexStore =
+      new DynamoHashStore[String, Int, IndexEntry](dynamoConfig)
+    
+    new RecorderVhs(
+      new RecorderHybridStore(objectLocationPrefix)
+    )
+  }
+}

--- a/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/RecorderVhs.scala
+++ b/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/RecorderVhs.scala
@@ -12,7 +12,7 @@ import uk.ac.wellcome.json.JsonUtil._
 
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.store.dynamo.DynamoHashStore
-import uk.ac.wellcome.storage.dynamo.{DynamoHashEntry, DynamoConfig}
+import uk.ac.wellcome.storage.dynamo.{DynamoConfig, DynamoHashEntry}
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.store.{
   HybridIndexedStoreEntry,
@@ -81,17 +81,21 @@ object RecorderVhs {
   def build(config: Config): RecorderVhs = {
     // TODO: from where do we get the correct values for this?
     val objectLocationPrefix = ObjectLocationPrefix("namespace", "path")
-    val dynamoConfig = DynamoBuilder.buildDynamoConfig(config, namespace = "namespace")
+    val dynamoConfig =
+      DynamoBuilder.buildDynamoConfig(config, namespace = "namespace")
     implicit val s3Client = S3Builder.buildS3Client(config)
     implicit val dynamoClient = DynamoBuilder.buildDynamoClient(config)
-    RecorderVhs.build(objectLocationPrefix, dynamoConfig, dynamoClient, s3Client)
+    RecorderVhs.build(
+      objectLocationPrefix,
+      dynamoConfig,
+      dynamoClient,
+      s3Client)
   }
 
-  def build(
-    objectLocationPrefix: ObjectLocationPrefix,
-    dynamoConfig: DynamoConfig,
-    dynamoClient: AmazonDynamoDB,
-    s3Client: AmazonS3): RecorderVhs = {
+  def build(objectLocationPrefix: ObjectLocationPrefix,
+            dynamoConfig: DynamoConfig,
+            dynamoClient: AmazonDynamoDB,
+            s3Client: AmazonS3): RecorderVhs = {
     new RecorderVhs(
       new RecorderHybridStore(
         objectLocationPrefix,
@@ -101,7 +105,8 @@ object RecorderVhs {
     )
   }
 
-  def buildIndexStore(dynamoClient: AmazonDynamoDB, dynamoConfig: DynamoConfig) = {
+  def buildIndexStore(dynamoClient: AmazonDynamoDB,
+                      dynamoConfig: DynamoConfig) = {
     type IndexEntry = HybridIndexedStoreEntry[ObjectLocation, EmptyMetadata]
     type HashEntry = DynamoHashEntry[String, Int, IndexEntry]
     implicit val client = dynamoClient

--- a/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerService.scala
+++ b/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerService.scala
@@ -7,8 +7,8 @@ import akka.Done
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.typesafe.Runnable
 import uk.ac.wellcome.models.Implicits._
-import uk.ac.wellcome.platform.recorder.{EmptyMetadata, GetLocation}
 
+import uk.ac.wellcome.bigmessaging.typesafe.{EmptyMetadata, GetLocation}
 import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.bigmessaging.message.MessageStream
 

--- a/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerService.scala
+++ b/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerService.scala
@@ -10,7 +10,7 @@ import uk.ac.wellcome.json.JsonUtil._
 
 import uk.ac.wellcome.bigmessaging.typesafe.{EmptyMetadata, GetLocation}
 import uk.ac.wellcome.messaging.MessageSender
-import uk.ac.wellcome.bigmessaging.message.MessageStream
+import uk.ac.wellcome.bigmessaging.message.BigMessageStream
 
 import uk.ac.wellcome.storage.store.{HybridStoreEntry, VersionedStore}
 import uk.ac.wellcome.storage.{Identified, Version}
@@ -20,7 +20,7 @@ class RecorderWorkerService[MsgDestination](
     String,
     Int,
     HybridStoreEntry[TransformedBaseWork, EmptyMetadata]] with GetLocation,
-  messageStream: MessageStream[TransformedBaseWork],
+  messageStream: BigMessageStream[TransformedBaseWork],
   msgSender: MessageSender[MsgDestination])
     extends Runnable {
 

--- a/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerService.scala
+++ b/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerService.scala
@@ -6,7 +6,7 @@ import akka.Done
 
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.typesafe.Runnable
-import uk.ac.wellcome.models.Implicits._
+import uk.ac.wellcome.json.JsonUtil._
 
 import uk.ac.wellcome.bigmessaging.typesafe.{EmptyMetadata, GetLocation}
 import uk.ac.wellcome.messaging.MessageSender

--- a/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerService.scala
+++ b/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerService.scala
@@ -4,24 +4,22 @@ import scala.util.{Try, Success, Failure}
 import scala.concurrent.Future
 import akka.Done
 
-import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.typesafe.Runnable
 import uk.ac.wellcome.models.Implicits._
+import uk.ac.wellcome.platform.recorder.{EmptyMetadata, GetLocation}
 
 import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.bigmessaging.message.MessageStream
 
 import uk.ac.wellcome.storage.store.{VersionedStore, HybridStoreEntry}
-import uk.ac.wellcome.storage.{Identified, ObjectLocation}
-
-case class EmptyMetadata()
+import uk.ac.wellcome.storage.{Version, Identified}
 
 class RecorderWorkerService[MsgDestination](
   store: VersionedStore[
     String,
     Int,
-    HybridStoreEntry[TransformedBaseWork, EmptyMetadata]],
+    HybridStoreEntry[TransformedBaseWork, EmptyMetadata]] with GetLocation,
   messageStream: MessageStream[TransformedBaseWork],
   msgSender: MessageSender[MsgDestination])
     extends Runnable {
@@ -32,7 +30,8 @@ class RecorderWorkerService[MsgDestination](
   private def processMessage(work: TransformedBaseWork): Future[Unit] =
     Future.fromTry {
       for {
-        location <- storeWork(work)
+        key <- storeWork(work)
+        location <- store.getLocation(key)
         _ <- msgSender.sendT(location)
       } yield ()
     }
@@ -41,15 +40,14 @@ class RecorderWorkerService[MsgDestination](
     HybridStoreEntry(work, EmptyMetadata())
 
   private def storeWork(
-    work: TransformedBaseWork): Try[ObjectLocation] = {
+    work: TransformedBaseWork): Try[Version[String, Int]] = {
     val result = store.upsert(work.sourceIdentifier.toString)(createEntry(work)) {
       case HybridStoreEntry(existingWork, _) => createEntry(
         if (existingWork.version > work.version) { existingWork }
         else { work })
     }
     result match {
-      case Right(Identified(key_, _)) =>
-        Success(ObjectLocation("fill/in", "later"))
+      case Right(Identified(key, _)) => Success(key)
       case Left(error) => Failure(error.e)
     }
   }

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderFeatureTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderFeatureTest.scala
@@ -1,3 +1,4 @@
+/*
 package uk.ac.wellcome.platform.recorder
 
 import org.scalatest.concurrent.IntegrationPatience
@@ -24,9 +25,9 @@ class RecorderFeatureTest
     val work = createUnidentifiedWork
 
     withLocalSqsQueue { queue =>
-      withLocalS3Bucket { bucket =>
-        withLocalSnsTopic { topic =>
-          withWorkerService(bucket, topic, queue) { case (_, vhs) =>
+      withMemoryMessageSender { msgSender =>
+        withRecorderVhs { vhs => 
+          withWorkerService(queue, vhs, msgSender) { service =>
             sendMessage[TransformedBaseWork](queue = queue, obj = work)
 
             eventually {
@@ -40,3 +41,4 @@ class RecorderFeatureTest
     }
   }
 }
+*/

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderFeatureTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderFeatureTest.scala
@@ -1,5 +1,6 @@
-/*
 package uk.ac.wellcome.platform.recorder
+
+import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType
 
 import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.{FunSpec, Matchers}
@@ -8,32 +9,44 @@ import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.platform.recorder.fixtures.WorkerServiceFixture
-import uk.ac.wellcome.storage.{Version, Identified}
-import uk.ac.wellcome.storage.store.HybridStoreEntry
 
 import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
+import uk.ac.wellcome.storage.fixtures.DynamoFixtures
+import uk.ac.wellcome.storage.dynamo.DynamoConfig
+import uk.ac.wellcome.storage.ObjectLocationPrefix
 
-class RecorderFeatureTest
+class RecorderIntegrationTest
     extends FunSpec
     with Matchers
     with IntegrationPatience
+    with DynamoFixtures
     with BigMessagingFixture
     with WorkerServiceFixture
     with WorksGenerators {
 
+  override def createTable(table: DynamoFixtures.Table): DynamoFixtures.Table = {
+    createTableWithHashKey(
+      table,
+      keyName = "id",
+      keyType = ScalarAttributeType.S
+    )
+  }
+
   it("receives a transformed Work, and saves it to the VHS") {
     val work = createUnidentifiedWork
-
     withLocalSqsQueue { queue =>
-      withMemoryMessageSender { msgSender =>
-        withRecorderVhs { vhs => 
-          withWorkerService(queue, vhs, msgSender) { service =>
-            sendMessage[TransformedBaseWork](queue = queue, obj = work)
-
-            eventually {
-              val key = Version(work.sourceIdentifier.toString, 0)
-              vhs.get(key) shouldBe
-                Right(Identified(key, HybridStoreEntry(work, EmptyMetadata())))
+      withLocalS3Bucket { bucket =>
+        withLocalDynamoDbTable { table =>
+          withMemoryMessageSender { msgSender =>
+            val vhs = RecorderVhs.build(
+              ObjectLocationPrefix("test", "root"),
+              DynamoConfig(table.name, table.index),
+              dynamoClient,
+              s3Client,
+            )
+            withWorkerService(queue, vhs, msgSender) { service =>
+              sendMessage[TransformedBaseWork](queue = queue, obj = work)
+              eventually {}
             }
           }
         }
@@ -41,4 +54,3 @@ class RecorderFeatureTest
     }
   }
 }
-*/

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderFeatureTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderFeatureTest.scala
@@ -24,7 +24,8 @@ class RecorderIntegrationTest
     with WorkerServiceFixture
     with WorksGenerators {
 
-  override def createTable(table: DynamoFixtures.Table): DynamoFixtures.Table = {
+  override def createTable(
+    table: DynamoFixtures.Table): DynamoFixtures.Table = {
     createTableWithHashKey(
       table,
       keyName = "id",

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderFeatureTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderFeatureTest.scala
@@ -3,18 +3,20 @@ package uk.ac.wellcome.platform.recorder
 import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.Implicits._
-import uk.ac.wellcome.messaging.fixtures.Messaging
+
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.platform.recorder.fixtures.WorkerServiceFixture
-import uk.ac.wellcome.storage.fixtures.LocalVersionedHybridStore
+import uk.ac.wellcome.storage.{Version, Identified}
+import uk.ac.wellcome.storage.store.HybridStoreEntry
+
+import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
 
 class RecorderFeatureTest
     extends FunSpec
     with Matchers
     with IntegrationPatience
-    with LocalVersionedHybridStore
-    with Messaging
+    with BigMessagingFixture
     with WorkerServiceFixture
     with WorksGenerators {
 
@@ -23,18 +25,14 @@ class RecorderFeatureTest
 
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
-        withLocalDynamoDbTable { table =>
-          withLocalSnsTopic { topic =>
-            withWorkerService(table, bucket, topic, queue) { _ =>
-              sendMessage[TransformedBaseWork](queue = queue, obj = work)
+        withLocalSnsTopic { topic =>
+          withWorkerService(bucket, topic, queue) { case (_, vhs) =>
+            sendMessage[TransformedBaseWork](queue = queue, obj = work)
 
-              eventually {
-                assertStored[TransformedBaseWork](
-                  table = table,
-                  id = work.sourceIdentifier.toString,
-                  record = work
-                )
-              }
+            eventually {
+              val key = Version(work.sourceIdentifier.toString, 0)
+              vhs.get(key) shouldBe
+                Right(Identified(key, HybridStoreEntry(work, EmptyMetadata())))
             }
           }
         }

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderIntegrationTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderIntegrationTest.scala
@@ -11,10 +11,14 @@ import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.platform.recorder.fixtures.WorkerServiceFixture
 
 import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
-import uk.ac.wellcome.bigmessaging.typesafe.VHSBuilder
+import uk.ac.wellcome.bigmessaging.typesafe.{VHSBuilder, EmptyMetadata}
 import uk.ac.wellcome.storage.fixtures.DynamoFixtures
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
-import uk.ac.wellcome.storage.ObjectLocationPrefix
+import uk.ac.wellcome.storage.{Identified, ObjectLocation, ObjectLocationPrefix}
+import uk.ac.wellcome.storage.store.{
+  HybridIndexedStoreEntry,
+  TypedStoreEntry
+}
 
 class RecorderIntegrationTest
     extends FunSpec
@@ -34,21 +38,44 @@ class RecorderIntegrationTest
     )
   }
 
-  it("receives a transformed Work, and saves it to the VHS") {
-    val work = createUnidentifiedWork
+  it("receives a transformed Work, saves it to the VHS, and sends off a message") {
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { table =>
           withMemoryMessageSender { msgSender =>
             val vhs = VHSBuilder.build[TransformedBaseWork](
-              ObjectLocationPrefix("test", "root"),
+              ObjectLocationPrefix(namespace = bucket.name, path = "recorder"),
               DynamoConfig(table.name, table.index),
               dynamoClient,
               s3Client,
             )
             withWorkerService(queue, vhs, msgSender) { service =>
+              val work = createUnidentifiedWork
               sendMessage[TransformedBaseWork](queue = queue, obj = work)
-              eventually {}
+              eventually {
+                val key = assertWorkStored(vhs, work)
+                val tryLocation = vhs.getLocation(key)
+                tryLocation.isSuccess shouldBe true
+                val location = tryLocation.get
+
+                // Check index entry stored correctly in dynamo
+                vhs.hybridStore.indexedStore.get(key) shouldBe
+                  Right(
+                    Identified(
+                      key,
+                      HybridIndexedStoreEntry(location, EmptyMetadata())))
+
+                // Check typed entry stored correctly in S3
+                vhs.hybridStore.typedStore.get(location) shouldBe
+                  Right(
+                    Identified(
+                      location,
+                      TypedStoreEntry(work, Map.empty)))
+
+                // Check S3 location put on queue
+                msgSender.getMessages[ObjectLocation].toList shouldBe
+                  List(location)
+              }
             }
           }
         }

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderIntegrationTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderIntegrationTest.scala
@@ -5,6 +5,7 @@ import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType
 import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.Implicits._
+import uk.ac.wellcome.json.JsonUtil._
 
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderIntegrationTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderIntegrationTest.scala
@@ -11,6 +11,7 @@ import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.platform.recorder.fixtures.WorkerServiceFixture
 
 import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
+import uk.ac.wellcome.bigmessaging.typesafe.VHSBuilder
 import uk.ac.wellcome.storage.fixtures.DynamoFixtures
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
 import uk.ac.wellcome.storage.ObjectLocationPrefix
@@ -39,7 +40,7 @@ class RecorderIntegrationTest
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { table =>
           withMemoryMessageSender { msgSender =>
-            val vhs = RecorderVhs.build(
+            val vhs = VHSBuilder.build[TransformedBaseWork](
               ObjectLocationPrefix("test", "root"),
               DynamoConfig(table.name, table.index),
               dynamoClient,

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderIntegrationTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderIntegrationTest.scala
@@ -11,14 +11,11 @@ import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.platform.recorder.fixtures.WorkerServiceFixture
 
 import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
-import uk.ac.wellcome.bigmessaging.typesafe.{VHSBuilder, EmptyMetadata}
+import uk.ac.wellcome.bigmessaging.typesafe.{EmptyMetadata, VHSBuilder}
 import uk.ac.wellcome.storage.fixtures.DynamoFixtures
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
 import uk.ac.wellcome.storage.{Identified, ObjectLocation, ObjectLocationPrefix}
-import uk.ac.wellcome.storage.store.{
-  HybridIndexedStoreEntry,
-  TypedStoreEntry
-}
+import uk.ac.wellcome.storage.store.{HybridIndexedStoreEntry, TypedStoreEntry}
 
 class RecorderIntegrationTest
     extends FunSpec
@@ -38,7 +35,8 @@ class RecorderIntegrationTest
     )
   }
 
-  it("receives a transformed Work, saves it to the VHS, and sends off a message") {
+  it(
+    "receives a transformed Work, saves it to the VHS, and sends off a message") {
     withLocalSqsQueue { queue =>
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { table =>
@@ -67,10 +65,7 @@ class RecorderIntegrationTest
 
                 // Check typed entry stored correctly in S3
                 vhs.hybridStore.typedStore.get(location) shouldBe
-                  Right(
-                    Identified(
-                      location,
-                      TypedStoreEntry(work, Map.empty)))
+                  Right(Identified(location, TypedStoreEntry(work, Map.empty)))
 
                 // Check S3 location put on queue
                 msgSender.getMessages[ObjectLocation].toList shouldBe

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderIntegrationTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderIntegrationTest.scala
@@ -42,7 +42,9 @@ class RecorderIntegrationTest
           withLocalSnsTopic { topic =>
             withSnsMessageSender(topic) { msgSender =>
               val vhs = VHSBuilder.build[TransformedBaseWork](
-                ObjectLocationPrefix(namespace = bucket.name, path = "recorder"),
+                ObjectLocationPrefix(
+                  namespace = bucket.name,
+                  path = "recorder"),
                 DynamoConfig(table.name, table.index),
                 dynamoClient,
                 s3Client,

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/fixtures/WorkerServiceFixture.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/fixtures/WorkerServiceFixture.scala
@@ -14,7 +14,12 @@ import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 
 import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryVersionedStore}
-import uk.ac.wellcome.storage.{ObjectLocation, Identified, StoreWriteError, Version}
+import uk.ac.wellcome.storage.{
+  Identified,
+  ObjectLocation,
+  StoreWriteError,
+  Version
+}
 import uk.ac.wellcome.storage.store.{HybridStoreEntry, VersionedStore}
 import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
 
@@ -85,7 +90,7 @@ trait WorkerServiceFixture extends BigMessagingFixture {
   }
 
   def assertWorkNotStored[T <: TransformedBaseWork](vhs: RecorderVhs,
-                                                            work: T) = {
+                                                    work: T) = {
 
     val id = work.sourceIdentifier.toString
     val workExists = vhs.getLatest(id) match {

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/fixtures/WorkerServiceFixture.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/fixtures/WorkerServiceFixture.scala
@@ -6,7 +6,7 @@ import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.platform.recorder.services.RecorderWorkerService
-import uk.ac.wellcome.platform.recorder.{EmptyMetadata, GetLocation}
+import uk.ac.wellcome.bigmessaging.typesafe.{EmptyMetadata, GetLocation}
 
 import uk.ac.wellcome.bigmessaging.memory.MemoryTypedStoreCompanion
 import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/fixtures/WorkerServiceFixture.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/fixtures/WorkerServiceFixture.scala
@@ -1,45 +1,54 @@
 package uk.ac.wellcome.platform.recorder.fixtures
 
+import scala.util.{Try, Success}
+
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.models.Implicits._
-import uk.ac.wellcome.messaging.fixtures.Messaging
-import uk.ac.wellcome.messaging.fixtures.SNS.Topic
-import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.platform.recorder.services.RecorderWorkerService
-import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
-import uk.ac.wellcome.storage.fixtures.LocalVersionedHybridStore
-import uk.ac.wellcome.storage.fixtures.S3.Bucket
-import uk.ac.wellcome.storage.vhs.EmptyMetadata
+import uk.ac.wellcome.platform.recorder.{EmptyMetadata, GetLocation}
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import uk.ac.wellcome.bigmessaging.memory.MemoryTypedStoreCompanion
+import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
+import uk.ac.wellcome.messaging.fixtures.SNS.Topic
+import uk.ac.wellcome.messaging.fixtures.SQS.Queue
+import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 
-trait WorkerServiceFixture extends LocalVersionedHybridStore with Messaging {
+import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
+import uk.ac.wellcome.storage.store.memory.{MemoryVersionedStore, MemoryStore}
+import uk.ac.wellcome.storage.{Version, ObjectLocation}
+import uk.ac.wellcome.storage.store.{VersionedStore, HybridStoreEntry}
+import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
+
+trait WorkerServiceFixture extends BigMessagingFixture {
+
+  type Entry = HybridStoreEntry[TransformedBaseWork, EmptyMetadata]
+
+  type RecorderVhs = VersionedStore[String, Int, Entry] with GetLocation
+
+  def withRecorderVhs[R](testWith: TestWith[RecorderVhs, R]): R = {
+    val internalStore =
+      new MemoryStore[Version[String, Int], Entry](Map.empty) with MemoryMaxima[String, Entry]
+    val vhs =
+      new MemoryVersionedStore[String, Entry](internalStore) with GetLocation {
+        def getLocation(key: Version[String, Int]): Try[ObjectLocation] =
+          Success(ObjectLocation("test", s"${key.id}/${key.version}"))
+      }
+    testWith(vhs)
+  }
+
   def withWorkerService[R](
-    table: Table,
     storageBucket: Bucket,
     topic: Topic,
-    queue: Queue)(testWith: TestWith[RecorderWorkerService, R]): R =
+    queue: Queue)(testWith: TestWith[(RecorderWorkerService[String], RecorderVhs), R]): R =
     withActorSystem { implicit actorSystem =>
-      withMetricsSender() { metricsSender =>
-        withSNSWriter(topic) { snsWriter =>
-          withTypeVHS[TransformedBaseWork, EmptyMetadata, R](
-            bucket = storageBucket,
-            table = table) { versionedHybridStore =>
-            withMessageStream[TransformedBaseWork, R](
-              queue = queue,
-              metricsSender = metricsSender) { messageStream =>
-              val workerService = new RecorderWorkerService(
-                versionedHybridStore = versionedHybridStore,
-                messageStream = messageStream,
-                snsWriter = snsWriter
-              )
-
-              workerService.run()
-
-              testWith(workerService)
-            }
-          }
+      implicit val streamStore = MemoryTypedStoreCompanion[ObjectLocation, TransformedBaseWork]()
+      withMessageStream[TransformedBaseWork, R](queue = queue) { msgStream =>
+        withRecorderVhs[R] { vhs =>
+          val msgSender = new MemoryMessageSender()
+          val workerService = new RecorderWorkerService(vhs, msgStream, msgSender)
+          workerService.run()
+          testWith((workerService, vhs))
         }
       }
     }

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/fixtures/WorkerServiceFixture.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/fixtures/WorkerServiceFixture.scala
@@ -10,13 +10,11 @@ import uk.ac.wellcome.platform.recorder.{EmptyMetadata, GetLocation}
 
 import uk.ac.wellcome.bigmessaging.memory.MemoryTypedStoreCompanion
 import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
-import uk.ac.wellcome.messaging.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 
-import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.store.memory.{MemoryVersionedStore, MemoryStore}
-import uk.ac.wellcome.storage.{Version, ObjectLocation}
+import uk.ac.wellcome.storage.{Version, ObjectLocation, StoreWriteError}
 import uk.ac.wellcome.storage.store.{VersionedStore, HybridStoreEntry}
 import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
 
@@ -26,30 +24,43 @@ trait WorkerServiceFixture extends BigMessagingFixture {
 
   type RecorderVhs = VersionedStore[String, Int, Entry] with GetLocation
 
-  def withRecorderVhs[R](testWith: TestWith[RecorderVhs, R]): R = {
-    val internalStore =
-      new MemoryStore[Version[String, Int], Entry](Map.empty) with MemoryMaxima[String, Entry]
-    val vhs =
-      new MemoryVersionedStore[String, Entry](internalStore) with GetLocation {
-        def getLocation(key: Version[String, Int]): Try[ObjectLocation] =
-          Success(ObjectLocation("test", s"${key.id}/${key.version}"))
-      }
-    testWith(vhs)
+  type InternalStore = MemoryStore[Version[String, Int], Entry] with MemoryMaxima[String, Entry]
+
+  class MemoryRecorderVhs(
+    internalStore: InternalStore =
+      new MemoryStore[Version[String, Int], Entry](Map.empty)
+        with MemoryMaxima[String, Entry]
+  ) extends MemoryVersionedStore[String, Entry](internalStore) with GetLocation {
+
+    def getLocation(key: Version[String, Int]): Try[ObjectLocation] =
+      Success(ObjectLocation("test", s"${key.id}/${key.version}"))
   }
 
-  def withWorkerService[R](
-    storageBucket: Bucket,
-    topic: Topic,
-    queue: Queue)(testWith: TestWith[(RecorderWorkerService[String], RecorderVhs), R]): R =
+  class BrokenMemoryRecorderVhs extends MemoryRecorderVhs() {
+    override def put(id: Version[String, Int])(entry: Entry): WriteEither =
+      Left(StoreWriteError(new Error("BOOM!")))
+  }
+
+  def withRecorderVhs[R](testWith: TestWith[RecorderVhs, R]): R = {
+    testWith(new MemoryRecorderVhs())
+  }
+
+  def withBrokenRecorderVhs[R](testWith: TestWith[RecorderVhs, R]): R = {
+    testWith(new BrokenMemoryRecorderVhs())
+  }
+
+  def withMemoryMessageSender[R](testWith: TestWith[MemoryMessageSender, R]): R = {
+    testWith(new MemoryMessageSender())
+  }
+
+  def withWorkerService[R](queue: Queue, vhs: RecorderVhs, msgSender: MemoryMessageSender)(
+    testWith: TestWith[RecorderWorkerService[String], R]): R =
     withActorSystem { implicit actorSystem =>
       implicit val streamStore = MemoryTypedStoreCompanion[ObjectLocation, TransformedBaseWork]()
       withMessageStream[TransformedBaseWork, R](queue = queue) { msgStream =>
-        withRecorderVhs[R] { vhs =>
-          val msgSender = new MemoryMessageSender()
-          val workerService = new RecorderWorkerService(vhs, msgStream, msgSender)
-          workerService.run()
-          testWith((workerService, vhs))
-        }
+        val workerService = new RecorderWorkerService(vhs, msgStream, msgSender)
+        workerService.run()
+        testWith(workerService)
       }
     }
 }

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/fixtures/WorkerServiceFixture.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/fixtures/WorkerServiceFixture.scala
@@ -12,6 +12,7 @@ import uk.ac.wellcome.bigmessaging.memory.MemoryTypedStoreCompanion
 import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
+import uk.ac.wellcome.messaging.MessageSender
 
 import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryVersionedStore}
 import uk.ac.wellcome.storage.{
@@ -61,10 +62,10 @@ trait WorkerServiceFixture extends BigMessagingFixture {
     testWith(new MemoryMessageSender())
   }
 
-  def withWorkerService[R](queue: Queue,
-                           vhs: RecorderVhs,
-                           msgSender: MemoryMessageSender)(
-    testWith: TestWith[RecorderWorkerService[String], R]): R =
+  def withWorkerService[R, D](queue: Queue,
+                              vhs: RecorderVhs,
+                              msgSender: MessageSender[D])(
+    testWith: TestWith[RecorderWorkerService[D], R]): R =
     withActorSystem { implicit actorSystem =>
       implicit val streamStore =
         MemoryTypedStoreCompanion[ObjectLocation, TransformedBaseWork]()

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/fixtures/WorkerServiceFixture.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/fixtures/WorkerServiceFixture.scala
@@ -14,7 +14,7 @@ import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 
 import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryVersionedStore}
-import uk.ac.wellcome.storage.{ObjectLocation, StoreWriteError, Version}
+import uk.ac.wellcome.storage.{ObjectLocation, Identified, StoreWriteError, Version}
 import uk.ac.wellcome.storage.store.{HybridStoreEntry, VersionedStore}
 import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
 
@@ -69,4 +69,29 @@ trait WorkerServiceFixture extends BigMessagingFixture {
         testWith(workerService)
       }
     }
+
+  def assertWorkStored[T <: TransformedBaseWork](
+    vhs: RecorderVhs,
+    work: T,
+    expectedVhsVersion: Int = 0): Version[String, Int] = {
+
+    val id = work.sourceIdentifier.toString
+    vhs.getLatest(id) shouldBe
+      Right(
+        Identified(
+          Version(id, expectedVhsVersion),
+          HybridStoreEntry(work, EmptyMetadata())))
+    Version(id, expectedVhsVersion)
+  }
+
+  def assertWorkNotStored[T <: TransformedBaseWork](vhs: RecorderVhs,
+                                                            work: T) = {
+
+    val id = work.sourceIdentifier.toString
+    val workExists = vhs.getLatest(id) match {
+      case Left(_)  => false
+      case Right(_) => true
+    }
+    workExists shouldBe false
+  }
 }

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/fixtures/WorkerServiceFixture.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/fixtures/WorkerServiceFixture.scala
@@ -43,7 +43,6 @@ trait WorkerServiceFixture extends BigMessagingFixture {
       Success(ObjectLocation("test", s"${key.id}/${key.version}"))
   }
 
-
   class BrokenMemoryRecorderVhs extends MemoryRecorderVhs() {
     override def put(id: Version[String, Int])(entry: Entry): WriteEither =
       Left(StoreWriteError(new Error("BOOM!")))

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/fixtures/WorkerServiceFixture.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/fixtures/WorkerServiceFixture.scala
@@ -94,10 +94,6 @@ trait WorkerServiceFixture extends BigMessagingFixture {
                                                     work: T) = {
 
     val id = work.sourceIdentifier.toString
-    val workExists = vhs.getLatest(id) match {
-      case Left(_)  => false
-      case Right(_) => true
-    }
-    workExists shouldBe false
+    vhs.getLatest(id) shouldBe a[Left[_, _]]
   }
 }

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/fixtures/WorkerServiceFixture.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/fixtures/WorkerServiceFixture.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.recorder.fixtures
 
-import scala.util.{Try, Success}
+import scala.util.{Success, Try}
 
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.models.Implicits._
@@ -13,9 +13,9 @@ import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 
-import uk.ac.wellcome.storage.store.memory.{MemoryVersionedStore, MemoryStore}
-import uk.ac.wellcome.storage.{Version, ObjectLocation, StoreWriteError}
-import uk.ac.wellcome.storage.store.{VersionedStore, HybridStoreEntry}
+import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryVersionedStore}
+import uk.ac.wellcome.storage.{ObjectLocation, StoreWriteError, Version}
+import uk.ac.wellcome.storage.store.{HybridStoreEntry, VersionedStore}
 import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
 
 trait WorkerServiceFixture extends BigMessagingFixture {
@@ -24,13 +24,15 @@ trait WorkerServiceFixture extends BigMessagingFixture {
 
   type RecorderVhs = VersionedStore[String, Int, Entry] with GetLocation
 
-  type InternalStore = MemoryStore[Version[String, Int], Entry] with MemoryMaxima[String, Entry]
+  type InternalStore =
+    MemoryStore[Version[String, Int], Entry] with MemoryMaxima[String, Entry]
 
   class MemoryRecorderVhs(
     internalStore: InternalStore =
       new MemoryStore[Version[String, Int], Entry](Map.empty)
-        with MemoryMaxima[String, Entry]
-  ) extends MemoryVersionedStore[String, Entry](internalStore) with GetLocation {
+      with MemoryMaxima[String, Entry]
+  ) extends MemoryVersionedStore[String, Entry](internalStore)
+      with GetLocation {
 
     def getLocation(key: Version[String, Int]): Try[ObjectLocation] =
       Success(ObjectLocation("test", s"${key.id}/${key.version}"))
@@ -49,14 +51,18 @@ trait WorkerServiceFixture extends BigMessagingFixture {
     testWith(new BrokenMemoryRecorderVhs())
   }
 
-  def withMemoryMessageSender[R](testWith: TestWith[MemoryMessageSender, R]): R = {
+  def withMemoryMessageSender[R](
+    testWith: TestWith[MemoryMessageSender, R]): R = {
     testWith(new MemoryMessageSender())
   }
 
-  def withWorkerService[R](queue: Queue, vhs: RecorderVhs, msgSender: MemoryMessageSender)(
+  def withWorkerService[R](queue: Queue,
+                           vhs: RecorderVhs,
+                           msgSender: MemoryMessageSender)(
     testWith: TestWith[RecorderWorkerService[String], R]): R =
     withActorSystem { implicit actorSystem =>
-      implicit val streamStore = MemoryTypedStoreCompanion[ObjectLocation, TransformedBaseWork]()
+      implicit val streamStore =
+        MemoryTypedStoreCompanion[ObjectLocation, TransformedBaseWork]()
       withMessageStream[TransformedBaseWork, R](queue = queue) { msgStream =>
         val workerService = new RecorderWorkerService(vhs, msgStream, msgSender)
         workerService.run()

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/fixtures/WorkerServiceFixture.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/fixtures/WorkerServiceFixture.scala
@@ -69,7 +69,7 @@ trait WorkerServiceFixture extends BigMessagingFixture {
     withActorSystem { implicit actorSystem =>
       implicit val streamStore =
         MemoryTypedStoreCompanion[ObjectLocation, TransformedBaseWork]()
-      withMessageStream[TransformedBaseWork, R](queue = queue) { msgStream =>
+      withBigMessageStream[TransformedBaseWork, R](queue = queue) { msgStream =>
         val workerService = new RecorderWorkerService(vhs, msgStream, msgSender)
         workerService.run()
         testWith(workerService)

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/fixtures/WorkerServiceFixture.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/fixtures/WorkerServiceFixture.scala
@@ -1,15 +1,13 @@
 package uk.ac.wellcome.platform.recorder.fixtures
 
 import scala.util.{Success, Try}
-import io.circe.generic.semiauto.{deriveEncoder, deriveDecoder}
-import io.circe.{Encoder, Decoder}
 
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.platform.recorder.services.RecorderWorkerService
-import uk.ac.wellcome.bigmessaging.typesafe.{EmptyMetadata, GetLocation}
 
+import uk.ac.wellcome.bigmessaging.typesafe.{EmptyMetadata, GetLocation}
 import uk.ac.wellcome.bigmessaging.memory.MemoryTypedStoreCompanion
 import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
@@ -24,7 +22,6 @@ import uk.ac.wellcome.storage.{
 }
 import uk.ac.wellcome.storage.store.{HybridStoreEntry, VersionedStore}
 import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
-import uk.ac.wellcome.storage.streaming.Codec
 
 trait WorkerServiceFixture extends BigMessagingFixture {
 
@@ -51,12 +48,6 @@ trait WorkerServiceFixture extends BigMessagingFixture {
     override def put(id: Version[String, Int])(entry: Entry): WriteEither =
       Left(StoreWriteError(new Error("BOOM!")))
   }
-
-  // Cache these here to improve compilation times (otherwise they are
-  // re-derived every time they are required)
-  implicit val workEncoder: Encoder[TransformedBaseWork] = deriveEncoder
-  implicit val workDecoder: Decoder[TransformedBaseWork] = deriveDecoder
-  implicit val workCodec: Codec[TransformedBaseWork] = Codec.typeCodec
 
   def withRecorderVhs[R](testWith: TestWith[RecorderVhs, R]): R = {
     testWith(new MemoryRecorderVhs())

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
@@ -10,13 +10,13 @@ import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.recorder.fixtures.WorkerServiceFixture
-import uk.ac.wellcome.platform.recorder.EmptyMetadata
 
 import uk.ac.wellcome.storage.{Identified, ObjectLocation, Version}
 import uk.ac.wellcome.storage.store.HybridStoreEntry
 
 import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
+import uk.ac.wellcome.bigmessaging.typesafe.EmptyMetadata
 
 class RecorderWorkerServiceTest
     extends FunSpec

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
@@ -64,13 +64,10 @@ class RecorderWorkerServiceTest
             val newerWork =
               olderWork.copy(version = 10, title = "A nice new thing")
             sendMessage[TransformedBaseWork](queue = queue, newerWork)
-            eventually {
-              assertWorkStored(vhs, newerWork)
-              sendMessage[TransformedBaseWork](queue = queue, obj = olderWork)
-              eventually {
-                assertWorkStored(vhs, newerWork)
-              }
-            }
+            eventually { assertWorkStored(vhs, newerWork) }
+            sendMessage[TransformedBaseWork](queue = queue, obj = olderWork)
+            eventually { assertQueueEmpty(queue) }
+            assertWorkStored(vhs, newerWork, 1)
           }
         }
       }

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
@@ -1,3 +1,4 @@
+/*
 package uk.ac.wellcome.platform.recorder.services
 
 import com.gu.scanamo.Scanamo
@@ -189,3 +190,4 @@ class RecorderWorkerServiceTest
     getMessages[T](topic) should contain(expectedWork)
   }
 }
+*/

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
@@ -11,12 +11,10 @@ import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.recorder.fixtures.WorkerServiceFixture
 
-import uk.ac.wellcome.storage.{Identified, ObjectLocation, Version}
-import uk.ac.wellcome.storage.store.HybridStoreEntry
+import uk.ac.wellcome.storage.ObjectLocation
 
 import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
-import uk.ac.wellcome.bigmessaging.typesafe.EmptyMetadata
 
 class RecorderWorkerServiceTest
     extends FunSpec
@@ -144,29 +142,5 @@ class RecorderWorkerServiceTest
         }
       }
     }
-  }
-
-  private def assertWorkStored[T <: TransformedBaseWork](
-    vhs: RecorderVhs,
-    work: T,
-    expectedVhsVersion: Int = 0) = {
-
-    val id = work.sourceIdentifier.toString
-    vhs.getLatest(id) shouldBe
-      Right(
-        Identified(
-          Version(id, expectedVhsVersion),
-          HybridStoreEntry(work, EmptyMetadata())))
-  }
-
-  private def assertWorkNotStored[T <: TransformedBaseWork](vhs: RecorderVhs,
-                                                            work: T) = {
-
-    val id = work.sourceIdentifier.toString
-    val workExists = vhs.getLatest(id) match {
-      case Left(_)  => false
-      case Right(_) => true
-    }
-    workExists shouldBe false
   }
 }

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
@@ -1,51 +1,49 @@
-/*
 package uk.ac.wellcome.platform.recorder.services
 
-import com.gu.scanamo.Scanamo
-import io.circe.Decoder
-import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+//import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
+
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.models.Implicits._
-import uk.ac.wellcome.messaging.fixtures.SNS.Topic
-import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
-import uk.ac.wellcome.messaging.fixtures.{Messaging, SQS}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.recorder.fixtures.WorkerServiceFixture
-import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
-import uk.ac.wellcome.storage.fixtures.LocalVersionedHybridStore
-import uk.ac.wellcome.storage.fixtures.S3.Bucket
-import uk.ac.wellcome.storage.vhs.HybridRecord
+import uk.ac.wellcome.platform.recorder.EmptyMetadata
+
+import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
+import uk.ac.wellcome.storage.{Version, Identified}
+import uk.ac.wellcome.storage.store.HybridStoreEntry
+
+import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
+import uk.ac.wellcome.messaging.fixtures.SQS
+import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
 
 class RecorderWorkerServiceTest
     extends FunSpec
     with Matchers
     with MockitoSugar
     with Akka
-    with LocalVersionedHybridStore
     with SQS
     with ScalaFutures
-    with Messaging
+    with BigMessagingFixture
     with MetricsSenderFixture
-    with IntegrationPatience
+    //with IntegrationPatience
     with WorkerServiceFixture
     with WorksGenerators {
 
   it("records an UnidentifiedWork") {
-    withLocalDynamoDbTable { table =>
-      withLocalSnsTopic { topic =>
-        withLocalS3Bucket { storageBucket =>
-          withLocalSqsQueue { queue =>
-            withLocalSnsTopic { topic =>
-              val work = createUnidentifiedWork
-              sendMessage[TransformedBaseWork](queue = queue, obj = work)
-              withWorkerService(table, storageBucket, topic, queue) { _ =>
-                eventually {
-                  assertStoredSingleWork(topic, table, work)
-                }
+    withLocalSnsTopic { topic =>
+      withLocalS3Bucket { storageBucket =>
+        withLocalSqsQueue { queue =>
+          withLocalSnsTopic { topic =>
+            val work = createUnidentifiedWork
+            sendMessage[TransformedBaseWork](queue = queue, obj = work)
+            withWorkerService(storageBucket, topic, queue) { case  (service, vhs) =>
+              eventually {
+                assertWorkStored(vhs, work)
               }
             }
           }
@@ -55,17 +53,15 @@ class RecorderWorkerServiceTest
   }
 
   it("stores UnidentifiedInvisibleWorks") {
-    withLocalDynamoDbTable { table =>
-      withLocalSnsTopic { topic =>
-        withLocalS3Bucket { storageBucket =>
-          withLocalSqsQueue { queue =>
-            withLocalSnsTopic { topic =>
-              withWorkerService(table, storageBucket, topic, queue) { service =>
-                val invisibleWork = createUnidentifiedInvisibleWork
-                sendMessage[TransformedBaseWork](queue = queue, invisibleWork)
-                eventually {
-                  assertStoredSingleWork(topic, table, invisibleWork)
-                }
+    withLocalSnsTopic { topic =>
+      withLocalS3Bucket { storageBucket =>
+        withLocalSqsQueue { queue =>
+          withLocalSnsTopic { topic =>
+            withWorkerService(storageBucket, topic, queue) { case (service, vhs) =>
+              val invisibleWork = createUnidentifiedInvisibleWork
+              sendMessage[TransformedBaseWork](queue = queue, invisibleWork)
+              eventually {
+                assertWorkStored(vhs, invisibleWork)
               }
             }
           }
@@ -77,22 +73,19 @@ class RecorderWorkerServiceTest
   it("doesn't overwrite a newer work with an older work") {
     val olderWork = createUnidentifiedWork
     val newerWork = olderWork.copy(version = 10, title = "A nice new thing")
-
-    withLocalDynamoDbTable { table =>
-      withLocalSnsTopic { topic =>
-        withLocalS3Bucket { storageBucket =>
-          withLocalSqsQueue { queue =>
-            withLocalSnsTopic { topic =>
-              withWorkerService(table, storageBucket, topic, queue) { _ =>
-                sendMessage[TransformedBaseWork](queue = queue, newerWork)
+    withLocalSnsTopic { topic =>
+      withLocalS3Bucket { storageBucket =>
+        withLocalSqsQueue { queue =>
+          withLocalSnsTopic { topic =>
+            withWorkerService(storageBucket, topic, queue) { case (service, vhs) =>
+              sendMessage[TransformedBaseWork](queue = queue, newerWork)
+              eventually {
+                assertWorkStored(vhs, newerWork)
+                sendMessage[TransformedBaseWork](
+                  queue = queue,
+                  obj = olderWork)
                 eventually {
-                  assertStoredSingleWork(topic, table, newerWork)
-                  sendMessage[TransformedBaseWork](
-                    queue = queue,
-                    obj = olderWork)
-                  eventually {
-                    assertStoredSingleWork(topic, table, newerWork)
-                  }
+                  assertWorkStored(vhs, newerWork)
                 }
               }
             }
@@ -105,23 +98,19 @@ class RecorderWorkerServiceTest
   it("overwrites an older work with an newer work") {
     val olderWork = createUnidentifiedWork
     val newerWork = olderWork.copy(version = 10, title = "A nice new thing")
-
-    withLocalDynamoDbTable { table =>
-      withLocalS3Bucket { storageBucket =>
-        withLocalSqsQueue { queue =>
-          withLocalSnsTopic { topic =>
-            withWorkerService(table, storageBucket, topic, queue) { _ =>
-              sendMessage[TransformedBaseWork](queue = queue, obj = olderWork)
+    withLocalS3Bucket { storageBucket =>
+      withLocalSqsQueue { queue =>
+        withLocalSnsTopic { topic =>
+          withWorkerService(storageBucket, topic, queue) { case (service, vhs) =>
+            sendMessage[TransformedBaseWork](queue = queue, obj = olderWork)
+            eventually {
+              assertWorkStored(vhs, olderWork)
+              sendMessage[TransformedBaseWork](queue = queue, obj = newerWork)
               eventually {
-                assertStoredSingleWork(topic, table, olderWork)
-                sendMessage[TransformedBaseWork](queue = queue, obj = newerWork)
-                eventually {
-                  assertStoredSingleWork(
-                    topic,
-                    table,
-                    newerWork,
-                    expectedVhsVersion = 2)
-                }
+                assertWorkStored(
+                  vhs,
+                  newerWork,
+                  expectedVhsVersion = 1)
               }
             }
           }
@@ -130,21 +119,20 @@ class RecorderWorkerServiceTest
     }
   }
 
+  /*
   it("fails if saving to S3 fails") {
-    withLocalDynamoDbTable { table =>
-      withLocalSnsTopic { topic =>
-        val badBucket = Bucket(name = "bad-bukkit")
-        withLocalSqsQueueAndDlq {
-          case QueuePair(queue, dlq) =>
-            withWorkerService(table, badBucket, topic, queue) { _ =>
-              val work = createUnidentifiedWork
-              sendMessage[TransformedBaseWork](queue = queue, obj = work)
-              eventually {
-                assertQueueEmpty(queue)
-                assertQueueHasSize(dlq, 1)
-              }
+    withLocalSnsTopic { topic =>
+      val badBucket = Bucket(name = "bad-bukkit")
+      withLocalSqsQueueAndDlq {
+        case QueuePair(queue, dlq) =>
+          withWorkerService(badBucket, topic, queue) { case (service, vhs) =>
+            val work = createUnidentifiedWork
+            sendMessage[TransformedBaseWork](queue = queue, obj = work)
+            eventually {
+              assertQueueEmpty(queue)
+              assertQueueHasSize(dlq, 1)
             }
-        }
+          }
       }
     }
   }
@@ -167,27 +155,17 @@ class RecorderWorkerServiceTest
       }
     }
   }
+  */
 
-  private def assertStoredSingleWork[T <: TransformedBaseWork](
-    topic: Topic,
-    table: Table,
-    expectedWork: T,
-    expectedVhsVersion: Int = 1)(implicit decoder: Decoder[T]) = {
-    val actualRecords: List[HybridRecord] =
-      Scanamo
-        .scan[HybridRecord](dynamoDbClient)(table.name)
-        .map(_.right.get)
+  private def assertWorkStored[T <: TransformedBaseWork](
+    vhs: RecorderVhs,
+    work: T,
+    expectedVhsVersion: Int = 0) = {
 
-    actualRecords.size shouldBe 1
-
-    val hybridRecord: HybridRecord = actualRecords.head
-    hybridRecord.id shouldBe expectedWork.sourceIdentifier.toString
-    hybridRecord.version shouldBe expectedVhsVersion
-
-    val actualEntry = getObjectFromS3[T](hybridRecord.location)
-
-    actualEntry shouldBe expectedWork
-    getMessages[T](topic) should contain(expectedWork)
+    val id = work.sourceIdentifier.toString
+    vhs.getLatest(id) shouldBe
+      Right(Identified(
+        Version(id, expectedVhsVersion),
+        HybridStoreEntry(work, EmptyMetadata())))
   }
 }
-*/

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
@@ -1,14 +1,11 @@
 package uk.ac.wellcome.platform.recorder.services
 
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 
-import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.recorder.fixtures.WorkerServiceFixture
 
 import uk.ac.wellcome.storage.ObjectLocation
@@ -19,12 +16,8 @@ import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
 class RecorderWorkerServiceTest
     extends FunSpec
     with Matchers
-    with MockitoSugar
-    with Akka
-    with SQS
     with ScalaFutures
     with BigMessagingFixture
-    with MetricsSenderFixture
     with IntegrationPatience
     with WorkerServiceFixture
     with WorksGenerators {

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
@@ -7,6 +7,7 @@ import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.recorder.fixtures.WorkerServiceFixture
+import uk.ac.wellcome.json.JsonUtil._
 
 import uk.ac.wellcome.storage.ObjectLocation
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -275,8 +275,7 @@ object CatalogueDependencies {
       WellcomeDependencies.messagingTypesafeLibrary
 
   val recorderDependencies: Seq[ModuleID] =
-    ExternalDependencies.mockitoDependencies ++
-      WellcomeDependencies.messagingTypesafeLibrary
+    ExternalDependencies.mockitoDependencies
 
   val reindexWorkerDependencies: Seq[ModuleID] =
     ExternalDependencies.mockitoDependencies ++


### PR DESCRIPTION
## Issues

https://github.com/wellcometrust/platform/issues/3628
https://github.com/wellcometrust/platform/issues/3819

## Description


Upgrades `recorder` to use:
* `scala-messaging`  v5.3.1
* `scala-storage` v7.19.0