### PR TITLE
put both APIs on the same index and container version

### DIFF
--- a/api/terraform/locals.tf
+++ b/api/terraform/locals.tf
@@ -10,11 +10,11 @@ locals {
 
   production_api     = "romulus"
   pinned_nginx       = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_api-gw:bad0dbfa548874938d16496e313b05adb71268b7"
-  pinned_remus_api   = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/api:292324924a0a3346c22b881e0b327354593ebce7"
+  pinned_remus_api   = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/api:437a5fc8fa81bd24420e449e586b958b7aa59fca"
   pinned_romulus_api = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/api:437a5fc8fa81bd24420e449e586b958b7aa59fca"
   romulus_es_config = {
     index_v1 = "v1-2019-01-24-production-changes"
-    index_v2 = "v2-2019-04-26-contributors-label-from-multiple-subfields"
+    index_v2 = "v2-20190816-alternative-titles"
     doc_type = "work"
   }
   remus_es_config = {

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -3,7 +3,7 @@ module "catalogue_pipeline_20190816" {
 
   namespace = "catalogue-20190816"
 
-  release_label = "latest"
+  release_label = "prod"
 
   account_id      = "${data.aws_caller_identity.current.account_id}"
   aws_region      = "${local.aws_region}"


### PR DESCRIPTION
Causing issues with being able to bump versions because the data is now out of date and not backwards incompatible.