### PR TITLE
Recorder should send MessageNotification rather than ObjectLocation

### DIFF
--- a/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerService.scala
+++ b/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerService.scala
@@ -10,7 +10,7 @@ import uk.ac.wellcome.json.JsonUtil._
 
 import uk.ac.wellcome.bigmessaging.typesafe.{EmptyMetadata, GetLocation}
 import uk.ac.wellcome.messaging.MessageSender
-import uk.ac.wellcome.bigmessaging.message.BigMessageStream
+import uk.ac.wellcome.bigmessaging.message.{BigMessageStream, MessageNotification, RemoteNotification}
 
 import uk.ac.wellcome.storage.store.{HybridStoreEntry, VersionedStore}
 import uk.ac.wellcome.storage.{Identified, Version}
@@ -32,7 +32,7 @@ class RecorderWorkerService[MsgDestination](
       for {
         key <- storeWork(work)
         location <- store.getLocation(key)
-        _ <- msgSender.sendT(location)
+        _ <- msgSender.sendT[MessageNotification](RemoteNotification(location))
       } yield ()
     }
 

--- a/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerService.scala
+++ b/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerService.scala
@@ -10,7 +10,11 @@ import uk.ac.wellcome.json.JsonUtil._
 
 import uk.ac.wellcome.bigmessaging.typesafe.{EmptyMetadata, GetLocation}
 import uk.ac.wellcome.messaging.MessageSender
-import uk.ac.wellcome.bigmessaging.message.{BigMessageStream, MessageNotification, RemoteNotification}
+import uk.ac.wellcome.bigmessaging.message.{
+  BigMessageStream,
+  MessageNotification,
+  RemoteNotification
+}
 
 import uk.ac.wellcome.storage.store.{HybridStoreEntry, VersionedStore}
 import uk.ac.wellcome.storage.{Identified, Version}

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderIntegrationTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderIntegrationTest.scala
@@ -13,7 +13,10 @@ import uk.ac.wellcome.platform.recorder.fixtures.WorkerServiceFixture
 
 import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
 import uk.ac.wellcome.bigmessaging.typesafe.VHSBuilder
-import uk.ac.wellcome.bigmessaging.message.{MessageNotification, RemoteNotification}
+import uk.ac.wellcome.bigmessaging.message.{
+  MessageNotification,
+  RemoteNotification
+}
 import uk.ac.wellcome.storage.fixtures.DynamoFixtures
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
 import uk.ac.wellcome.storage.ObjectLocationPrefix
@@ -61,7 +64,8 @@ class RecorderIntegrationTest
                   val messages = listMessagesReceivedFromSNS(topic)
                     .map(_.message)
                     .map(fromJson[MessageNotification](_).get)
-                  messages.toList shouldBe List(RemoteNotification(location.get))
+                  messages.toList shouldBe List(
+                    RemoteNotification(location.get))
                 }
               }
             }

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderIntegrationTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderIntegrationTest.scala
@@ -13,9 +13,10 @@ import uk.ac.wellcome.platform.recorder.fixtures.WorkerServiceFixture
 
 import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
 import uk.ac.wellcome.bigmessaging.typesafe.VHSBuilder
+import uk.ac.wellcome.bigmessaging.message.{MessageNotification, RemoteNotification}
 import uk.ac.wellcome.storage.fixtures.DynamoFixtures
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
-import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
+import uk.ac.wellcome.storage.ObjectLocationPrefix
 
 class RecorderIntegrationTest
     extends FunSpec
@@ -59,8 +60,8 @@ class RecorderIntegrationTest
                   getObjectFromS3[TransformedBaseWork](location.get) shouldBe work
                   val messages = listMessagesReceivedFromSNS(topic)
                     .map(_.message)
-                    .map(fromJson[ObjectLocation](_).get)
-                  messages.toList shouldBe List(location.get)
+                    .map(fromJson[MessageNotification](_).get)
+                  messages.toList shouldBe List(RemoteNotification(location.get))
                 }
               }
             }

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
@@ -12,7 +12,10 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.storage.ObjectLocation
 
 import uk.ac.wellcome.messaging.fixtures.SQS
-import uk.ac.wellcome.bigmessaging.message.{MessageNotification, RemoteNotification}
+import uk.ac.wellcome.bigmessaging.message.{
+  MessageNotification,
+  RemoteNotification
+}
 import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
 
 class RecorderWorkerServiceTest

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
@@ -12,6 +12,7 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.storage.ObjectLocation
 
 import uk.ac.wellcome.messaging.fixtures.SQS
+import uk.ac.wellcome.bigmessaging.message.{MessageNotification, RemoteNotification}
 import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
 
 class RecorderWorkerServiceTest
@@ -116,7 +117,7 @@ class RecorderWorkerServiceTest
     }
   }
 
-  it("sends the object location to the queue") {
+  it("sends the remote notification to the queue") {
     withLocalSqsQueue { queue =>
       withMemoryMessageSender { msgSender =>
         withRecorderVhs { vhs =>
@@ -125,8 +126,8 @@ class RecorderWorkerServiceTest
             sendMessage[TransformedBaseWork](queue = queue, obj = work)
             eventually {
               val id = work.sourceIdentifier.toString
-              msgSender.getMessages[ObjectLocation].toList shouldBe List(
-                ObjectLocation("test", s"${id}/${0}")
+              msgSender.getMessages[MessageNotification].toList shouldBe List(
+                RemoteNotification(ObjectLocation("test", s"${id}/${0}"))
               )
             }
           }


### PR DESCRIPTION
The `matcher` is expecting an `MessageNotification` rather than an `ObjectLocation`.

Here we wrap the `ObjectLocation` inside a `RemoteNotification` so the matcher can decode it correctly.