### PR TITLE
Update merger messaging and storage libs

### DIFF
--- a/.sbt_metadata/merger.json
+++ b/.sbt_metadata/merger.json
@@ -2,6 +2,7 @@
   "id" : "merger",
   "folder" : "pipeline/merger",
   "dependencyIds" : [
-    "internal_model"
+    "internal_model",
+    "big_messaging_typesafe"
   ]
 }

--- a/build.sbt
+++ b/build.sbt
@@ -94,7 +94,7 @@ lazy val matcher = setupProject(project, "pipeline/matcher",
 )
 
 lazy val merger = setupProject(project, "pipeline/merger",
-  localDependencies = Seq(internal_model),
+  localDependencies = Seq(internal_model, big_messaging_typesafe),
   externalDependencies = CatalogueDependencies.mergerDependencies
 )
 

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/Main.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/Main.scala
@@ -13,7 +13,7 @@ import uk.ac.wellcome.models.Implicits._
 
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.typesafe.SQSBuilder
-import uk.ac.wellcome.bigmessaging.typesafe.{VHSBuilder, BigMessagingBuilder}
+import uk.ac.wellcome.bigmessaging.typesafe.{BigMessagingBuilder, VHSBuilder}
 
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.typesafe.S3Builder

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/Main.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/Main.scala
@@ -3,17 +3,20 @@ package uk.ac.wellcome.platform.merger
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.Config
-import uk.ac.wellcome.messaging.sns.NotificationMessage
-import uk.ac.wellcome.messaging.typesafe.{MessagingBuilder, SQSBuilder}
+import scala.concurrent.ExecutionContext
+
 import uk.ac.wellcome.models.work.internal.{BaseWork, TransformedBaseWork}
 import uk.ac.wellcome.platform.merger.services._
-import uk.ac.wellcome.storage.typesafe.VHSBuilder
-import uk.ac.wellcome.storage.vhs.EmptyMetadata
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 import uk.ac.wellcome.models.Implicits._
 
-import scala.concurrent.ExecutionContext
+import uk.ac.wellcome.messaging.sns.NotificationMessage
+import uk.ac.wellcome.messaging.typesafe.SQSBuilder
+import uk.ac.wellcome.bigmessaging.typesafe.{VHSBuilder, BigMessagingBuilder}
+
+import uk.ac.wellcome.storage.store.s3.S3TypedStore
+import uk.ac.wellcome.storage.typesafe.S3Builder
 
 object Main extends WellcomeTypesafeApp {
   runWithConfig { config: Config =>
@@ -23,10 +26,13 @@ object Main extends WellcomeTypesafeApp {
       AkkaBuilder.buildExecutionContext()
     implicit val materializer: ActorMaterializer =
       AkkaBuilder.buildActorMaterializer()
+    implicit val s3Client =
+      S3Builder.buildS3Client(config)
+    implicit val msgStore =
+      S3TypedStore[BaseWork]
 
     val playbackService = new RecorderPlaybackService(
-      versionedHybridStore =
-        VHSBuilder.buildVHS[TransformedBaseWork, EmptyMetadata](config)
+      vhs = VHSBuilder.build[TransformedBaseWork](config)
     )
 
     val mergerManager = new MergerManager(
@@ -37,7 +43,7 @@ object Main extends WellcomeTypesafeApp {
       sqsStream = SQSBuilder.buildSQSStream[NotificationMessage](config),
       playbackService = playbackService,
       mergerManager = mergerManager,
-      messageWriter = MessagingBuilder.buildMessageWriter[BaseWork](config)
+      msgSender = BigMessagingBuilder.buildBigMessageSender[BaseWork](config)
     )
   }
 }

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerService.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerService.scala
@@ -39,7 +39,7 @@ class MergerWorkerService[Destination](
     } yield ()
 
   private def sendWorks(mergedWorks: Seq[BaseWork]) =
-    Future.sequence(mergedWorks.map {
-      work => Future.fromTry(msgSender.sendT(work))
+    Future.sequence(mergedWorks.map { work =>
+      Future.fromTry(msgSender.sendT(work))
     })
 }

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerService.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerService.scala
@@ -1,22 +1,23 @@
 package uk.ac.wellcome.platform.merger.services
 
 import akka.Done
-import uk.ac.wellcome.messaging.message.MessageWriter
-import uk.ac.wellcome.messaging.sns.NotificationMessage
-import uk.ac.wellcome.messaging.sqs.SQSStream
+import scala.concurrent.{ExecutionContext, Future}
+
 import uk.ac.wellcome.models.matcher.{MatchedIdentifiers, MatcherResult}
 import uk.ac.wellcome.models.work.internal.BaseWork
 import uk.ac.wellcome.typesafe.Runnable
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.models.Implicits._
 
-import scala.concurrent.{ExecutionContext, Future}
+import uk.ac.wellcome.bigmessaging.BigMessageSender
+import uk.ac.wellcome.messaging.sns.NotificationMessage
+import uk.ac.wellcome.messaging.sqs.SQSStream
 
-class MergerWorkerService(
+class MergerWorkerService[Destination](
   sqsStream: SQSStream[NotificationMessage],
   playbackService: RecorderPlaybackService,
   mergerManager: MergerManager,
-  messageWriter: MessageWriter[BaseWork]
+  msgSender: BigMessageSender[Destination, BaseWork]
 )(implicit ec: ExecutionContext)
     extends Runnable {
 
@@ -37,11 +38,8 @@ class MergerWorkerService(
       _ <- sendWorks(works)
     } yield ()
 
-  private def sendWorks(mergedWorks: Seq[BaseWork]) = {
-    Future
-      .sequence(
-        mergedWorks.map(
-          messageWriter.write(_, "merged-work")
-        ))
-  }
+  private def sendWorks(mergedWorks: Seq[BaseWork]) =
+    Future.sequence(mergedWorks.map {
+      work => Future.fromTry(msgSender.sendT(work))
+    })
 }

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackService.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackService.scala
@@ -1,12 +1,11 @@
 package uk.ac.wellcome.platform.merger.services
 
-import scala.util.Try
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.models.matcher.WorkIdentifier
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 
 import uk.ac.wellcome.bigmessaging.EmptyMetadata
-import uk.ac.wellcome.storage.{Identified, NoVersionExistsError, Version}
+import uk.ac.wellcome.storage.{Identified, NoVersionExistsError}
 import uk.ac.wellcome.storage.store.{HybridStoreEntry, VersionedStore}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -31,7 +30,7 @@ class RecorderPlaybackService(
   def fetchAllWorks(workIdentifiers: Seq[WorkIdentifier])
     : Future[Seq[Option[TransformedBaseWork]]] = {
     Future.sequence(
-      workIdentifiers.map(id => Future.fromTry(Try(getWorkForIdentifier(id))))
+      workIdentifiers.map(id => Future { getWorkForIdentifier(id) })
     )
   }
 
@@ -45,7 +44,7 @@ class RecorderPlaybackService(
   private def getWorkForIdentifier(
     workIdentifier: WorkIdentifier): Option[TransformedBaseWork] =
     vhs.getLatest(workIdentifier.identifier) match {
-      case Right(Identified(Version(_, version), HybridStoreEntry(work, _))) =>
+      case Right(Identified(_, HybridStoreEntry(work, _))) =>
         if (work.version == workIdentifier.version) {
           Some(work)
         } else {

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackService.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackService.scala
@@ -6,7 +6,7 @@ import uk.ac.wellcome.models.matcher.WorkIdentifier
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 
 import uk.ac.wellcome.bigmessaging.EmptyMetadata
-import uk.ac.wellcome.storage.{Identified, Version, NoVersionExistsError}
+import uk.ac.wellcome.storage.{Identified, NoVersionExistsError, Version}
 import uk.ac.wellcome.storage.store.{HybridStoreEntry, VersionedStore}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -53,8 +53,9 @@ class RecorderPlaybackService(
             s"VHS version = ${work.version}, identifier version = ${workIdentifier.version}, so discarding work")
           None
         }
-      case Left(NoVersionExistsError(_)) => throw new NoSuchElementException(
-        s"Work ${workIdentifier.identifier} is not in VHS!")
+      case Left(NoVersionExistsError(_)) =>
+        throw new NoSuchElementException(
+          s"Work ${workIdentifier.identifier} is not in VHS!")
       case Left(readError) => throw readError.e
     }
 }

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackService.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackService.scala
@@ -1,13 +1,13 @@
 package uk.ac.wellcome.platform.merger.services
 
-import scala.util.{Try, Success, Failure}
+import scala.util.{Failure, Success, Try}
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.models.matcher.WorkIdentifier
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 
 import uk.ac.wellcome.bigmessaging.EmptyMetadata
-import uk.ac.wellcome.storage.{Version, Identified}
-import uk.ac.wellcome.storage.store.{VersionedStore, HybridStoreEntry}
+import uk.ac.wellcome.storage.{Identified, Version}
+import uk.ac.wellcome.storage.store.{HybridStoreEntry, VersionedStore}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -22,7 +22,8 @@ class RecorderPlaybackService(
   vhs: VersionedStore[String,
                       Int,
                       HybridStoreEntry[TransformedBaseWork, EmptyMetadata]])(
-  implicit ec: ExecutionContext) extends Logging {
+  implicit ec: ExecutionContext)
+    extends Logging {
 
   /** Given a collection of matched identifiers, return all the
     * corresponding works from VHS.
@@ -45,9 +46,8 @@ class RecorderPlaybackService(
     workIdentifier: WorkIdentifier): Try[Option[TransformedBaseWork]] =
     vhs.getLatest(workIdentifier.identifier) match {
       case Left(readError) => Failure(new Error(s"${readError}"))
-      case Right(Identified(Version(_, version), HybridStoreEntry(work, _))) => 
-        if (work.version == workIdentifier.version) { Success(Some(work)) }
-        else {
+      case Right(Identified(Version(_, version), HybridStoreEntry(work, _))) =>
+        if (work.version == workIdentifier.version) { Success(Some(work)) } else {
           debug(
             s"VHS version = ${work.version}, identifier version = ${workIdentifier.version}, so discarding work")
           Success(None)

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerIntegrationTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerIntegrationTest.scala
@@ -2,35 +2,32 @@ package uk.ac.wellcome.platform.merger
 
 import org.scalatest.FunSpec
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
-import uk.ac.wellcome.messaging.fixtures.Messaging
-import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.platform.merger.fixtures.{
-  LocalWorksVhs,
   MatcherResultFixture,
   WorkerServiceFixture
 }
-import uk.ac.wellcome.storage.fixtures.LocalVersionedHybridStore
 import uk.ac.wellcome.models.Implicits._
 
-class MergerFeatureTest
+import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
+import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
+
+class MergerIntegrationTest
     extends FunSpec
-    with Messaging
+    with BigMessagingFixture
     with IntegrationPatience
-    with LocalVersionedHybridStore
     with ScalaFutures
-    with LocalWorksVhs
     with MatcherResultFixture
     with WorkerServiceFixture
     with WorksGenerators {
 
   it("reads matcher result messages off a queue and deletes them") {
     withLocalSnsTopic { topic =>
-      withTransformedBaseWorkVHS { vhs =>
+      withVHS { vhs =>
         withLocalSqsQueueAndDlq {
           case QueuePair(queue, dlq) =>
-            withWorkerService(vhs, topic, queue) { _ =>
+            withWorkerService(vhs, queue, topic) { _ =>
               val work = createUnidentifiedWork
 
               givenStoredInVhs(vhs, work)

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/LocalWorksVhs.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/LocalWorksVhs.scala
@@ -6,7 +6,7 @@ import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.bigmessaging.fixtures.VHSFixture
 import uk.ac.wellcome.bigmessaging.EmptyMetadata
-import uk.ac.wellcome.storage.{Identified, Version}
+import uk.ac.wellcome.storage.Identified
 import uk.ac.wellcome.storage.store.HybridStoreEntry
 
 trait LocalWorksVhs
@@ -21,8 +21,7 @@ trait LocalWorksVhs
 
       vhs.getLatest(work.sourceIdentifier.toString) match {
         case Left(error) => throw new Error(s"${error}")
-        case Right(
-            Identified(Version(_, version), HybridStoreEntry(storedWork, _))) =>
+        case Right(Identified(_, HybridStoreEntry(storedWork, _))) =>
           storedWork shouldBe work
       }
     }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/LocalWorksVhs.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/LocalWorksVhs.scala
@@ -22,10 +22,8 @@ trait LocalWorksVhs
       vhs.getLatest(work.sourceIdentifier.toString) match {
         case Left(error) => throw new Error(s"${error}")
         case Right(
-            Identified(
-              Version(_, version),
-              HybridStoreEntry(storedWork, _))) =>
+            Identified(Version(_, version), HybridStoreEntry(storedWork, _))) =>
           storedWork shouldBe work
       }
-  }
+    }
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/LocalWorksVhs.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/LocalWorksVhs.scala
@@ -17,17 +17,15 @@ trait LocalWorksVhs
   def givenStoredInVhs(vhs: VHS, works: TransformedBaseWork*): Seq[Assertion] =
     works.map { work =>
       val entry = HybridStoreEntry(work, EmptyMetadata())
-      vhs.upsert(work.sourceIdentifier.toString)(entry)(_ => entry)
+      vhs.init(work.sourceIdentifier.toString)(entry)
 
-      eventually {
-        vhs.getLatest(work.sourceIdentifier.toString) match {
-          case Left(error) => throw new Error(s"${error}")
-          case Right(
-              Identified(
-                Version(_, version),
-                HybridStoreEntry(storedWork, _))) =>
-            storedWork shouldBe work
-        }
+      vhs.getLatest(work.sourceIdentifier.toString) match {
+        case Left(error) => throw new Error(s"${error}")
+        case Right(
+            Identified(
+              Version(_, version),
+              HybridStoreEntry(storedWork, _))) =>
+          storedWork shouldBe work
       }
-    }
+  }
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/LocalWorksVhs.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/LocalWorksVhs.scala
@@ -6,13 +6,13 @@ import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.bigmessaging.fixtures.VHSFixture
 import uk.ac.wellcome.bigmessaging.EmptyMetadata
-import uk.ac.wellcome.storage.{Version, Identified}
+import uk.ac.wellcome.storage.{Identified, Version}
 import uk.ac.wellcome.storage.store.HybridStoreEntry
 
 trait LocalWorksVhs
-  extends VHSFixture[TransformedBaseWork]
-  with Eventually
-  with ScalaFutures {
+    extends VHSFixture[TransformedBaseWork]
+    with Eventually
+    with ScalaFutures {
 
   def givenStoredInVhs(vhs: VHS, works: TransformedBaseWork*): Seq[Assertion] =
     works.map { work =>
@@ -22,7 +22,10 @@ trait LocalWorksVhs
       eventually {
         vhs.getLatest(work.sourceIdentifier.toString) match {
           case Left(error) => throw new Error(s"${error}")
-          case Right(Identified(Version(_, version), HybridStoreEntry(storedWork, _))) =>
+          case Right(
+              Identified(
+                Version(_, version),
+                HybridStoreEntry(storedWork, _))) =>
             storedWork shouldBe work
         }
       }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/WorkerServiceFixture.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/WorkerServiceFixture.scala
@@ -1,6 +1,8 @@
 package uk.ac.wellcome.platform.merger.fixtures
 
+import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
+import com.amazonaws.services.cloudwatch.model.StandardUnit
 
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.models.work.internal.BaseWork
@@ -11,14 +13,21 @@ import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSConfig}
 import uk.ac.wellcome.messaging.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 
+import uk.ac.wellcome.monitoring.Metrics
+import uk.ac.wellcome.monitoring.memory.MemoryMetrics
+
 trait WorkerServiceFixture extends LocalWorksVhs {
 
-  def withWorkerService[R](vhs: VHS, queue: Queue, topic: Topic)(
+  def withWorkerService[R](
+    vhs: VHS,
+    queue: Queue,
+    topic: Topic,
+    metrics: Metrics[Future, StandardUnit] = new MemoryMetrics[StandardUnit])(
     testWith: TestWith[MergerWorkerService[SNSConfig], R]): R =
     withLocalS3Bucket { bucket =>
       withSqsBigMessageSender[BaseWork, R](bucket, topic) { msgSender =>
         withActorSystem { implicit actorSystem =>
-          withSQSStream[NotificationMessage, R](queue) { sqsStream =>
+          withSQSStream[NotificationMessage, R](queue, metrics) { sqsStream =>
             val workerService = new MergerWorkerService(
               sqsStream = sqsStream,
               playbackService = new RecorderPlaybackService(vhs),

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/WorkerServiceFixture.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/WorkerServiceFixture.scala
@@ -1,51 +1,42 @@
 package uk.ac.wellcome.platform.merger.fixtures
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.messaging.sns.NotificationMessage
-import uk.ac.wellcome.messaging.fixtures.Messaging
-import uk.ac.wellcome.messaging.fixtures.SNS.Topic
-import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.models.work.internal.BaseWork
-import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.platform.merger.services._
 import uk.ac.wellcome.models.Implicits._
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSConfig}
+import uk.ac.wellcome.messaging.fixtures.SNS.Topic
+import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 
-trait WorkerServiceFixture extends LocalWorksVhs with Messaging {
-  def withWorkerService[R](vhs: TransformedBaseWorkVHS,
-                           topic: Topic,
-                           queue: Queue,
-                           metricsSender: MetricsSender)(
-    testWith: TestWith[MergerWorkerService, R]): R =
-    withLocalS3Bucket { messageBucket =>
-      withMessageWriter[BaseWork, R](messageBucket, topic) { messageWriter =>
+trait WorkerServiceFixture extends LocalWorksVhs {
+
+  def withWorkerService[R](vhs: VHS, queue: Queue, topic: Topic)(testWith: TestWith[MergerWorkerService[SNSConfig], R]): R =
+    withLocalS3Bucket { bucket =>
+      withSqsBigMessageSender[BaseWork, R](bucket, topic) { msgSender =>
         withActorSystem { implicit actorSystem =>
-          withSQSStream[NotificationMessage, R](
-            queue = queue,
-            metricsSender = metricsSender) { sqsStream =>
+          withSQSStream[NotificationMessage, R](queue) { sqsStream =>
             val workerService = new MergerWorkerService(
               sqsStream = sqsStream,
               playbackService = new RecorderPlaybackService(vhs),
               mergerManager = new MergerManager(PlatformMerger),
-              messageWriter = messageWriter
+              msgSender = msgSender
             )
-
             workerService.run()
+            testWith(workerService)
+        }
+      }
+    }
+  }
 
+  def withWorkerService[R](vhs: VHS)(testWith: TestWith[MergerWorkerService[SNSConfig], R]): R =
+      withLocalSqsQueue { queue =>
+        withLocalSnsTopic { topic =>
+          withWorkerService(vhs, queue, topic) { workerService =>
             testWith(workerService)
           }
         }
       }
-    }
-
-  def withWorkerService[R](
-    vhs: TransformedBaseWorkVHS,
-    topic: Topic,
-    queue: Queue)(testWith: TestWith[MergerWorkerService, R]): R =
-    withMetricsSender() { metricsSender =>
-      withWorkerService(vhs, topic, queue, metricsSender) { workerService =>
-        testWith(workerService)
-      }
-    }
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/WorkerServiceFixture.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/WorkerServiceFixture.scala
@@ -18,11 +18,11 @@ import uk.ac.wellcome.monitoring.memory.MemoryMetrics
 
 trait WorkerServiceFixture extends LocalWorksVhs {
 
-  def withWorkerService[R](
-    vhs: VHS,
-    queue: Queue,
-    topic: Topic,
-    metrics: Metrics[Future, StandardUnit] = new MemoryMetrics[StandardUnit])(
+  def withWorkerService[R](vhs: VHS,
+                           queue: Queue,
+                           topic: Topic,
+                           metrics: Metrics[Future, StandardUnit] =
+                             new MemoryMetrics[StandardUnit])(
     testWith: TestWith[MergerWorkerService[SNSConfig], R]): R =
     withLocalS3Bucket { bucket =>
       withSqsBigMessageSender[BaseWork, R](bucket, topic) { msgSender =>

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/WorkerServiceFixture.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/WorkerServiceFixture.scala
@@ -13,7 +13,8 @@ import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 
 trait WorkerServiceFixture extends LocalWorksVhs {
 
-  def withWorkerService[R](vhs: VHS, queue: Queue, topic: Topic)(testWith: TestWith[MergerWorkerService[SNSConfig], R]): R =
+  def withWorkerService[R](vhs: VHS, queue: Queue, topic: Topic)(
+    testWith: TestWith[MergerWorkerService[SNSConfig], R]): R =
     withLocalS3Bucket { bucket =>
       withSqsBigMessageSender[BaseWork, R](bucket, topic) { msgSender =>
         withActorSystem { implicit actorSystem =>
@@ -26,17 +27,18 @@ trait WorkerServiceFixture extends LocalWorksVhs {
             )
             workerService.run()
             testWith(workerService)
-        }
-      }
-    }
-  }
-
-  def withWorkerService[R](vhs: VHS)(testWith: TestWith[MergerWorkerService[SNSConfig], R]): R =
-      withLocalSqsQueue { queue =>
-        withLocalSnsTopic { topic =>
-          withWorkerService(vhs, queue, topic) { workerService =>
-            testWith(workerService)
           }
         }
       }
+    }
+
+  def withWorkerService[R](vhs: VHS)(
+    testWith: TestWith[MergerWorkerService[SNSConfig], R]): R =
+    withLocalSqsQueue { queue =>
+      withLocalSnsTopic { topic =>
+        withWorkerService(vhs, queue, topic) { workerService =>
+          testWith(workerService)
+        }
+      }
+    }
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -266,15 +266,13 @@ class MergerWorkerServiceTest
   def withMergerWorkerServiceFixtures[R](
     testWith: TestWith[(VHS, QueuePair, Topic), R]): R =
     withVHS { vhs =>
-      withLocalSqsQueueAndDlq { case QueuePair(queue, dlq) =>
-        withLocalSnsTopic { topic =>
-          withWorkerService(
-            vhs = vhs,
-            topic = topic,
-            queue = queue) { _ =>
-            testWith((vhs, QueuePair(queue, dlq), topic))
+      withLocalSqsQueueAndDlq {
+        case QueuePair(queue, dlq) =>
+          withLocalSnsTopic { topic =>
+            withWorkerService(vhs = vhs, topic = topic, queue = queue) { _ =>
+              testWith((vhs, QueuePair(queue, dlq), topic))
+            }
           }
-        }
       }
     }
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -1,34 +1,34 @@
 package uk.ac.wellcome.platform.merger.services
 
-import org.mockito.Matchers.endsWith
-import org.mockito.Mockito.{atLeastOnce, times, verify}
+// import org.mockito.Matchers.endsWith
+// import org.mockito.Mockito.{atLeastOnce, times, verify}
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.messaging.fixtures.SNS.Topic
-import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
-import uk.ac.wellcome.messaging.fixtures.Messaging
+
 import uk.ac.wellcome.models.matcher.{MatchedIdentifiers, MatcherResult}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.monitoring.MetricsSender
-import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
+// import uk.ac.wellcome.monitoring.MetricsSender
+// import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.merger.fixtures.{
-  LocalWorksVhs,
   MatcherResultFixture,
   WorkerServiceFixture
 }
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.models.Implicits._
 
+import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
+import uk.ac.wellcome.messaging.fixtures.SNS.Topic
+import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
+
 class MergerWorkerServiceTest
     extends FunSpec
     with ScalaFutures
     with IntegrationPatience
-    with MetricsSenderFixture
-    with Messaging
+    with BigMessagingFixture
+    // with MetricsSenderFixture
     with WorksGenerators
-    with LocalWorksVhs
     with MatcherResultFixture
     with Matchers
     with MockitoSugar
@@ -37,7 +37,7 @@ class MergerWorkerServiceTest
   it(
     "reads matcher result messages, retrieves the works from vhs and sends them to sns") {
     withMergerWorkerServiceFixtures {
-      case (vhs, QueuePair(queue, dlq), topic, metricsSender) =>
+      case (vhs, QueuePair(queue, dlq), topic) =>
         val work1 = createUnidentifiedWork
         val work2 = createUnidentifiedWork
         val work3 = createUnidentifiedWork
@@ -59,15 +59,15 @@ class MergerWorkerServiceTest
           val worksSent = getMessages[BaseWork](topic)
           worksSent should contain only (work1, work2, work3)
 
-          verify(metricsSender, atLeastOnce)
-            .incrementCount(endsWith("_success"))
+          // verify(metricsSender, atLeastOnce)
+          //   .incrementCount(endsWith("_success"))
         }
     }
   }
 
   it("sends InvisibleWorks unmerged") {
     withMergerWorkerServiceFixtures {
-      case (vhs, QueuePair(queue, dlq), topic, metricsSender) =>
+      case (vhs, QueuePair(queue, dlq), topic) =>
         val work = createUnidentifiedInvisibleWork
 
         val matcherResult = matcherResultWith(Set(Set(work)))
@@ -86,15 +86,15 @@ class MergerWorkerServiceTest
           val worksSent = getMessages[BaseWork](topic)
           worksSent should contain only work
 
-          verify(metricsSender, times(1))
-            .incrementCount(endsWith("_success"))
+          // verify(metricsSender, times(1))
+          //   .incrementCount(endsWith("_success"))
         }
     }
   }
 
   it("fails if the work is not in vhs") {
     withMergerWorkerServiceFixtures {
-      case (_, QueuePair(queue, dlq), topic, metricsSender) =>
+      case (_, QueuePair(queue, dlq), topic) =>
         val work = createUnidentifiedWork
 
         val matcherResult = matcherResultWith(Set(Set(work)))
@@ -109,15 +109,15 @@ class MergerWorkerServiceTest
           assertQueueHasSize(dlq, 1)
           listMessagesReceivedFromSNS(topic) shouldBe empty
 
-          verify(metricsSender, times(3))
-            .incrementCount(endsWith("_failure"))
+          // verify(metricsSender, times(3))
+          //   .incrementCount(endsWith("_failure"))
         }
     }
   }
 
   it("discards works with newer versions in vhs, sends along the others") {
     withMergerWorkerServiceFixtures {
-      case (vhs, QueuePair(queue, dlq), topic, _) =>
+      case (vhs, QueuePair(queue, dlq), topic) =>
         val work = createUnidentifiedWork
         val olderWork = createUnidentifiedWork
         val newerWork = olderWork.copy(version = 2)
@@ -142,7 +142,7 @@ class MergerWorkerServiceTest
 
   it("discards works with version 0 and sends along the others") {
     withMergerWorkerServiceFixtures {
-      case (vhs, QueuePair(queue, dlq), topic, metricsSender) =>
+      case (vhs, QueuePair(queue, dlq), topic) =>
         val versionZeroWork = createUnidentifiedWorkWith(version = 0)
         val work = versionZeroWork
           .copy(version = 1)
@@ -163,8 +163,8 @@ class MergerWorkerServiceTest
           val worksSent = getMessages[BaseWork](topic)
           worksSent should contain only work
 
-          verify(metricsSender, times(1))
-            .incrementCount(endsWith("_success"))
+          // verify(metricsSender, times(1))
+          //   .incrementCount(endsWith("_success"))
         }
     }
   }
@@ -176,7 +176,7 @@ class MergerWorkerServiceTest
     val works = List(physicalWork, digitalWork)
 
     withMergerWorkerServiceFixtures {
-      case (vhs, QueuePair(queue, dlq), topic, _) =>
+      case (vhs, QueuePair(queue, dlq), topic) =>
         givenStoredInVhs(vhs, works: _*)
 
         val matcherResult = MatcherResult(
@@ -218,7 +218,7 @@ class MergerWorkerServiceTest
     val works = workPair1 ++ workPair2
 
     withMergerWorkerServiceFixtures {
-      case (vhs, QueuePair(queue, dlq), topic, _) =>
+      case (vhs, QueuePair(queue, dlq), topic) =>
         givenStoredInVhs(vhs, works: _*)
 
         val matcherResult = MatcherResult(
@@ -251,36 +251,30 @@ class MergerWorkerServiceTest
 
   it("fails if the message sent is not a matcher result") {
     withMergerWorkerServiceFixtures {
-      case (_, QueuePair(queue, dlq), _, metricsSender) =>
+      case (_, QueuePair(queue, dlq), _) =>
         sendInvalidJSONto(queue)
 
         eventually {
           assertQueueEmpty(queue)
           assertQueueHasSize(dlq, 1)
-          verify(metricsSender, times(3))
-            .incrementCount(endsWith("_recognisedFailure"))
+          // verify(metricsSender, times(3))
+          //   .incrementCount(endsWith("_recognisedFailure"))
         }
     }
   }
 
   def withMergerWorkerServiceFixtures[R](
-    testWith: TestWith[
-      (TransformedBaseWorkVHS, QueuePair, Topic, MetricsSender),
-      R]): R =
-    withTransformedBaseWorkVHS { vhs =>
-      withLocalSqsQueueAndDlq {
-        case queuePair @ QueuePair(queue, _) =>
-          withLocalSnsTopic { topic =>
-            withMockMetricsSender { mockMetricsSender =>
-              withWorkerService(
-                vhs = vhs,
-                topic = topic,
-                queue = queue,
-                metricsSender = mockMetricsSender) { _ =>
-                testWith((vhs, queuePair, topic, mockMetricsSender))
-              }
-            }
+    testWith: TestWith[(VHS, QueuePair, Topic), R]): R =
+    withVHS { vhs =>
+      withLocalSqsQueueAndDlq { case QueuePair(queue, dlq) =>
+        withLocalSnsTopic { topic =>
+          withWorkerService(
+            vhs = vhs,
+            topic = topic,
+            queue = queue) { _ =>
+            testWith((vhs, QueuePair(queue, dlq), topic))
           }
+        }
       }
     }
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -261,7 +261,8 @@ class MergerWorkerServiceTest
   }
 
   def withMergerWorkerServiceFixtures[R](
-    testWith: TestWith[(VHS, QueuePair, Topic, MemoryMetrics[StandardUnit]), R]): R =
+    testWith: TestWith[(VHS, QueuePair, Topic, MemoryMetrics[StandardUnit]), R])
+    : R =
     withVHS { vhs =>
       withLocalSqsQueueAndDlq {
         case QueuePair(queue, dlq) =>

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackServiceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackServiceTest.scala
@@ -95,7 +95,9 @@ class RecorderPlaybackServiceTest
     }
   }
 
-  private def fetchAllWorks(vhs: VHS, works: TransformedBaseWork*): Future[Seq[Option[TransformedBaseWork]]] = {
+  private def fetchAllWorks(
+    vhs: VHS,
+    works: TransformedBaseWork*): Future[Seq[Option[TransformedBaseWork]]] = {
     val service = new RecorderPlaybackService(vhs)
 
     val workIdentifiers = works

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackServiceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackServiceTest.scala
@@ -10,8 +10,6 @@ import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.platform.merger.fixtures.LocalWorksVhs
 
-// import uk.ac.wellcome.storage.NoVersionExistsError
-
 class RecorderPlaybackServiceTest
     extends FunSpec
     with Matchers

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackServiceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackServiceTest.scala
@@ -2,13 +2,10 @@ package uk.ac.wellcome.platform.merger.services
 
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.fixtures._
 import uk.ac.wellcome.models.matcher.WorkIdentifier
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.platform.merger.fixtures.LocalWorksVhs
-import uk.ac.wellcome.storage.vhs.EmptyMetadata
-import uk.ac.wellcome.models.Implicits._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -23,7 +20,7 @@ class RecorderPlaybackServiceTest
   it("fetches a single Work") {
     val work = createUnidentifiedWork
 
-    withRecorderVHS { vhs =>
+    withVHS { vhs =>
       givenStoredInVhs(vhs, work)
 
       whenReady(fetchAllWorks(vhs = vhs, work)) { result =>
@@ -35,7 +32,7 @@ class RecorderPlaybackServiceTest
   it("throws an error if asked to fetch a missing entry") {
     val work = createUnidentifiedWork
 
-    withRecorderVHS { vhs =>
+    withVHS { vhs =>
       whenReady(fetchAllWorks(vhs = vhs, work).failed) { result =>
         result shouldBe a[NoSuchElementException]
         result.getMessage shouldBe s"Work ${work.sourceIdentifier} is not in VHS!"
@@ -46,7 +43,7 @@ class RecorderPlaybackServiceTest
   it("returns None if asked to fetch a Work with version 0") {
     val work = createUnidentifiedWorkWith(version = 0)
 
-    withRecorderVHS { vhs =>
+    withVHS { vhs =>
       whenReady(fetchAllWorks(vhs = vhs, work)) { result =>
         result shouldBe Seq(None)
       }
@@ -61,7 +58,7 @@ class RecorderPlaybackServiceTest
       version = work.version + 1
     )
 
-    withRecorderVHS { vhs =>
+    withVHS { vhs =>
       givenStoredInVhs(vhs, workToStore)
 
       whenReady(fetchAllWorks(vhs = vhs, work)) { result =>
@@ -87,7 +84,7 @@ class RecorderPlaybackServiceTest
     val lookupWorks = (unchangedWorks ++ outdatedWorks ++ zeroWorks).toList
     val storedWorks = (unchangedWorks ++ updatedWorks ++ zeroWorks).toList
 
-    withRecorderVHS { vhs =>
+    withVHS { vhs =>
       givenStoredInVhs(vhs, storedWorks: _*)
 
       whenReady(fetchAllWorks(vhs = vhs, lookupWorks: _*)) { result =>
@@ -98,9 +95,7 @@ class RecorderPlaybackServiceTest
     }
   }
 
-  private def fetchAllWorks(
-    vhs: TransformedBaseWorkVHS,
-    works: TransformedBaseWork*): Future[Seq[Option[TransformedBaseWork]]] = {
+  private def fetchAllWorks(vhs: VHS, works: TransformedBaseWork*): Future[Seq[Option[TransformedBaseWork]]] = {
     val service = new RecorderPlaybackService(vhs)
 
     val workIdentifiers = works
@@ -109,17 +104,5 @@ class RecorderPlaybackServiceTest
       }
 
     service.fetchAllWorks(workIdentifiers)
-  }
-
-  private def withRecorderVHS[R](
-    testWith: TestWith[TransformedBaseWorkVHS, R]): R = {
-    withLocalS3Bucket { bucket =>
-      withLocalDynamoDbTable { table =>
-        withTypeVHS[TransformedBaseWork, EmptyMetadata, R](bucket, table) {
-          vhs =>
-            testWith(vhs)
-        }
-      }
-    }
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -266,8 +266,7 @@ object CatalogueDependencies {
       WellcomeDependencies.messagingTypesafeLibrary
 
   val mergerDependencies: Seq[ModuleID] =
-    ExternalDependencies.mockitoDependencies ++
-      WellcomeDependencies.messagingTypesafeLibrary
+    ExternalDependencies.mockitoDependencies
 
   val miroTransformerDependencies: Seq[ModuleID] =
     ExternalDependencies.apacheCommonsDependencies ++


### PR DESCRIPTION
## Issues

https://github.com/wellcometrust/platform/issues/3628
https://github.com/wellcometrust/platform/issues/3819

## Description


Upgrades `merger` to use:
* `scala-messaging`  v5.3.1
* `scala-storage` v7.19.0