### PR TITLE
Revert encode MessageNotification in old format

### DIFF
--- a/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerService.scala
+++ b/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerService.scala
@@ -3,22 +3,21 @@ package uk.ac.wellcome.platform.recorder.services
 import scala.util.{Failure, Success, Try}
 import scala.concurrent.Future
 import akka.Done
-import io.circe.{Encoder, Json}
 
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.typesafe.Runnable
+import uk.ac.wellcome.json.JsonUtil._
 
 import uk.ac.wellcome.bigmessaging.{EmptyMetadata, GetLocation}
 import uk.ac.wellcome.messaging.MessageSender
-import uk.ac.wellcome.bigmessaging.message.BigMessageStream
+import uk.ac.wellcome.bigmessaging.message.{
+  BigMessageStream,
+  MessageNotification,
+  RemoteNotification
+}
 
 import uk.ac.wellcome.storage.store.{HybridStoreEntry, VersionedStore}
 import uk.ac.wellcome.storage.{Identified, Version}
-
-// The ObjectLocation format used in the matcher is from the old storage lib and
-// differs to the ObjectLocation used in the storage lib here. For that reason
-// we manually encode a "RemoteNotification" type with the expected fields
-case class MatcherNotification(namespace: String, key: String)
 
 class RecorderWorkerService[MsgDestination](
   store: VersionedStore[
@@ -29,19 +28,6 @@ class RecorderWorkerService[MsgDestination](
   msgSender: MessageSender[MsgDestination])
     extends Runnable {
 
-  implicit val encodeMatcherNotification = new Encoder[MatcherNotification] {
-    final def apply(value: MatcherNotification): Json =
-      Json.obj(
-        ("type", Json.fromString("RemoteNotification")),
-        (
-          "location",
-          Json.obj(
-            ("namespace", Json.fromString(value.namespace)),
-            ("key", Json.fromString(value.key))
-          ))
-      )
-  }
-
   def run(): Future[Done] =
     messageStream.foreach(this.getClass.getSimpleName, processMessage)
 
@@ -50,9 +36,7 @@ class RecorderWorkerService[MsgDestination](
       for {
         key <- storeWork(work)
         location <- store.getLocation(key)
-        _ <- msgSender.sendT(
-          MatcherNotification(location.namespace, location.path)
-        )
+        _ <- msgSender.sendT[MessageNotification](RemoteNotification(location))
       } yield ()
     }
 

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderIntegrationTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderIntegrationTest.scala
@@ -1,17 +1,22 @@
 package uk.ac.wellcome.platform.recorder
 
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType
+
 import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.{FunSpec, Matchers}
-import io.circe.parser.parse
-
 import uk.ac.wellcome.models.Implicits._
+import uk.ac.wellcome.json.JsonUtil._
+
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.platform.recorder.fixtures.WorkerServiceFixture
 
 import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
 import uk.ac.wellcome.bigmessaging.typesafe.VHSBuilder
+import uk.ac.wellcome.bigmessaging.message.{
+  MessageNotification,
+  RemoteNotification
+}
 import uk.ac.wellcome.storage.fixtures.DynamoFixtures
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
 import uk.ac.wellcome.storage.ObjectLocationPrefix
@@ -58,18 +63,9 @@ class RecorderIntegrationTest
                   getObjectFromS3[TransformedBaseWork](location.get) shouldBe work
                   val messages = listMessagesReceivedFromSNS(topic)
                     .map(_.message)
-                    .map(parse(_).right)
-                  val expected = parse(
-                    s"""
-                    |{
-                    |  "type": "RemoteNotification",
-                    |  "location": {
-                    |    "namespace": "${location.get.namespace}",
-                    |    "key": "${location.get.path}"
-                    |  }
-                    |}""".stripMargin
-                  ).right
-                  messages.toList shouldBe List(expected)
+                    .map(fromJson[MessageNotification](_).get)
+                  messages.toList shouldBe List(
+                    RemoteNotification(location.get))
                 }
               }
             }

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
@@ -4,11 +4,11 @@ import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{FunSpec, Matchers}
 import io.circe.parser.parse
 
-import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.recorder.fixtures.WorkerServiceFixture
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.models.Implicits._
 
 import uk.ac.wellcome.storage.ObjectLocation
 
@@ -132,7 +132,7 @@ class RecorderWorkerServiceTest
                 |  "type": "RemoteNotification",
                 |  "location": {
                 |    "namespace": "test",
-                |    "key": "${id}/0"
+                |    "path": "${id}/0"
                 |  }
                 |}""".stripMargin
               ).right


### PR DESCRIPTION
This reverts commit #146 (no longer required as `matcher` has been updated to use new messaging / storage libs in #153)