### PR TITLE
Fix backwards compatibility with adaptor

### DIFF
--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
@@ -64,6 +64,9 @@ class VHSInternalStore[T, Metadata](
 
 case class BackwardsCompatObjectLocation(namespace: String, key: String)
 
+// The adaptor stores ObjectLocation with an older format to what is used by the
+// recent storage libs: namely the `path` is stored as `key`. This store uses
+// the old format internally whilst exposing the modern API
 class BackwardsCompatIndexStore[T, Metadata](
   indexStore: Store[
     Version[String, Int],
@@ -84,7 +87,7 @@ class BackwardsCompatIndexStore[T, Metadata](
     }
 
   def put(id: Version[String, Int])(
-    entry: HybridIndexedStoreEntry[ObjectLocation, Metadata]): WriteEither =
+    entry: IndexEntry[ObjectLocation]): WriteEither =
     indexStore.put(id)(toBackwardsCompat(entry)) match {
       case Left(error) => Left(error)
       case Right(Identified(id, entry)) =>

--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
@@ -14,8 +14,8 @@ import uk.ac.wellcome.storage.{
   Identified,
   ObjectLocation,
   ObjectLocationPrefix,
-  Version,
-  ReadError
+  ReadError,
+  Version
 }
 import uk.ac.wellcome.storage.maxima.Maxima
 
@@ -68,26 +68,29 @@ class BackwardsCompatIndexStore[T, Metadata](
   indexStore: Store[
     Version[String, Int],
     HybridIndexedStoreEntry[BackwardsCompatObjectLocation, Metadata]
-  ] with Maxima[String, Int]) extends Store[Version[String, Int], HybridIndexedStoreEntry[ObjectLocation, Metadata]] with Maxima[String, Int] {
+  ] with Maxima[String, Int])
+    extends Store[
+      Version[String, Int],
+      HybridIndexedStoreEntry[ObjectLocation, Metadata]]
+    with Maxima[String, Int] {
 
   def get(id: Version[String, Int]): ReadEither =
     indexStore.get(id) match {
       case Left(error) => Left(error)
       case Right(
-        Identified(
-          id,
-          HybridIndexedStoreEntry(
-            BackwardsCompatObjectLocation(namespace, path),
-            metadata))) =>
-        Right(
           Identified(
             id,
             HybridIndexedStoreEntry(
-              ObjectLocation(namespace, path),
-              metadata)))
+              BackwardsCompatObjectLocation(namespace, path),
+              metadata))) =>
+        Right(
+          Identified(
+            id,
+            HybridIndexedStoreEntry(ObjectLocation(namespace, path), metadata)))
     }
 
-  def put(id: Version[String, Int])(item: HybridIndexedStoreEntry[ObjectLocation, Metadata]): WriteEither =
+  def put(id: Version[String, Int])(
+    item: HybridIndexedStoreEntry[ObjectLocation, Metadata]): WriteEither =
     throw new Exception("BackwardsCompatIndexStore is read only")
 
   def max(q: String): Either[ReadError, Int] =

--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
@@ -24,11 +24,7 @@ trait GetLocation {
   def getLocation(key: Version[String, Int]): Try[ObjectLocation]
 }
 
-class VHS[T](override val hybridStore: VHSInternalStore[T, EmptyMetadata])
-    extends VHSWithMetadata[T, EmptyMetadata](hybridStore)
-
-class VHSWithMetadata[T, Metadata](
-  val hybridStore: VHSInternalStore[T, Metadata])
+class VHS[T, Metadata](val hybridStore: VHSInternalStore[T, Metadata])
     extends VersionedHybridStore[
       String,
       Int,

--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
@@ -97,15 +97,22 @@ class BackwardsCompatIndexStore[T, Metadata](
   def max(q: String): Either[ReadError, Int] =
     indexStore.max(q)
 
-  private def fromBackwardsCompat(entry: IndexEntry[BackwardsCompatObjectLocation]): IndexEntry[ObjectLocation] =
+  private def fromBackwardsCompat(
+    entry: IndexEntry[BackwardsCompatObjectLocation])
+    : IndexEntry[ObjectLocation] =
     entry match {
-      case HybridIndexedStoreEntry(BackwardsCompatObjectLocation(namespace, path), metadata) =>
+      case HybridIndexedStoreEntry(
+          BackwardsCompatObjectLocation(namespace, path),
+          metadata) =>
         HybridIndexedStoreEntry(ObjectLocation(namespace, path), metadata)
     }
 
-  private def toBackwardsCompat(entry: IndexEntry[ObjectLocation]): IndexEntry[BackwardsCompatObjectLocation] =
+  private def toBackwardsCompat(entry: IndexEntry[ObjectLocation])
+    : IndexEntry[BackwardsCompatObjectLocation] =
     entry match {
       case HybridIndexedStoreEntry(ObjectLocation(namespace, path), metadata) =>
-        HybridIndexedStoreEntry(BackwardsCompatObjectLocation(namespace, path), metadata)
+        HybridIndexedStoreEntry(
+          BackwardsCompatObjectLocation(namespace, path),
+          metadata)
     }
 }

--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
@@ -14,7 +14,8 @@ import uk.ac.wellcome.storage.{
   Identified,
   ObjectLocation,
   ObjectLocationPrefix,
-  Version
+  Version,
+  ReadError
 }
 import uk.ac.wellcome.storage.maxima.Maxima
 
@@ -59,4 +60,36 @@ class VHSInternalStore[T, Metadata](
       id.id.toString,
       id.version.toString,
       UUID.randomUUID().toString)
+}
+
+case class BackwardsCompatObjectLocation(namespace: String, key: String)
+
+class BackwardsCompatIndexStore[T, Metadata](
+  indexStore: Store[
+    Version[String, Int],
+    HybridIndexedStoreEntry[BackwardsCompatObjectLocation, Metadata]
+  ] with Maxima[String, Int]) extends Store[Version[String, Int], HybridIndexedStoreEntry[ObjectLocation, Metadata]] with Maxima[String, Int] {
+
+  def get(id: Version[String, Int]): ReadEither =
+    indexStore.get(id) match {
+      case Left(error) => Left(error)
+      case Right(
+        Identified(
+          id,
+          HybridIndexedStoreEntry(
+            BackwardsCompatObjectLocation(namespace, path),
+            metadata))) =>
+        Right(
+          Identified(
+            id,
+            HybridIndexedStoreEntry(
+              ObjectLocation(namespace, path),
+              metadata)))
+    }
+
+  def put(id: Version[String, Int])(item: HybridIndexedStoreEntry[ObjectLocation, Metadata]): WriteEither =
+    throw new Exception("BackwardsCompatIndexStore is read only")
+
+  def max(q: String): Either[ReadError, Int] =
+    indexStore.max(q)
 }

--- a/common/big_messaging_typesafe/src/main/scala/uk/ac/wellcome/bigmessaging/typesafe/VHSBuilder.scala
+++ b/common/big_messaging_typesafe/src/main/scala/uk/ac/wellcome/bigmessaging/typesafe/VHSBuilder.scala
@@ -11,14 +11,17 @@ import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
 import uk.ac.wellcome.storage.store.dynamo.DynamoHashStore
 import uk.ac.wellcome.storage.dynamo.{DynamoConfig, DynamoHashEntry}
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
-import uk.ac.wellcome.storage.store.HybridIndexedStoreEntry
-import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
+import uk.ac.wellcome.storage.store.{Store, HybridIndexedStoreEntry}
+import uk.ac.wellcome.storage.maxima.Maxima
+import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix, Version}
 import uk.ac.wellcome.storage.typesafe.{DynamoBuilder, S3Builder}
 import uk.ac.wellcome.storage.streaming.Codec
 import uk.ac.wellcome.bigmessaging.{
   EmptyMetadata,
   VHS,
-  VHSInternalStore
+  VHSInternalStore,
+  BackwardsCompatObjectLocation,
+  BackwardsCompatIndexStore
 }
 
 object VHSBuilder {
@@ -35,12 +38,17 @@ object VHSBuilder {
         DynamoValue.fromMap(Map.empty)
     }
 
-  type WithMetaFormat[Metadata] =
+  type IndexStore[Metadata, Location] = Store[
+    Version[String, Int],
+    HybridIndexedStoreEntry[Location, Metadata]
+  ] with Maxima[String, Int]
+
+  type IndexFormat[Metadata, Location] =
     DynamoFormat[
       DynamoHashEntry[
         String,
         Int,
-        HybridIndexedStoreEntry[ObjectLocation, Metadata]
+        HybridIndexedStoreEntry[Location, Metadata]
       ]
     ]
 
@@ -60,7 +68,7 @@ object VHSBuilder {
   def buildWithMetadata[T, Metadata](config: Config, namespace: String = "vhs")(
     implicit
     codec: Codec[T],
-    format: WithMetaFormat[Metadata]): VHS[T, Metadata] =
+    format: IndexFormat[Metadata, ObjectLocation]): VHS[T, Metadata] =
     VHSBuilder.buildWithMetadata(
       buildObjectLocationPrefix(config, namespace = namespace),
       DynamoBuilder.buildDynamoConfig(config, namespace = namespace),
@@ -74,19 +82,53 @@ object VHSBuilder {
                                      s3Client: AmazonS3)(
     implicit
     codec: Codec[T],
-    format: WithMetaFormat[Metadata]): VHS[T, Metadata] = {
+    format: IndexFormat[Metadata, ObjectLocation]): VHS[T, Metadata] = {
     implicit val s3 = s3Client;
-    implicit val dynamo = dynamoClient;
     new VHS(
       new VHSInternalStore(
         objectLocationPrefix,
-        new DynamoHashStore[
-          String,
-          Int,
-          HybridIndexedStoreEntry[ObjectLocation, Metadata]
-        ](dynamoConfig),
-        S3TypedStore[T]
-      )
+        createIndexStore(dynamoClient, dynamoConfig),
+        S3TypedStore[T])
+    )
+  }
+
+  def buildBackwardsCompat[T](config: Config, namespace: String = "vhs")(
+    implicit codec: Codec[T]): VHS[T, EmptyMetadata] =
+    VHSBuilder.buildBackwardsCompatWithMetadata[T, EmptyMetadata](config, namespace)
+
+  def buildBackwardsCompat[T](objectLocationPrefix: ObjectLocationPrefix,
+               dynamoConfig: DynamoConfig,
+               dynamoClient: AmazonDynamoDB,
+               s3Client: AmazonS3)(implicit codec: Codec[T]): VHS[T, EmptyMetadata] =
+    VHSBuilder.buildBackwardsCompatWithMetadata[T, EmptyMetadata](objectLocationPrefix,
+                                                   dynamoConfig,
+                                                   dynamoClient,
+                                                   s3Client)
+
+  def buildBackwardsCompatWithMetadata[T, Metadata](config: Config, namespace: String = "vhs")(
+    implicit
+    codec: Codec[T],
+    format: IndexFormat[Metadata, BackwardsCompatObjectLocation]): VHS[T, Metadata] =
+    VHSBuilder.buildBackwardsCompatWithMetadata(
+      buildObjectLocationPrefix(config, namespace = namespace),
+      DynamoBuilder.buildDynamoConfig(config, namespace = namespace),
+      DynamoBuilder.buildDynamoClient(config),
+      S3Builder.buildS3Client(config)
+    )
+
+  def buildBackwardsCompatWithMetadata[T, Metadata](objectLocationPrefix: ObjectLocationPrefix,
+                                        dynamoConfig: DynamoConfig,
+                                        dynamoClient: AmazonDynamoDB,
+                                        s3Client: AmazonS3)(
+    implicit
+    codec: Codec[T],
+    format: IndexFormat[Metadata, BackwardsCompatObjectLocation]): VHS[T, Metadata] = {
+    implicit val s3 = s3Client;
+    new VHS(
+      new VHSInternalStore(
+        objectLocationPrefix,
+        createBackwardsCompatIndexStore(dynamoClient, dynamoConfig),
+        S3TypedStore[T])
     )
   }
 
@@ -94,4 +136,24 @@ object VHSBuilder {
     ObjectLocationPrefix(
       namespace = config.required(s"aws.${namespace}.s3.bucketName"),
       path = config.getOrElse(s"aws.${namespace}.s3.globalPrefix")(default = ""))
+
+  private def createIndexStore[Metadata, Location](
+    dynamoClient: AmazonDynamoDB,
+    dynamoConfig: DynamoConfig)(
+    implicit format: IndexFormat[Metadata, Location]): IndexStore[Metadata, Location] = {
+    implicit val dynamo = dynamoClient;
+      new DynamoHashStore[
+        String,
+        Int,
+        HybridIndexedStoreEntry[Location, Metadata]
+      ](dynamoConfig)
+  }
+
+  private def createBackwardsCompatIndexStore[Metadata](
+    dynamoClient: AmazonDynamoDB,
+    dynamoConfig: DynamoConfig)(
+    implicit format: IndexFormat[Metadata, BackwardsCompatObjectLocation]): IndexStore[Metadata, ObjectLocation] =
+    new BackwardsCompatIndexStore(
+      createIndexStore[Metadata, BackwardsCompatObjectLocation](dynamoClient, dynamoConfig)
+    )
 }

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/Main.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/Main.scala
@@ -46,7 +46,7 @@ object Main extends WellcomeTypesafeApp {
       msgSender = BigMessagingBuilder
         .buildBigMessageSender[TransformedBaseWork](config),
       store = VHSBuilder
-        .buildWithMetadata[MiroRecord, MiroMetadata](config)
+        .buildBackwardsCompatWithMetadata[MiroRecord, MiroMetadata](config)
     )
 
     new MiroTransformerWorkerService(

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiver.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiver.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.transformer.miro.services
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
-
+import io.circe.Json
 import grizzled.slf4j.Logging
 
 import uk.ac.wellcome.json.exceptions.JsonDecodingError
@@ -16,7 +16,7 @@ import uk.ac.wellcome.bigmessaging.BigMessageSender
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 
 import uk.ac.wellcome.storage.store.{HybridStoreEntry, Store}
-import uk.ac.wellcome.storage.{Identified, ObjectLocation, Version}
+import uk.ac.wellcome.storage.{Identified, Version}
 
 // In future we should just receive the ID and version from the adaptor as the
 // S3 specific `location` field is an implementation detail we should not be
@@ -24,7 +24,7 @@ import uk.ac.wellcome.storage.{Identified, ObjectLocation, Version}
 case class HybridRecord(
   id: String,
   version: Int,
-  location: ObjectLocation
+  location: Json
 )
 
 class MiroVHSRecordReceiver[MsgDestination](

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
@@ -2,6 +2,7 @@ package uk.ac.wellcome.platform.transformer.miro.fixtures
 
 import scala.util.Random
 import scala.concurrent.ExecutionContext.Implicits.global
+import io.circe.Json
 
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
@@ -22,7 +23,7 @@ import uk.ac.wellcome.messaging.fixtures.SNS.Topic
 import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
 import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSConfig}
 
-import uk.ac.wellcome.storage.{ObjectLocation, Version}
+import uk.ac.wellcome.storage.Version
 import uk.ac.wellcome.storage.store.{HybridStoreEntry, Store}
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.store.memory.MemoryStore
@@ -67,7 +68,10 @@ trait MiroVHSRecordReceiverFixture
     HybridRecord(
       id = id,
       version = version,
-      location = ObjectLocation("namespace", "path")
+      location = Json.obj(
+        ("namespace", Json.fromString("namespace.doesnt.matter")),
+        ("key", Json.fromString("path/is/irrelevant"))
+      )
     )
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/Main.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/Main.scala
@@ -39,7 +39,7 @@ object Main extends WellcomeTypesafeApp {
       msgSender = BigMessagingBuilder
         .buildBigMessageSender[TransformedBaseWork](config),
       store = VHSBuilder
-        .build[SierraTransformable](config))
+        .buildBackwardsCompat[SierraTransformable](config))
 
     new SierraTransformerWorkerService(
       messageReceiver = messageReceiver,

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/HybridRecordReceiver.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/HybridRecordReceiver.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.platform.transformer.sierra.services
 import grizzled.slf4j.Logging
 import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
+import io.circe.Json
 
 import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
@@ -13,12 +14,12 @@ import uk.ac.wellcome.bigmessaging.BigMessageSender
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 
 import uk.ac.wellcome.storage.store.{HybridStoreEntry, VersionedStore}
-import uk.ac.wellcome.storage.{Identified, ObjectLocation, Version}
+import uk.ac.wellcome.storage.{Identified, Version}
 
 case class HybridRecord(
   id: String,
   version: Int,
-  location: ObjectLocation
+  location: Json
 )
 
 class HybridRecordReceiver[MsgDestination](

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformerIntegrationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformerIntegrationTest.scala
@@ -49,7 +49,7 @@ class SierraTransformerIntegrationTest
         withLocalS3Bucket { storageBucket =>
           withLocalS3Bucket { messagingBucket =>
             withLocalDynamoDbTable { table =>
-              val vhs = VHSBuilder.build[SierraTransformable](
+              val vhs = VHSBuilder.buildBackwardsCompat[SierraTransformable](
                 ObjectLocationPrefix(
                   namespace = storageBucket.name,
                   path = "sierra"),

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/fixtures/HybridRecordReceiverFixture.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/fixtures/HybridRecordReceiverFixture.scala
@@ -2,6 +2,7 @@ package uk.ac.wellcome.platform.transformer.sierra.fixtures
 
 import scala.util.Random
 import com.amazonaws.services.sns.AmazonSNS
+import io.circe.Json
 
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.platform.transformer.sierra.services.{
@@ -20,7 +21,6 @@ import uk.ac.wellcome.messaging.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSConfig}
 
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
-import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.store.HybridStoreEntry
 import uk.ac.wellcome.storage.Version
 
@@ -63,7 +63,10 @@ trait HybridRecordReceiverFixture extends VHSFixture[SierraTransformable] {
     HybridRecord(
       id = id,
       version = version,
-      location = ObjectLocation("namespace.doesnt.matter", "path/is/irrelevant")
+      location = Json.obj(
+        ("namespace", Json.fromString("namespace.doesnt.matter")),
+        ("key", Json.fromString("path/is/irrelevant"))
+      )
     )
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/services/HybridRecordReceiverTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/services/HybridRecordReceiverTest.scala
@@ -9,6 +9,7 @@ import org.mockito.Matchers.any
 import com.amazonaws.services.sns.AmazonSNS
 import com.amazonaws.services.sns.model.PublishRequest
 import org.scalatest.{FunSpec, Matchers}
+import io.circe.Json
 
 import uk.ac.wellcome.json.exceptions.JsonDecodingError
 import uk.ac.wellcome.models.transformable.SierraTransformable
@@ -23,8 +24,6 @@ import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.json.JsonUtil._
 
 import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
-
-import uk.ac.wellcome.storage.ObjectLocation
 
 class HybridRecordReceiverTest
     extends FunSpec
@@ -134,8 +133,10 @@ class HybridRecordReceiverTest
             HybridRecord(
               id = "some-nonexistent-id",
               version = 1,
-              location =
-                ObjectLocation(namespace = "some.namespace", path = "some/path")
+              location = Json.obj(
+                ("namespace", Json.fromString("some.namespace")),
+                ("key", Json.fromString("some/path"))
+              )
             )
           )
           withHybridRecordReceiver(vhs, topic, bucket) { recordReceiver =>


### PR DESCRIPTION
The adaptor stores `ObjectLocation` with an older format to what is used by the
recent storage libs: namely the `path` is stored as `key`.

This PR introduces an index store for VHS that uses the old format internally whilst exposing the modern API.