### PR TITLE
add vhs_sierra_sourcedata_table_name

### DIFF
--- a/pipeline/terraform/locals.tf
+++ b/pipeline/terraform/locals.tf
@@ -20,6 +20,7 @@ locals {
   sierra_reindexer_topic_name = "${data.terraform_remote_state.shared_infra.catalogue_sierra_reindex_topic_name}"
 
   vhs_sierra_sourcedata_bucket_name = "${data.terraform_remote_state.catalogue_infra_critical.vhs_sierra_bucket_name}"
+  vhs_sierra_sourcedata_table_name  = "${data.terraform_remote_state.catalogue_infra_critical.vhs_sierra_table_name}"
 
   infra_bucket = "${data.terraform_remote_state.shared_infra.infra_bucket}"
 

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -36,14 +36,15 @@ module "catalogue_pipeline_20190829" {
   vhs_sierra_read_policy            = "${local.vhs_sierra_read_policy}"
   vhs_miro_read_policy              = "${local.vhs_miro_read_policy}"
   vhs_sierra_sourcedata_bucket_name = "${local.vhs_sierra_sourcedata_bucket_name}"
+  vhs_sierra_sourcedata_table_name  = "${local.vhs_sierra_sourcedata_table_name}"
 }
 
-module "catalogue_pipeline_20190910" {
+module "catalogue_pipeline_20190910-02" {
   source = "stack"
 
-  namespace = "catalogue-20190910"
+  namespace = "catalogue-20190910-02"
 
-  release_label = "stage"
+  release_label = "latest"
 
   account_id      = "${data.aws_caller_identity.current.account_id}"
   aws_region      = "${local.aws_region}"
@@ -75,4 +76,5 @@ module "catalogue_pipeline_20190910" {
   vhs_sierra_read_policy            = "${local.vhs_sierra_read_policy}"
   vhs_miro_read_policy              = "${local.vhs_miro_read_policy}"
   vhs_sierra_sourcedata_bucket_name = "${local.vhs_sierra_sourcedata_bucket_name}"
+  vhs_sierra_sourcedata_table_name  = "${local.vhs_sierra_sourcedata_table_name}"
 }

--- a/pipeline/terraform/stack/service_transformer_sierra.tf
+++ b/pipeline/terraform/stack/service_transformer_sierra.tf
@@ -45,9 +45,10 @@ module "sierra_transformer" {
     metrics_namespace      = "sierra_transformer"
     messages_bucket_name   = "${aws_s3_bucket.messages.id}"
     vhs_sierra_bucket_name = "${var.vhs_sierra_sourcedata_bucket_name}"
+    vhs_sierra_table_name  = "${var.vhs_sierra_sourcedata_table_name}"
   }
 
-  env_vars_length = 4
+  env_vars_length = 6
 
   secret_env_vars        = {}
   secret_env_vars_length = "0"

--- a/pipeline/terraform/stack/variables.tf
+++ b/pipeline/terraform/stack/variables.tf
@@ -28,6 +28,7 @@ variable "sierra_adapter_topic_names" {
 variable "vhs_miro_read_policy" {}
 variable "vhs_sierra_read_policy" {}
 variable "vhs_sierra_sourcedata_bucket_name" {}
+variable "vhs_sierra_sourcedata_table_name" {}
 
 variable "private_subnets" {
   type = "list"

--- a/pipeline/transformer/transformer_sierra/src/main/resources/application.conf
+++ b/pipeline/transformer/transformer_sierra/src/main/resources/application.conf
@@ -3,3 +3,4 @@ aws.metrics.namespace=${?metrics_namespace}
 aws.message.writer.sns.topic.arn=${?sns_arn}
 aws.message.writer.s3.bucketName=${?messages_bucket_name}
 aws.vhs.s3.bucketName=${?vhs_sierra_bucket_name}
+aws.vhs.dynamo.tableName=${?vhs_sierra_table_name}


### PR DESCRIPTION
The transformer is cycling as the `aws.vhs.dynamo.tableName` environment variable is not defined (required by [`scala-storage`](https://github.com/wellcometrust/scala-storage/blob/master/storage_typesafe/src/main/scala/uk/ac/wellcome/storage/typesafe/DynamoBuilder.scala#L13-L14))