### PR TITLE
use Display paradigm to return Aggregations

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -123,7 +123,7 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
       case None            => defaultIndex
     }
 
-    val aggregations = request._aggregations
+    val aggregations = request.aggregations
 
     val worksSearchOptions = WorksSearchOptions(
       filters = buildFilters(request),

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/Aggregation.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/Aggregation.scala
@@ -6,14 +6,19 @@ import uk.ac.wellcome.json.JsonUtil._
 
 import scala.util.{Failure, Success}
 
+trait OntologyType {
+  val ontologyType: String
+}
+object OntologyType {}
+
 // TODO: Return a `ParseError`s where applicable
 case class Genre(label: String)
-case class AggregationSet(workType: Option[Aggregation[WorkType]],
-                          genre: Option[Aggregation[Genre]])
-object AggregationSet {
+case class Aggregations(workType: Option[Aggregation[WorkType]],
+                        genre: Option[Aggregation[Genre]])
+object Aggregations {
   val validAggregationRequests = List("workType", "genre")
 
-  def isEmpty(a: AggregationSet): Boolean =
+  def isEmpty(a: Aggregations): Boolean =
     a.workType.isEmpty && a.genre.isEmpty
 
   def getFromJson[AggregationDataType](json: Json)(
@@ -31,7 +36,7 @@ object AggregationSet {
     })
   }
 
-  def apply(jsonString: String): Option[AggregationSet] = {
+  def apply(jsonString: String): Option[Aggregations] = {
     val json = fromJson[Map[String, Json]](jsonString)
 
     json match {
@@ -47,7 +52,7 @@ object AggregationSet {
             val genre =
               jsonMap.get("genre").flatMap(json => getFromJson[Genre](json))
 
-            Some(AggregationSet(workType = workType, genre = genre))
+            Some(Aggregations(workType = workType, genre = genre))
         }
     }
   }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayAggregations.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayAggregations.scala
@@ -1,0 +1,52 @@
+package uk.ac.wellcome.platform.api.models
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.circe.generic.extras.JsonKey
+import io.swagger.annotations.{ApiModel, ApiModelProperty}
+import uk.ac.wellcome.display.models.DisplayWorkType
+
+@ApiModel(
+  value = "AggregationMap",
+  description = "A map of the different aggregations on the ResultList."
+)
+case class DisplayAggregations(
+  @ApiModelProperty(
+    value = "WorkType aggregation on a set of results."
+  ) workType: Option[DisplayAggregation[DisplayWorkType]],
+  @ApiModelProperty(
+    value = "Genre aggregation on a set of results."
+  ) genre: Option[DisplayAggregation[Genre]],
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "Aggregations"
+)
+
+case class DisplayAggregation[T](
+  @ApiModelProperty(
+    value = "An aggregation on a set of results"
+  ) buckets: List[DisplayAggregationBucket[T]],
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "Aggregation")
+
+case class DisplayAggregationBucket[T](
+  @ApiModelProperty(
+    value = "The data that this aggregation is of."
+  ) data: T,
+  @ApiModelProperty(
+    value = "The count of how often this data occurs in this set of results."
+  ) count: Int,
+  @JsonProperty("type") @JsonKey("type") ontologyType: String =
+    "AggregationBucket")
+
+case object DisplayAggregations {
+  // We've done all this here as we need the end type e.g. WorkType to be converted to
+  // DisplayWorkType. TODO: Some sort of auto-derivation
+  def apply(aggregationMap: Aggregations): DisplayAggregations =
+    DisplayAggregations(
+      workType = aggregationMap.workType.map(
+        aggregation =>
+          DisplayAggregation(
+            buckets = aggregation.buckets.map(bucket =>
+              DisplayAggregationBucket(
+                data = DisplayWorkType(bucket.data),
+                count = bucket.count)))),
+      genre = None
+    )
+}

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayResultList.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayResultList.scala
@@ -14,7 +14,7 @@ case class DisplayResultList[T <: DisplayWork](
   @ApiModelProperty(value = "Total number of pages in the result list") totalPages: Int,
   @ApiModelProperty(value = "Total number of results in the result list") totalResults: Int,
   @ApiModelProperty(value = "Aggregations included about the results list") aggregations: Option[
-    AggregationSet],
+    DisplayAggregations],
   @ApiModelProperty(value = "List of things in the current page") results: List[
     T]) {
   @ApiModelProperty(
@@ -37,6 +37,6 @@ case object DisplayResultList {
         .ceil(resultList.totalResults.toDouble / pageSize.toDouble)
         .toInt,
       totalResults = resultList.totalResults,
-      aggregations = resultList.aggregations
+      aggregations = resultList.aggregations.map(DisplayAggregations(_))
     )
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/ResultList.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/ResultList.scala
@@ -5,5 +5,5 @@ import uk.ac.wellcome.models.work.internal.IdentifiedWork
 case class ResultList(
   results: List[IdentifiedWork],
   totalResults: Int,
-  aggregations: Option[AggregationSet]
+  aggregations: Option[Aggregations]
 )

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/requests/Requests.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/requests/Requests.scala
@@ -21,20 +21,20 @@ trait MultipleResultsRequest[W <: WorksIncludes] extends ApiRequest {
   val pageSize: Option[Int]
   val include: Option[W]
   val query: Option[String]
+  val aggregations: List[AggregationRequest]
   val _index: Option[String]
   val _queryType: Option[String]
-  val _aggregations: List[AggregationRequest]
   val request: Request
 }
 
 case class V1MultipleResultsRequest(
   @Min(1) @QueryParam page: Int = 1,
   @Min(1) @Max(100) @QueryParam pageSize: Option[Int],
+  @QueryParam() aggregations: List[AggregationRequest] = Nil,
   @QueryParam includes: Option[V1WorksIncludes],
   @QueryParam query: Option[String],
   @QueryParam _index: Option[String],
   @QueryParam _queryType: Option[String] = None,
-  @QueryParam() _aggregations: List[AggregationRequest] = Nil,
   request: Request
 ) extends MultipleResultsRequest[V1WorksIncludes] {
   val include: Option[V1WorksIncludes] = includes
@@ -47,11 +47,11 @@ case class V2MultipleResultsRequest(
   @QueryParam query: Option[String],
   @QueryParam workType: Option[String],
   @QueryParam("items.locations.locationType") itemLocationType: Option[String],
+  @QueryParam() aggregations: List[AggregationRequest] = Nil,
   @QueryParam _index: Option[String],
   @QueryParam _queryType: Option[String],
   @QueryParam _dateFrom: Option[LocalDate],
   @QueryParam _dateTo: Option[LocalDate],
-  @QueryParam() _aggregations: List[AggregationRequest] = Nil,
   request: Request
 ) extends MultipleResultsRequest[V2WorksIncludes]
 

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/responses/Responses.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/responses/Responses.scala
@@ -2,7 +2,10 @@ package uk.ac.wellcome.platform.api.responses
 
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonUnwrapped}
 import uk.ac.wellcome.display.models.{DisplayWork, WorksIncludes}
-import uk.ac.wellcome.platform.api.models.{AggregationSet, DisplayResultList}
+import uk.ac.wellcome.platform.api.models.{
+  DisplayAggregations,
+  DisplayResultList
+}
 import uk.ac.wellcome.platform.api.requests.{ApiRequest, MultipleResultsRequest}
 
 case class ResultResponse(
@@ -19,7 +22,7 @@ case class ResultListResponse(
   results: List[_ <: Any],
   prevPage: Option[String] = None,
   nextPage: Option[String] = None,
-  aggregations: Option[AggregationSet] = None
+  aggregations: Option[DisplayAggregations] = None
 )
 
 object ResultListResponse {

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -11,7 +11,7 @@ import com.sksamuel.elastic4s.requests.searches.{SearchHit, SearchResponse}
 import uk.ac.wellcome.display.models.AggregationRequest
 import uk.ac.wellcome.models.work.internal.{IdentifiedBaseWork, IdentifiedWork}
 import uk.ac.wellcome.platform.api.models.{
-  AggregationSet,
+  Aggregations,
   ResultList,
   WorkFilter,
   WorkQuery
@@ -136,8 +136,8 @@ class WorksService @Inject()(searchService: ElasticsearchService)(
     }.toList
 
   private def searchResponseToAggregationResults(
-    searchResponse: SearchResponse): Option[AggregationSet] = {
-    AggregationSet(searchResponse.aggregationsAsString)
+    searchResponse: SearchResponse): Option[Aggregations] = {
+    Aggregations(searchResponse.aggregationsAsString)
   }
 
   private def jsonTo[T <: IdentifiedBaseWork](document: String)(

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/models/AggregationResultsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/models/AggregationResultsTest.scala
@@ -43,7 +43,7 @@ class AggregationResultsTest extends FunSpec with Matchers {
         |}
         |""".stripMargin
 
-    val singleAgg = AggregationSet(responseString)
+    val singleAgg = Aggregations(responseString)
     singleAgg.get.workType shouldBe Some(
       Aggregation(List(
         AggregationBucket(data = WorkType("a", "Books"), count = 393145),

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/responses/ResultListResponseTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/responses/ResultListResponseTest.scala
@@ -27,10 +27,10 @@ class ResultListResponseTest extends FunSpec with Matchers {
     pageSize = Some(displayResultList.pageSize),
     includes = None,
     query = None,
+    aggregations = Nil,
     _queryType = None,
     _index = None,
-    request = Request(method = Method.Get, uri = requestUri),
-    _aggregations = Nil
+    request = Request(method = Method.Get, uri = requestUri)
   )
 
   it("inclues a nextPage and prevPage parameter where appropriate") {

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -14,7 +14,7 @@ import uk.ac.wellcome.platform.api.generators.SearchOptionsGenerators
 import uk.ac.wellcome.platform.api.models.{
   Aggregation,
   AggregationBucket,
-  AggregationSet,
+  Aggregations,
   DateRangeFilter,
   ResultList,
   WorkTypeFilter
@@ -422,7 +422,7 @@ class WorksServiceTest
             createWorksSearchOptionsWith(
               aggregations = List(WorkTypeAggregationRequest()))
 
-          val expectedAggregations = AggregationSet(
+          val expectedAggregations = Aggregations(
             Some(
               Aggregation(List(
                 AggregationBucket(data = WorkType("a", "Archives"), count = 1),
@@ -450,7 +450,7 @@ class WorksServiceTest
     allWorks: Seq[IdentifiedBaseWork],
     expectedWorks: Seq[IdentifiedBaseWork],
     expectedTotalResults: Int,
-    expectedAggregations: Option[AggregationSet] = None,
+    expectedAggregations: Option[Aggregations] = None,
     worksSearchOptions: WorksSearchOptions = createWorksSearchOptions
   ): Assertion =
     assertResultIsCorrect(
@@ -466,7 +466,7 @@ class WorksServiceTest
     allWorks: Seq[IdentifiedBaseWork],
     expectedWorks: Seq[IdentifiedBaseWork],
     expectedTotalResults: Int,
-    expectedAggregations: Option[AggregationSet] = None,
+    expectedAggregations: Option[Aggregations] = None,
     worksSearchOptions: WorksSearchOptions = createWorksSearchOptions
   ): Assertion =
     assertResultIsCorrect(
@@ -486,7 +486,7 @@ class WorksServiceTest
     allWorks: Seq[IdentifiedBaseWork],
     expectedWorks: Seq[IdentifiedBaseWork],
     expectedTotalResults: Int,
-    expectedAggregations: Option[AggregationSet],
+    expectedAggregations: Option[Aggregations],
     worksSearchOptions: WorksSearchOptions
   ): Assertion =
     withLocalWorksIndex { index =>

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2ErrorsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2ErrorsTest.scala
@@ -45,22 +45,22 @@ class ApiV2ErrorsTest extends ApiV2WorksTestBase with ApiErrorsTestBase {
     "returns a 400 Bad Request for errors in the ?aggregations parameter") {
     it("a single invalid aggregation") {
       assertIsBadRequest(
-        "/works?_aggregations=foo",
-        description = "_aggregations: 'foo' is not a valid aggregation"
+        "/works?aggregations=foo",
+        description = "aggregations: 'foo' is not a valid aggregation"
       )
     }
 
     it("multiple invalid aggregations") {
       assertIsBadRequest(
-        "/works?_aggregations=foo,bar",
-        description = "_aggregations: 'foo', 'bar' are not valid aggregations"
+        "/works?aggregations=foo,bar",
+        description = "aggregations: 'foo', 'bar' are not valid aggregations"
       )
     }
 
     it("a mixture of valid and invalid aggregations") {
       assertIsBadRequest(
-        "/works?_aggregations=foo,workType,bar",
-        description = "_aggregations: 'foo', 'bar' are not valid aggregations"
+        "/works?aggregations=foo,workType,bar",
+        description = "aggregations: 'foo', 'bar' are not valid aggregations"
       )
     }
   }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -399,7 +399,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
 
         eventually {
           server.httpGet(
-            path = s"/$apiPrefix/works?_aggregations=workType",
+            path = s"/$apiPrefix/works?aggregations=workType",
             andExpect = Status.Ok,
             withJsonBody = s"""
                               |{

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -406,31 +406,36 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
                               |  ${resultList(apiPrefix, totalResults = 5)},
                               |  "results": [],
                               |  "aggregations": {
+                              |  "type" : "Aggregations",
                               |   "workType": {
+                              |     "type" : "Aggregation",
                               |     "buckets": [
                               |       {
                               |         "data" : {
                               |           "id" : "a",
                               |           "label" : "Books",
-                              |           "ontologyType" : "WorkType"
+                              |           "type" : "WorkType"
                               |         },
-                              |         "count" : 2
+                              |         "count" : 2,
+                              |         "type" : "AggregationBucket"
                               |       },
                               |       {
                               |         "data" : {
                               |           "id" : "d",
                               |           "label" : "Journals",
-                              |           "ontologyType" : "WorkType"
+                              |           "type" : "WorkType"
                               |         },
-                              |         "count" : 1
+                              |         "count" : 1,
+                              |         "type" : "AggregationBucket"
                               |       },
                               |       {
                               |         "data" : {
                               |           "id" : "k",
                               |           "label" : "Pictures",
-                              |           "ontologyType" : "WorkType"
+                              |           "type" : "WorkType"
                               |         },
-                              |         "count" : 2
+                              |         "count" : 2,
+                              |         "type" : "AggregationBucket"
                               |       }
                               |     ]
                               |   }


### PR DESCRIPTION
https://github.com/wellcometrust/platform/issues/3864

* Rename `AggregationSet` => `Aggregations` - there's no need to put the data type in the name @jtweed 
* Add Display version off `Aggregations`. I didn't create a Display case object for all the types as it seemed like overkill, and also had to convert the `WorkType` => `DisplayWorkType`. This doesn't seem like the best way, but without rethinking the whole `JSON => InternalType => DisplayType` paradigm, this seemed most inline with what we have.


