### PR TITLE
Get sierra data from S3 directly in the transformer rather than VHS

### DIFF
--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
@@ -14,7 +14,6 @@ import uk.ac.wellcome.storage.{
   Identified,
   ObjectLocation,
   ObjectLocationPrefix,
-  ReadError,
   Version
 }
 import uk.ac.wellcome.storage.maxima.Maxima
@@ -60,59 +59,4 @@ class VHSInternalStore[T, Metadata](
       id.id.toString,
       id.version.toString,
       UUID.randomUUID().toString)
-}
-
-case class BackwardsCompatObjectLocation(namespace: String, key: String)
-
-// The adaptor stores ObjectLocation with an older format to what is used by the
-// recent storage libs: namely the `path` is stored as `key`. This store uses
-// the old format internally whilst exposing the modern API
-class BackwardsCompatIndexStore[T, Metadata](
-  indexStore: Store[
-    Version[String, Int],
-    HybridIndexedStoreEntry[BackwardsCompatObjectLocation, Metadata]
-  ] with Maxima[String, Int])
-    extends Store[
-      Version[String, Int],
-      HybridIndexedStoreEntry[ObjectLocation, Metadata]]
-    with Maxima[String, Int] {
-
-  type IndexEntry[Location] = HybridIndexedStoreEntry[Location, Metadata]
-
-  def get(id: Version[String, Int]): ReadEither =
-    indexStore.get(id) match {
-      case Left(error) => Left(error)
-      case Right(Identified(id, entry)) =>
-        Right(Identified(id, fromBackwardsCompat(entry)))
-    }
-
-  def put(id: Version[String, Int])(
-    entry: IndexEntry[ObjectLocation]): WriteEither =
-    indexStore.put(id)(toBackwardsCompat(entry)) match {
-      case Left(error) => Left(error)
-      case Right(Identified(id, entry)) =>
-        Right(Identified(id, fromBackwardsCompat(entry)))
-    }
-
-  def max(q: String): Either[ReadError, Int] =
-    indexStore.max(q)
-
-  private def fromBackwardsCompat(
-    entry: IndexEntry[BackwardsCompatObjectLocation])
-    : IndexEntry[ObjectLocation] =
-    entry match {
-      case HybridIndexedStoreEntry(
-          BackwardsCompatObjectLocation(namespace, path),
-          metadata) =>
-        HybridIndexedStoreEntry(ObjectLocation(namespace, path), metadata)
-    }
-
-  private def toBackwardsCompat(entry: IndexEntry[ObjectLocation])
-    : IndexEntry[BackwardsCompatObjectLocation] =
-    entry match {
-      case HybridIndexedStoreEntry(ObjectLocation(namespace, path), metadata) =>
-        HybridIndexedStoreEntry(
-          BackwardsCompatObjectLocation(namespace, path),
-          metadata)
-    }
 }

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/Main.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/Main.scala
@@ -4,7 +4,6 @@ import scala.concurrent.ExecutionContext
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import org.scanamo.auto._
 import com.typesafe.config.Config
 
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
@@ -15,11 +14,10 @@ import uk.ac.wellcome.platform.transformer.miro.services.{
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
-import uk.ac.wellcome.platform.transformer.miro.models.MiroMetadata
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.platform.transformer.miro.Implicits._
 
-import uk.ac.wellcome.bigmessaging.typesafe.{BigMessagingBuilder, VHSBuilder}
+import uk.ac.wellcome.bigmessaging.typesafe.BigMessagingBuilder
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.typesafe.SQSBuilder
 import uk.ac.wellcome.messaging.sns.SNSConfig
@@ -45,8 +43,7 @@ object Main extends WellcomeTypesafeApp {
     val vhsRecordReceiver = new MiroVHSRecordReceiver[SNSConfig](
       msgSender = BigMessagingBuilder
         .buildBigMessageSender[TransformedBaseWork](config),
-      store = VHSBuilder
-        .buildBackwardsCompatWithMetadata[MiroRecord, MiroMetadata](config)
+      store = S3TypedStore[MiroRecord]
     )
 
     new MiroTransformerWorkerService(

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiver.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiver.scala
@@ -14,7 +14,7 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.bigmessaging.BigMessageSender
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 
-import uk.ac.wellcome.storage.store.{TypedStoreEntry, Store}
+import uk.ac.wellcome.storage.store.{Store, TypedStoreEntry}
 import uk.ac.wellcome.storage.{Identified, ObjectLocation}
 
 // In future we should just receive the ID and version from the adaptor as the
@@ -64,8 +64,7 @@ class MiroVHSRecordReceiver[MsgDestination](
       .map(_ => ())
   }
 
-  private def getRecord(
-    record: HybridRecord): Try[MiroRecord] =
+  private def getRecord(record: HybridRecord): Try[MiroRecord] =
     record match {
       case HybridRecord(_, _, BackwardsCompatObjectLocation(namespace, path)) =>
         store.get(ObjectLocation(namespace, path)) match {

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
@@ -8,9 +8,9 @@ import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.platform.transformer.miro.generators.MiroRecordGenerators
 import uk.ac.wellcome.platform.transformer.miro.models.MiroMetadata
 import uk.ac.wellcome.platform.transformer.miro.services.{
+  BackwardsCompatObjectLocation,
   HybridRecord,
-  MiroVHSRecordReceiver,
-  BackwardsCompatObjectLocation
+  MiroVHSRecordReceiver
 }
 import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
 import uk.ac.wellcome.fixtures.TestWith
@@ -24,7 +24,7 @@ import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
 import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSConfig}
 
 import uk.ac.wellcome.storage.ObjectLocation
-import uk.ac.wellcome.storage.store.{TypedStoreEntry, Store}
+import uk.ac.wellcome.storage.store.{Store, TypedStoreEntry}
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.store.memory.MemoryStore
 import uk.ac.wellcome.storage.streaming.Codec._
@@ -61,10 +61,11 @@ trait MiroVHSRecordReceiverFixture
          |  "id": "${hybridRecord.id}",
          |  "location": ${toJson(hybridRecord.location).get},
          |  "version": ${hybridRecord.version},
-         |  "isClearedForCatalogueAPI": ${toJson(miroMetadata.isClearedForCatalogueAPI).get}
+         |  "isClearedForCatalogueAPI": ${toJson(
+           miroMetadata.isClearedForCatalogueAPI).get}
          |}
        """.stripMargin
-     )
+    )
   }
 
   def createHybridRecordWith(
@@ -79,7 +80,8 @@ trait MiroVHSRecordReceiverFixture
     HybridRecord(
       id = id,
       version = version,
-      location = BackwardsCompatObjectLocation(location.namespace, location.path)
+      location =
+        BackwardsCompatObjectLocation(location.namespace, location.path)
     )
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/Main.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/Main.scala
@@ -8,14 +8,14 @@ import scala.concurrent.ExecutionContext
 import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.platform.transformer.sierra.services.{
-  HybridRecordReceiver,
+  BackwardsCompatHybridRecordReceiver,
   SierraTransformerWorkerService
 }
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 import uk.ac.wellcome.models.Implicits._
 
-import uk.ac.wellcome.bigmessaging.typesafe.{BigMessagingBuilder, VHSBuilder}
+import uk.ac.wellcome.bigmessaging.typesafe.BigMessagingBuilder
 import uk.ac.wellcome.messaging.typesafe.SQSBuilder
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 
@@ -35,11 +35,11 @@ object Main extends WellcomeTypesafeApp {
     implicit val msgStore =
       S3TypedStore[TransformedBaseWork]
 
-    val messageReceiver = new HybridRecordReceiver(
+    val messageReceiver = new BackwardsCompatHybridRecordReceiver(
       msgSender = BigMessagingBuilder
         .buildBigMessageSender[TransformedBaseWork](config),
-      store = VHSBuilder
-        .buildBackwardsCompat[SierraTransformable](config))
+      store = S3TypedStore[SierraTransformable]
+    )
 
     new SierraTransformerWorkerService(
       messageReceiver = messageReceiver,

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/HybridRecordReceiver.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/HybridRecordReceiver.scala
@@ -24,8 +24,6 @@ case class HybridRecord(
   location: BackwardsCompatObjectLocation
 )
 
-case class UpcomingMsg(id: String, version: Int)
-
 abstract class HybridRecordReceiver[MsgDestination, MsgIn](
   msgSender: BigMessageSender[MsgDestination, TransformedBaseWork])(
   implicit decoder: Decoder[MsgIn]) extends Logging {
@@ -70,6 +68,11 @@ class BackwardsCompatHybridRecordReceiver[MsgDestination](
     }
 }
 
+case class UpcomingMsg(id: String, version: Int)
+
+// When the adaptor has been updated to use the new storage lib we should use this
+// receiver. The adaptor should be changed to emit just id / version as location is
+// an internal detail that should ideally be abstracted away.
 class UpcomingHybridRecordReceiver[MsgDestination](
   msgSender: BigMessageSender[MsgDestination, TransformedBaseWork],
   store: Store[Version[String, Int], HybridStoreEntry[SierraTransformable, EmptyMetadata]])

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/HybridRecordReceiver.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/HybridRecordReceiver.scala
@@ -13,7 +13,7 @@ import uk.ac.wellcome.bigmessaging.EmptyMetadata
 import uk.ac.wellcome.bigmessaging.BigMessageSender
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 
-import uk.ac.wellcome.storage.store.{HybridStoreEntry, VersionedStore, TypedStore, TypedStoreEntry}
+import uk.ac.wellcome.storage.store.{Store, HybridStoreEntry, TypedStoreEntry}
 import uk.ac.wellcome.storage.{Identified, Version, ObjectLocation}
 
 case class BackwardsCompatObjectLocation(namespace: String, key: String)
@@ -50,10 +50,11 @@ abstract class HybridRecordReceiver[MsgDestination, Location](
 
 class BackwardsCompatHybridRecordReceiver[MsgDestination](
   msgSender: BigMessageSender[MsgDestination, TransformedBaseWork],
-  store: TypedStore[ObjectLocation, SierraTransformable])
+  store: Store[ObjectLocation, TypedStoreEntry[SierraTransformable]])
     extends HybridRecordReceiver[MsgDestination, BackwardsCompatObjectLocation](msgSender) with Logging {
 
-  protected def getTransformable(record: HybridRecord[BackwardsCompatObjectLocation]): Try[SierraTransformable] =
+  protected def getTransformable(
+    record: HybridRecord[BackwardsCompatObjectLocation]): Try[SierraTransformable] =
     record match {
       case HybridRecord(_, _, BackwardsCompatObjectLocation(namespace, path)) =>
         store.get(ObjectLocation(namespace, path)) match {
@@ -66,9 +67,7 @@ class BackwardsCompatHybridRecordReceiver[MsgDestination](
 
 class UpcomingHybridRecordReceiver[MsgDestination](
   msgSender: BigMessageSender[MsgDestination, TransformedBaseWork],
-  store: VersionedStore[String,
-                        Int,
-                        HybridStoreEntry[SierraTransformable, EmptyMetadata]])
+  store: Store[Version[String, Int], HybridStoreEntry[SierraTransformable, EmptyMetadata]])
     extends HybridRecordReceiver[MsgDestination, ObjectLocation](msgSender) with Logging {
 
   protected def getTransformable(record: HybridRecord[ObjectLocation]): Try[SierraTransformable] =

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/SierraTransformerWorkerService.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/SierraTransformerWorkerService.scala
@@ -9,8 +9,8 @@ import uk.ac.wellcome.typesafe.Runnable
 
 import scala.concurrent.Future
 
-class SierraTransformerWorkerService[MsgDestination](
-  messageReceiver: HybridRecordReceiver[MsgDestination],
+class SierraTransformerWorkerService[MsgDestination, Location](
+  messageReceiver: HybridRecordReceiver[MsgDestination, Location],
   sierraTransformer: SierraTransformableTransformer,
   sqsStream: SQSStream[NotificationMessage]
 ) extends Runnable {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/SierraTransformerWorkerService.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/SierraTransformerWorkerService.scala
@@ -9,8 +9,8 @@ import uk.ac.wellcome.typesafe.Runnable
 
 import scala.concurrent.Future
 
-class SierraTransformerWorkerService[MsgDestination, Location](
-  messageReceiver: HybridRecordReceiver[MsgDestination, Location],
+class SierraTransformerWorkerService[MsgDestination, MsgIn](
+  messageReceiver: HybridRecordReceiver[MsgDestination, MsgIn],
   sierraTransformer: SierraTransformableTransformer,
   sqsStream: SQSStream[NotificationMessage]
 ) extends Runnable {

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformerIntegrationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformerIntegrationTest.scala
@@ -1,111 +1,92 @@
 package uk.ac.wellcome.platform.transformer.sierra
 
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType
 import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.{FunSpec, Matchers}
 
 import uk.ac.wellcome.models.transformable.sierra.test.utils.SierraGenerators
 import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.work.internal.UnidentifiedWork
-import uk.ac.wellcome.platform.transformer.sierra.services.SierraTransformerWorkerService
-import uk.ac.wellcome.platform.transformer.sierra.fixtures.HybridRecordReceiverFixture
+import uk.ac.wellcome.platform.transformer.sierra.services.{
+  SierraTransformerWorkerService,
+  BackwardsCompatObjectLocation
+}
+import uk.ac.wellcome.platform.transformer.sierra.fixtures.BackwardsCompatHybridRecordReceiverFixture
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.json.JsonUtil._
 
 import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
-import uk.ac.wellcome.bigmessaging.typesafe.VHSBuilder
 import uk.ac.wellcome.messaging.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSConfig}
 
-import uk.ac.wellcome.storage.fixtures.DynamoFixtures
-import uk.ac.wellcome.storage.dynamo.DynamoConfig
-import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 import uk.ac.wellcome.storage.streaming.Codec._
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
+import uk.ac.wellcome.storage.store.s3.S3TypedStore
 
 class SierraTransformerIntegrationTest
     extends FunSpec
     with Matchers
     with IntegrationPatience
-    with DynamoFixtures
     with BigMessagingFixture
-    with HybridRecordReceiverFixture
+    with BackwardsCompatHybridRecordReceiverFixture
     with SierraGenerators {
-
-  override def createTable(
-    table: DynamoFixtures.Table): DynamoFixtures.Table = {
-    createTableWithHashKey(
-      table,
-      keyName = "id",
-      keyType = ScalarAttributeType.S
-    )
-  }
 
   it("transforms sierra records and publishes the result to the given topic") {
     withLocalSnsTopic { topic =>
       withLocalSqsQueue { queue =>
         withLocalS3Bucket { storageBucket =>
           withLocalS3Bucket { messagingBucket =>
-            withLocalDynamoDbTable { table =>
-              val vhs = VHSBuilder.build[SierraTransformable](
-                ObjectLocationPrefix(
-                  namespace = storageBucket.name,
-                  path = "sierra"),
-                DynamoConfig(table.name, table.index),
-                dynamoClient,
-                s3Client,
-              )
-              withWorkerService(vhs, topic, messagingBucket, queue) {
-                workerService =>
-                  val id = createSierraBibNumber
-                  val title = "A pot of possums"
-                  val sierraTransformable = SierraTransformable(
-                    bibRecord = createSierraBibRecordWith(
-                      id = id,
-                      data = s"""
-                     |{
-                     | "id": "$id",
-                     | "title": "$title",
-                     | "varFields": []
-                     |}
-                      """.stripMargin
-                    )
+            val store = S3TypedStore[SierraTransformable]
+            withWorkerService(store, topic, messagingBucket, queue) {
+              workerService =>
+                val id = createSierraBibNumber
+                val title = "A pot of possums"
+                val sierraTransformable = SierraTransformable(
+                  bibRecord = createSierraBibRecordWith(
+                    id = id,
+                    data = s"""
+                   |{
+                   | "id": "$id",
+                   | "title": "$title",
+                   | "varFields": []
+                   |}
+                    """.stripMargin
                   )
-                  sendSqsMessage(
-                    queue = queue,
-                    obj = createHybridRecordNotificationWith(
-                      sierraTransformable,
-                      vhs
-                    )
+                )
+                sendSqsMessage(
+                  queue = queue,
+                  obj = createHybridRecordNotificationWith(
+                    sierraTransformable,
+                    store,
+                    namespace = storageBucket.name,
                   )
-                  eventually {
-                    val snsMessages = listMessagesReceivedFromSNS(topic)
-                    snsMessages.size should be >= 1
+                )
+                eventually {
+                  val snsMessages = listMessagesReceivedFromSNS(topic)
+                  snsMessages.size should be >= 1
 
-                    val sourceIdentifier =
-                      createSierraSystemSourceIdentifierWith(
-                        value = id.withCheckDigit
-                      )
+                  val sourceIdentifier =
+                    createSierraSystemSourceIdentifierWith(
+                      value = id.withCheckDigit
+                    )
 
-                    val sierraIdentifier =
-                      createSierraIdentifierSourceIdentifierWith(
-                        value = id.withoutCheckDigit
-                      )
+                  val sierraIdentifier =
+                    createSierraIdentifierSourceIdentifierWith(
+                      value = id.withoutCheckDigit
+                    )
 
-                    val works = getMessages[UnidentifiedWork](topic)
-                    works.length shouldBe >=(1)
+                  val works = getMessages[UnidentifiedWork](topic)
+                  works.length shouldBe >=(1)
 
-                    works.map { actualWork =>
-                      actualWork.sourceIdentifier shouldBe sourceIdentifier
-                      actualWork.title shouldBe title
-                      actualWork.identifiers shouldBe List(
-                        sourceIdentifier,
-                        sierraIdentifier)
-                    }
+                  works.map { actualWork =>
+                    actualWork.sourceIdentifier shouldBe sourceIdentifier
+                    actualWork.title shouldBe title
+                    actualWork.identifiers shouldBe List(
+                      sourceIdentifier,
+                      sierraIdentifier)
                   }
-              }
+                }
             }
           }
         }
@@ -113,12 +94,12 @@ class SierraTransformerIntegrationTest
     }
   }
 
-  def withWorkerService[R](vhs: VHS,
+  def withWorkerService[R](store: SierraStore,
                            topic: Topic,
                            bucket: Bucket,
                            queue: Queue)(
-    testWith: TestWith[SierraTransformerWorkerService[SNSConfig, ObjectLocation], R]): R =
-    withHybridRecordReceiver(vhs, topic, bucket) { messageReceiver =>
+    testWith: TestWith[SierraTransformerWorkerService[SNSConfig, BackwardsCompatObjectLocation], R]): R =
+    withHybridRecordReceiver(store, topic, bucket) { messageReceiver =>
       withActorSystem { implicit actorSystem =>
         withSQSStream[NotificationMessage, R](queue) { sqsStream =>
           val workerService = new SierraTransformerWorkerService(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformerIntegrationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformerIntegrationTest.scala
@@ -21,7 +21,7 @@ import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSConfig}
 
 import uk.ac.wellcome.storage.fixtures.DynamoFixtures
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
-import uk.ac.wellcome.storage.ObjectLocationPrefix
+import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 import uk.ac.wellcome.storage.streaming.Codec._
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 
@@ -49,7 +49,7 @@ class SierraTransformerIntegrationTest
         withLocalS3Bucket { storageBucket =>
           withLocalS3Bucket { messagingBucket =>
             withLocalDynamoDbTable { table =>
-              val vhs = VHSBuilder.buildBackwardsCompat[SierraTransformable](
+              val vhs = VHSBuilder.build[SierraTransformable](
                 ObjectLocationPrefix(
                   namespace = storageBucket.name,
                   path = "sierra"),
@@ -117,7 +117,7 @@ class SierraTransformerIntegrationTest
                            topic: Topic,
                            bucket: Bucket,
                            queue: Queue)(
-    testWith: TestWith[SierraTransformerWorkerService[SNSConfig], R]): R =
+    testWith: TestWith[SierraTransformerWorkerService[SNSConfig, ObjectLocation], R]): R =
     withHybridRecordReceiver(vhs, topic, bucket) { messageReceiver =>
       withActorSystem { implicit actorSystem =>
         withSQSStream[NotificationMessage, R](queue) { sqsStream =>

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformerIntegrationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformerIntegrationTest.scala
@@ -7,8 +7,8 @@ import uk.ac.wellcome.models.transformable.sierra.test.utils.SierraGenerators
 import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.work.internal.UnidentifiedWork
 import uk.ac.wellcome.platform.transformer.sierra.services.{
+  HybridRecord,
   SierraTransformerWorkerService,
-  BackwardsCompatObjectLocation
 }
 import uk.ac.wellcome.platform.transformer.sierra.fixtures.BackwardsCompatHybridRecordReceiverFixture
 import uk.ac.wellcome.fixtures.TestWith
@@ -98,7 +98,7 @@ class SierraTransformerIntegrationTest
                            topic: Topic,
                            bucket: Bucket,
                            queue: Queue)(
-    testWith: TestWith[SierraTransformerWorkerService[SNSConfig, BackwardsCompatObjectLocation], R]): R =
+    testWith: TestWith[SierraTransformerWorkerService[SNSConfig, HybridRecord], R]): R =
     withHybridRecordReceiver(store, topic, bucket) { messageReceiver =>
       withActorSystem { implicit actorSystem =>
         withSQSStream[NotificationMessage, R](queue) { sqsStream =>

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/fixtures/HybridRecordReceiverFixture.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/fixtures/HybridRecordReceiverFixture.scala
@@ -6,6 +6,7 @@ import com.amazonaws.services.sns.AmazonSNS
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.platform.transformer.sierra.services.{
   HybridRecord,
+  UpcomingMsg,
   UpcomingHybridRecordReceiver,
   BackwardsCompatHybridRecordReceiver,
   BackwardsCompatObjectLocation
@@ -68,7 +69,7 @@ trait BackwardsCompatHybridRecordReceiverFixture extends BigMessagingFixture {
     store: SierraStore,
     version: Int = 1,
     namespace: String = "test",
-    id: String = Random.alphanumeric take 10 mkString): HybridRecord[BackwardsCompatObjectLocation] = {
+    id: String = Random.alphanumeric take 10 mkString): HybridRecord = {
     val location = ObjectLocation(namespace = namespace, path = id)
     store.put(location)(TypedStoreEntry(sierraTransformable, Map.empty))
     HybridRecord(
@@ -92,7 +93,7 @@ trait BackwardsCompatHybridRecordReceiverFixture extends BigMessagingFixture {
   }
 }
 
-trait HybridRecordReceiverFixture extends VHSFixture[SierraTransformable] {
+trait UpcomingHybridRecordReceiverFixture extends VHSFixture[SierraTransformable] {
 
   def withHybridRecordReceiver[R](vhs: VHS,
                                   topic: Topic,
@@ -124,14 +125,10 @@ trait HybridRecordReceiverFixture extends VHSFixture[SierraTransformable] {
     sierraTransformable: SierraTransformable,
     vhs: VHS,
     version: Int = 1,
-    id: String = Random.alphanumeric take 10 mkString): HybridRecord[ObjectLocation] = {
+    id: String = Random.alphanumeric take 10 mkString): UpcomingMsg = {
 
     vhs.put(Version(id, version))(
       HybridStoreEntry(sierraTransformable, EmptyMetadata()))
-    HybridRecord(
-      id = id,
-      version = version,
-      location = ObjectLocation("namespace.doesnt.matter", "path/is/irrelevant")
-    )
+    UpcomingMsg(id = id, version = version)
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/fixtures/HybridRecordReceiverFixture.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/fixtures/HybridRecordReceiverFixture.scala
@@ -6,7 +6,9 @@ import com.amazonaws.services.sns.AmazonSNS
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.platform.transformer.sierra.services.{
   HybridRecord,
-  UpcomingHybridRecordReceiver
+  UpcomingHybridRecordReceiver,
+  BackwardsCompatHybridRecordReceiver,
+  BackwardsCompatObjectLocation
 }
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.models.Implicits._
@@ -14,14 +16,81 @@ import uk.ac.wellcome.json.JsonUtil._
 
 import uk.ac.wellcome.models.transformable.SierraTransformable
 
-import uk.ac.wellcome.bigmessaging.fixtures.VHSFixture
+import uk.ac.wellcome.bigmessaging.fixtures.{VHSFixture, BigMessagingFixture}
 import uk.ac.wellcome.bigmessaging.EmptyMetadata
 import uk.ac.wellcome.messaging.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSConfig}
 
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
-import uk.ac.wellcome.storage.store.HybridStoreEntry
-import uk.ac.wellcome.storage.{Version, ObjectLocation}
+import uk.ac.wellcome.storage.store.{HybridStoreEntry, Store, TypedStoreEntry}
+import uk.ac.wellcome.storage.store.memory.MemoryStore
+import uk.ac.wellcome.storage.{
+  ObjectLocation,
+  StoreReadError,
+  StoreWriteError,
+  Version
+}
+
+trait BackwardsCompatHybridRecordReceiverFixture extends BigMessagingFixture {
+
+  type SierraStore = Store[ObjectLocation, TypedStoreEntry[SierraTransformable]]
+
+  def withHybridRecordReceiver[R](store: SierraStore,
+                                  topic: Topic,
+                                  bucket: Bucket,
+                                  snsClient: AmazonSNS = snsClient)(
+    testWith: TestWith[BackwardsCompatHybridRecordReceiver[SNSConfig], R]): R =
+    withSqsBigMessageSender[TransformedBaseWork, R](bucket, topic, snsClient) {
+      msgSender =>
+        val recorderReciver = new BackwardsCompatHybridRecordReceiver(msgSender, store)
+        testWith(recorderReciver)
+    }
+
+  def createHybridRecordNotificationWith(
+    sierraTransformable: SierraTransformable,
+    store: SierraStore,
+    namespace: String = "test",
+    version: Int = 1): NotificationMessage = {
+
+    val hybridRecord = createHybridRecordWith(
+      sierraTransformable,
+      store,
+      namespace = namespace,
+      version = version
+    )
+    createNotificationMessageWith(
+      message = hybridRecord
+    )
+  }
+
+  def createHybridRecordWith(
+    sierraTransformable: SierraTransformable,
+    store: SierraStore,
+    version: Int = 1,
+    namespace: String = "test",
+    id: String = Random.alphanumeric take 10 mkString): HybridRecord[BackwardsCompatObjectLocation] = {
+    val location = ObjectLocation(namespace = namespace, path = id)
+    store.put(location)(TypedStoreEntry(sierraTransformable, Map.empty))
+    HybridRecord(
+      id = id,
+      version = version,
+      location = BackwardsCompatObjectLocation(location.namespace, location.path)
+    )
+  }
+
+  def withSierraStore[R](testWith: TestWith[SierraStore, R]): R =
+    testWith(new MemoryStore(Map.empty))
+
+  def withBrokenSierraStore[R](testWith: TestWith[SierraStore, R]): R =
+    testWith(BrokenSierraStore)
+
+  object BrokenSierraStore extends SierraStore {
+    def put(id: ObjectLocation)(entry: TypedStoreEntry[SierraTransformable]): WriteEither =
+      Left(StoreWriteError(new Error("BOOM!")))
+    def get(id: ObjectLocation): ReadEither =
+      Left(StoreReadError(new Error("BOOM!")))
+  }
+}
 
 trait HybridRecordReceiverFixture extends VHSFixture[SierraTransformable] {
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/services/HybridRecordReceiverTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/services/HybridRecordReceiverTest.scala
@@ -135,7 +135,7 @@ class HybridRecordReceiverTest
               version = 1,
               location = Json.obj(
                 ("namespace", Json.fromString("some.namespace")),
-                ("key", Json.fromString("some/path"))
+                ("path", Json.fromString("some/path"))
               )
             )
           )


### PR DESCRIPTION
The `BackwardsCompatIndexStore` did not work, as the new storage lib uses a different dynamo schema to what is used on the output of the adaptor (namely it now has a column called `payload` that stores the object location) :cry: 

This PR reverts to using the S3 `location` received from the sierra adaptor directly, rather than using the `version` and `id` in the `HybridRecord` to fetch from VHS (i.e. querying dynamo for the location, then fetching from S3).

An `UpcomingHybridRecordReceiver` is included for when we manage to upgrade the adaptor to use the new storage lib (in which case we can just put the `id` and `version` on the queue and use  the VHS to fetch the sierra data).