### PR TITLE
Date filtering when work has a broader date range than query

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkFilter.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkFilter.scala
@@ -46,13 +46,10 @@ case class DateRangeFilter(fromDate: Option[LocalDate],
     val maxDate = getElasticDate(toDate, Int.MaxValue)
 
     boolQuery should (
-
       // Start date of work is within query range
       RangeQuery("production.dates.range.from", gte = minDate, lte = maxDate),
-
       // End date of work is within query range
       RangeQuery("production.dates.range.to", gte = minDate, lte = maxDate),
-
       // Work date range is broader than whole query range
       boolQuery must (
         RangeQuery("production.dates.range.from", lte = minDate),

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkFilter.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkFilter.scala
@@ -1,24 +1,66 @@
 package uk.ac.wellcome.platform.api.models
 
 import java.time.LocalDate
+import com.sksamuel.elastic4s.ElasticDate
+import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.requests.searches.queries.{Query, RangeQuery}
 
-sealed trait WorkFilter
+sealed trait WorkFilter {
+
+  def query: Query
+}
 
 case class ItemLocationTypeFilter(locationTypeIds: Seq[String])
-    extends WorkFilter
+    extends WorkFilter {
+
+  def query =
+    termsQuery(
+      field = "items.agent.locations.locationType.id",
+      values = locationTypeIds)
+}
 
 case object ItemLocationTypeFilter {
+
   def apply(locationTypeId: String): ItemLocationTypeFilter =
     ItemLocationTypeFilter(locationTypeIds = Seq(locationTypeId))
 }
 
-case class WorkTypeFilter(workTypeIds: Seq[String]) extends WorkFilter
+case class WorkTypeFilter(workTypeIds: Seq[String]) extends WorkFilter {
+
+  def query =
+    termsQuery(field = "workType.id", values = workTypeIds)
+}
 
 case object WorkTypeFilter {
+
   def apply(workTypeId: String): WorkTypeFilter =
     WorkTypeFilter(workTypeIds = Seq(workTypeId))
 }
 
 case class DateRangeFilter(fromDate: Option[LocalDate],
                            toDate: Option[LocalDate])
-    extends WorkFilter
+    extends WorkFilter {
+
+  def query = {
+    val minDate = getElasticDate(fromDate, Int.MinValue)
+    val maxDate = getElasticDate(toDate, Int.MaxValue)
+
+    boolQuery should (
+
+      // Start date of work is within query range
+      RangeQuery("production.dates.range.from", gte = minDate, lte = maxDate),
+
+      // End date of work is within query range
+      RangeQuery("production.dates.range.to", gte = minDate, lte = maxDate),
+
+      // Work date range is broader than whole query range
+      boolQuery must (
+        RangeQuery("production.dates.range.from", lte = minDate),
+        RangeQuery("production.dates.range.to", gte = maxDate)
+      )
+    )
+  }
+
+  private def getElasticDate(date: Option[LocalDate], default: Int) =
+    Some(ElasticDate(date.getOrElse(LocalDate.ofEpochDay(default))))
+}


### PR DESCRIPTION
The date filtering is potentially broken for works with broad range.

For example, if a work had an unknown date in the 1970s (or was a periodical lasting for the whole decade), and the user searched for any works between 1972-1977, the work would not show up.

This PR updates the filtering so that it would show up.

**Note:** I may be wrong, with the new behaviour not being desired. Maybe worth discusing with @jamesgorrie Jenn, @jtweed.