### PR TITLE
Proposed method for sorting in API by "production.dates"

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -17,8 +17,8 @@ import grizzled.slf4j.Logging
 import uk.ac.wellcome.display.models.{
   AggregationRequest,
   ProductionDateFromSortRequest,
-  ProductionDateToSortRequest,
   ProductionDateSortRequest,
+  ProductionDateToSortRequest,
   SortRequest,
   SortingOrder,
   WorkTypeAggregationRequest
@@ -116,7 +116,7 @@ class ElasticsearchService @Inject()(elasticClient: ElasticClient)(
     val sort = queryOptions.sortBy
       .map {
         case ProductionDateFromSortRequest => "production.dates.range.from"
-        case ProductionDateToSortRequest => "production.dates.range.to"
+        case ProductionDateToSortRequest   => "production.dates.range.to"
         case ProductionDateSortRequest =>
           queryOptions.sortOrder match {
             case SortingOrder.Ascending  => "production.dates.range.to"

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -557,9 +557,9 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
   ) {
     withV2Api {
       case (indexV2, server: EmbeddedHttpServer) =>
-        val work1 = createDatedWork(dateLabel = "1900", canonicalId="1")
-        val work2 = createDatedWork(dateLabel = "1920", canonicalId="2")
-        val work3 = createDatedWork(dateLabel = "1910-1930", canonicalId="3")
+        val work1 = createDatedWork(dateLabel = "1900", canonicalId = "1")
+        val work2 = createDatedWork(dateLabel = "1920", canonicalId = "2")
+        val work3 = createDatedWork(dateLabel = "1910-1930", canonicalId = "3")
         insertIntoElasticsearch(indexV2, work1, work2, work3)
         val result1 =
           s"""{"id": "1", "title": "${work1.title}", "type": "Work"}"""
@@ -569,8 +569,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
           s"""{"id": "3", "title": "${work3.title}", "type": "Work"}"""
         eventually {
           server.httpGet(
-            path =
-              s"/$apiPrefix/works?sort=production.dates&sortOrder=asc",
+            path = s"/$apiPrefix/works?sort=production.dates&sortOrder=asc",
             andExpect = Status.Ok,
             withJsonBody = s"""
               |{
@@ -582,8 +581,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
         }
         eventually {
           server.httpGet(
-            path =
-              s"/$apiPrefix/works?sort=production.dates&sortOrder=desc",
+            path = s"/$apiPrefix/works?sort=production.dates&sortOrder=desc",
             andExpect = Status.Ok,
             withJsonBody = s"""
               |{

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/SortRequest.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/SortRequest.scala
@@ -8,12 +8,14 @@ case class SortsRequest(values: List[SortRequest])
 sealed trait SortRequest
 case object ProductionDateFromSortRequest extends SortRequest
 case object ProductionDateToSortRequest extends SortRequest
+case object ProductionDateSortRequest extends SortRequest
 
 object SortRequest {
   def apply(str: String): Either[InvalidSortRequest, SortRequest] =
     str match {
       case "production.dates.from" => Right(ProductionDateFromSortRequest)
       case "production.dates.to"   => Right(ProductionDateToSortRequest)
+      case "production.dates"      => Right(ProductionDateSortRequest)
       case _                       => Left(InvalidSortRequest(str))
     }
 }


### PR DESCRIPTION
## Issue

https://github.com/wellcometrust/platform/issues/3847

## Description

In #168 there was some discussion regarding the date sorting in the API.

The current implementation allows the user to explicitly sort by `production.dates.from` or `production.dates.to`. This is good for users who want flexibility, but this exposes an implementation detail that maybe should be hidden: namely, dates are stored as an `InstantRange`, which might be confusing as users would likely conceive of the vast majority of works being produced at a particular point, such as within a single year.

Here a further sort parameter `production.dates` is added. The strategy used is to

* sort by the `to` date when in `ascending` order
* sort by the `from` date when in `descending` order

This is done to stop works with broad date ranges always appearing high in the search results ([see test case for an example](https://github.com/wellcometrust/catalogue/pull/173/files#diff-15b3dabe1602921af2819a2a3456db34R555-R557)).

There are likely other strategies worth investigating, as this might not necessarily be what users want (the main issue being the results aren't reversed exactly when changing between `ascending` and `descending`), so some discussion and user research is probably required.