### PR TITLE
SierraTransformer trait

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/Main.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/Main.scala
@@ -43,7 +43,6 @@ object Main extends WellcomeTypesafeApp {
 
     new SierraTransformerWorkerService(
       messageReceiver = messageReceiver,
-      sierraTransformer = new SierraTransformableTransformer(),
       sqsStream = SQSBuilder.buildSQSStream[NotificationMessage](config)
     )
   }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
@@ -3,11 +3,14 @@ package uk.ac.wellcome.platform.transformer.sierra
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.json.exceptions.JsonDecodingError
 import uk.ac.wellcome.models.transformable.SierraTransformable
-import uk.ac.wellcome.models.transformable.sierra.{SierraItemNumber, SierraBibRecord}
+import uk.ac.wellcome.models.transformable.sierra.{
+  SierraBibRecord,
+  SierraItemNumber
+}
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.sierra.exceptions.{
-  SierraTransformerException,
-  ShouldNotTransformException
+  ShouldNotTransformException,
+  SierraTransformerException
 }
 import uk.ac.wellcome.platform.transformer.sierra.source.{
   SierraBibData,
@@ -19,16 +22,16 @@ import uk.ac.wellcome.platform.transformer.sierra.source.SierraMaterialType._
 import grizzled.slf4j.Logging
 import scala.util.{Failure, Success, Try}
 
-
 object SierraTransformableTransformer {
 
-  def apply(transformable: SierraTransformable, version: Int): Try[TransformedBaseWork] =
+  def apply(transformable: SierraTransformable,
+            version: Int): Try[TransformedBaseWork] =
     new SierraTransformableTransformer(transformable, version).transform
 }
 
-class SierraTransformableTransformer(
-  sierraTransformable: SierraTransformable,
-  version: Int) extends Logging {
+class SierraTransformableTransformer(sierraTransformable: SierraTransformable,
+                                     version: Int)
+    extends Logging {
 
   def transform: Try[TransformedBaseWork] =
     sierraTransformable.maybeBibRecord

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/SierraTransformerWorkerService.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/SierraTransformerWorkerService.scala
@@ -11,7 +11,6 @@ import scala.concurrent.Future
 
 class SierraTransformerWorkerService[MsgDestination, MsgIn](
   messageReceiver: HybridRecordReceiver[MsgDestination, MsgIn],
-  sierraTransformer: SierraTransformableTransformer,
   sqsStream: SQSStream[NotificationMessage]
 ) extends Runnable {
 
@@ -19,5 +18,5 @@ class SierraTransformerWorkerService[MsgDestination, MsgIn](
     sqsStream.foreach(this.getClass.getSimpleName, processMessage)
 
   private def processMessage(message: NotificationMessage): Future[Unit] =
-    messageReceiver.receiveMessage(message, sierraTransformer.transform)
+    messageReceiver.receiveMessage(message, SierraTransformableTransformer.apply)
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/SierraTransformerWorkerService.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/SierraTransformerWorkerService.scala
@@ -18,5 +18,7 @@ class SierraTransformerWorkerService[MsgDestination, MsgIn](
     sqsStream.foreach(this.getClass.getSimpleName, processMessage)
 
   private def processMessage(message: NotificationMessage): Future[Unit] =
-    messageReceiver.receiveMessage(message, SierraTransformableTransformer.apply)
+    messageReceiver.receiveMessage(
+      message,
+      SierraTransformableTransformer.apply)
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAlternativeTitles.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAlternativeTitles.scala
@@ -1,9 +1,11 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
-import uk.ac.wellcome.platform.transformer.sierra.source.SierraBibData
-import uk.ac.wellcome.platform.transformer.sierra.source.VarField
+import uk.ac.wellcome.platform.transformer.sierra.source.{SierraBibData, VarField}
+import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 
-trait SierraAlternativeTitles extends MarcUtils {
+object SierraAlternativeTitles extends SierraTransformer with MarcUtils {
+
+   type Output = List[String] 
 
   // Populate work:alternativeTitles
   //
@@ -14,7 +16,7 @@ trait SierraAlternativeTitles extends MarcUtils {
   //
   // 246 is only used when indicator2 is not equal to 6, as this is used for
   // the work:lettering field
-  def getAlternativeTitles(bibData: SierraBibData): List[String] =
+  def apply(bibId: SierraBibNumber, bibData: SierraBibData) =
     getAlternativeTitleFields(bibData).flatMap {
       getSubfieldContents(_, Some("a"))
     }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAlternativeTitles.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAlternativeTitles.scala
@@ -1,11 +1,14 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
-import uk.ac.wellcome.platform.transformer.sierra.source.{SierraBibData, VarField}
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  SierraBibData,
+  VarField
+}
 import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 
 object SierraAlternativeTitles extends SierraTransformer with MarcUtils {
 
-   type Output = List[String] 
+  type Output = List[String]
 
   // Populate work:alternativeTitles
   //

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraContributors.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraContributors.scala
@@ -1,12 +1,15 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
   SierraBibData
 }
 
-trait SierraContributors extends MarcUtils with SierraAgents {
+object SierraContributors extends SierraTransformer with MarcUtils with SierraAgents {
+
+  type Output = List[Contributor[MaybeDisplayable[AbstractAgent]]]
 
   /* Populate wwork:contributors. Rules:
    *
@@ -30,8 +33,7 @@ trait SierraContributors extends MarcUtils with SierraAgents {
    * https://www.loc.gov/marc/bibliographic/bd710.html
    *
    */
-  def getContributors(bibData: SierraBibData)
-    : List[Contributor[MaybeDisplayable[AbstractAgent]]] =
+  def apply(bibId: SierraBibNumber, bibData: SierraBibData) =
     getPersonContributors(bibData, marcTag = "100") ++
       getOrganisationContributors(bibData, marcTag = "110") ++
       getPersonContributors(bibData, marcTag = "700") ++

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraContributors.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraContributors.scala
@@ -7,7 +7,10 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   SierraBibData
 }
 
-object SierraContributors extends SierraTransformer with MarcUtils with SierraAgents {
+object SierraContributors
+    extends SierraTransformer
+    with MarcUtils
+    with SierraAgents {
 
   type Output = List[Contributor[MaybeDisplayable[AbstractAgent]]]
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraDescription.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraDescription.scala
@@ -1,29 +1,14 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
+import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
   SierraBibData
 }
 
-trait SierraDescription {
+object SierraDescription extends SierraTransformer {
 
-  def getSubfields(
-    bibData: SierraBibData,
-    marcTag: String,
-    marcSubfieldTags: List[String]
-  ): List[Map[String, MarcSubfield]] = {
-    val matchingFields = bibData.varFields
-      .filter {
-        _.marcTag.contains(marcTag)
-      }
-
-    matchingFields.map(varField => {
-      varField.subfields
-        .filter(subfield => marcSubfieldTags.contains(subfield.tag))
-        .map(subfield => subfield.tag -> subfield)
-        .toMap
-    })
-  }
+  type Output = Option[String]
 
   // Populate wwork:description.
   //
@@ -38,7 +23,7 @@ trait SierraDescription {
   //
   // https://www.loc.gov/marc/bibliographic/bd520.html
   //
-  def getDescription(bibData: SierraBibData): Option[String] = {
+  def apply(bibId: SierraBibNumber, bibData: SierraBibData) =
     getSubfields(bibData, "520", List("a", "b"))
       .foldLeft[List[String]](Nil)((acc, subfields) => {
 
@@ -59,5 +44,22 @@ trait SierraDescription {
       case Nil  => None
       case list => Some(list.mkString(" "))
     }
+
+  def getSubfields(
+    bibData: SierraBibData,
+    marcTag: String,
+    marcSubfieldTags: List[String]
+  ): List[Map[String, MarcSubfield]] = {
+    val matchingFields = bibData.varFields
+      .filter {
+        _.marcTag.contains(marcTag)
+      }
+
+    matchingFields.map(varField => {
+      varField.subfields
+        .filter(subfield => marcSubfieldTags.contains(subfield.tag))
+        .map(subfield => subfield.tag -> subfield)
+        .toMap
+    })
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraDimensions.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraDimensions.scala
@@ -1,8 +1,11 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import uk.ac.wellcome.platform.transformer.sierra.source.SierraBibData
+import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 
-trait SierraDimensions extends MarcUtils {
+object SierraDimensions extends SierraTransformer with MarcUtils {
+
+  type Output = Option[String]
 
   // Populate wwork:dimensions.
   //
@@ -34,7 +37,7 @@ trait SierraDimensions extends MarcUtils {
   //
   // https://www.loc.gov/marc/bibliographic/bd300.html
   //
-  def getDimensions(bibData: SierraBibData): Option[String] = {
+  def apply(bibId: SierraBibNumber, bibData: SierraBibData) = {
     val matchingSubfields = getMatchingSubfields(
       bibData = bibData,
       marcTag = "300",

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraEdition.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraEdition.scala
@@ -1,14 +1,17 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import uk.ac.wellcome.platform.transformer.sierra.source.SierraBibData
+import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 
-trait SierraEdition extends MarcUtils {
+object SierraEdition extends SierraTransformer with MarcUtils {
+
+  type Output = Option[String]
 
   // Populate work:edition
   //
   // Field 250 is used for this. In the very rare case where multiple 250 fields
   // are found, they are concatenated into a single string
-  def getEdition(bibData: SierraBibData): Option[String] = {
+  def apply(bibId: SierraBibNumber, bibData: SierraBibData) = {
     val editions = getMatchingVarFields(bibData, "250").flatMap {
       getSubfieldContents(_, Some("a"))
     }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraExtent.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraExtent.scala
@@ -1,8 +1,11 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import uk.ac.wellcome.platform.transformer.sierra.source.SierraBibData
+import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 
-trait SierraExtent extends MarcUtils {
+object SierraExtent extends SierraTransformer with MarcUtils {
+
+  type Output = Option[String]
 
   // Populate wwork:extent.
   //
@@ -24,7 +27,7 @@ trait SierraExtent extends MarcUtils {
   //
   // https://www.loc.gov/marc/bibliographic/bd300.html
   //
-  def getExtent(bibData: SierraBibData): Option[String] = {
+  def apply(bibId: SierraBibNumber, bibData: SierraBibData) = {
     val matchingSubfields = getMatchingSubfields(
       bibData = bibData,
       marcTag = "300",

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraGenres.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraGenres.scala
@@ -11,8 +11,11 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   SierraBibData,
   VarField
 }
+import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 
-trait SierraGenres extends MarcUtils with SierraConcepts {
+object SierraGenres extends SierraTransformer with MarcUtils with SierraConcepts {
+
+  type Output = List[Genre[MaybeDisplayable[AbstractConcept]]]
 
   private val marcTag = "655"
 
@@ -46,10 +49,8 @@ trait SierraGenres extends MarcUtils with SierraConcepts {
   //      Note that only concepts from subfield $a are identified; everything
   //      else is unidentified.
   //
-  def getGenres(
-    bibData: SierraBibData): List[Genre[MaybeDisplayable[AbstractConcept]]] = {
+  def apply(bibId: SierraBibNumber, bibData: SierraBibData) =
     getGenresForMarcTag(bibData, marcTag)
-  }
 
   private def getGenresForMarcTag(bibData: SierraBibData, marcTag: String) = {
     val marcVarFields = getMatchingVarFields(bibData, marcTag = marcTag)

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraGenres.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraGenres.scala
@@ -13,7 +13,10 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
 }
 import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 
-object SierraGenres extends SierraTransformer with MarcUtils with SierraConcepts {
+object SierraGenres
+    extends SierraTransformer
+    with MarcUtils
+    with SierraConcepts {
 
   type Output = List[Genre[MaybeDisplayable[AbstractConcept]]]
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiers.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiers.scala
@@ -4,7 +4,9 @@ import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 import uk.ac.wellcome.models.work.internal.{IdentifierType, SourceIdentifier}
 import uk.ac.wellcome.platform.transformer.sierra.source.SierraBibData
 
-trait SierraIdentifiers extends MarcUtils {
+object SierraIdentifiers extends SierraTransformer with MarcUtils {
+
+  type Output = List[SourceIdentifier]
 
   // Populate wwork:identifiers.
   //
@@ -18,8 +20,7 @@ trait SierraIdentifiers extends MarcUtils {
   //
   //    Adding other identifiers is out-of-scope for now.
   //
-  def getOtherIdentifiers(bibId: SierraBibNumber,
-                          bibData: SierraBibData): List[SourceIdentifier] = {
+  def apply(bibId: SierraBibNumber, bibData: SierraBibData) = {
     val sierraIdentifier = SourceIdentifier(
       identifierType = IdentifierType("sierra-identifier"),
       ontologyType = "Work",

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
@@ -11,11 +11,12 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   SierraItemData
 }
 
-trait SierraItems extends Logging with SierraLocation {
-  def getItems(bibId: SierraBibNumber,
-               bibData: SierraBibData,
-               itemDataMap: Map[SierraItemNumber, SierraItemData])
-    : List[MaybeDisplayable[Item]] = {
+case class SierraItems(itemDataMap: Map[SierraItemNumber, SierraItemData])
+  extends SierraTransformer with Logging with SierraLocation {
+
+  type Output = List[MaybeDisplayable[Item]]
+
+  def apply(bibId: SierraBibNumber, bibData: SierraBibData) = {
     val physicalItems = getPhysicalItems(itemDataMap)
     val maybeDigitalItem = getDigitalItem(bibId = bibId, bibData = bibData)
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
@@ -12,7 +12,9 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
 }
 
 case class SierraItems(itemDataMap: Map[SierraItemNumber, SierraItemData])
-  extends SierraTransformer with Logging with SierraLocation {
+    extends SierraTransformer
+    with Logging
+    with SierraLocation {
 
   type Output = List[MaybeDisplayable[Item]]
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguage.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguage.scala
@@ -2,8 +2,11 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import uk.ac.wellcome.models.work.internal.Language
 import uk.ac.wellcome.platform.transformer.sierra.source.SierraBibData
+import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 
-trait SierraLanguage {
+object SierraLanguage extends SierraTransformer {
+
+  type Output = Option[Language]
 
   // Populate wwork:language.
   //
@@ -15,7 +18,7 @@ trait SierraLanguage {
   //  - These are populated by ISO 639-2 language codes, but we treat them
   //    as opaque identifiers for our purposes.
   //
-  def getLanguage(bibData: SierraBibData): Option[Language] =
+  def apply(bibId: SierraBibNumber, bibData: SierraBibData) =
     bibData.lang.map { lang =>
       Language(
         id = lang.code,

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLettering.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLettering.scala
@@ -1,11 +1,14 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
+import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
   SierraBibData
 }
 
-trait SierraLettering {
+object SierraLettering extends SierraTransformer {
+
+  type Output = Option[String]
 
   // Populate wwork:lettering.
   //
@@ -30,7 +33,7 @@ trait SierraLettering {
   //
   // https://www.loc.gov/marc/bibliographic/bd246.html
   //
-  def getLettering(bibData: SierraBibData): Option[String] = {
+  def apply(bibId: SierraBibNumber, bibData: SierraBibData) = {
     val matchingSubfields = bibData.varFields
       .filter {
         _.marcTag.contains("246")

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidates.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidates.scala
@@ -10,6 +10,7 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   SierraBibData,
   SierraMaterialType
 }
+import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 import uk.ac.wellcome.platform.transformer.sierra.transformers.parsers.{
   MiroIdParser,
   WellcomeImagesURLParser
@@ -17,12 +18,15 @@ import uk.ac.wellcome.platform.transformer.sierra.transformers.parsers.{
 
 import scala.util.matching.Regex
 
-trait SierraMergeCandidates
-    extends MarcUtils
+object SierraMergeCandidates
+  extends SierraTransformer
+    with MarcUtils
     with WellcomeImagesURLParser
     with MiroIdParser {
 
-  def getMergeCandidates(sierraBibData: SierraBibData): List[MergeCandidate] =
+  type Output = List[MergeCandidate]
+
+  def apply(bibId: SierraBibNumber, sierraBibData: SierraBibData) =
     get776mergeCandidates(sierraBibData) ++
       getSinglePageMiroMergeCandidates(sierraBibData)
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidates.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidates.scala
@@ -19,7 +19,7 @@ import uk.ac.wellcome.platform.transformer.sierra.transformers.parsers.{
 import scala.util.matching.Regex
 
 object SierraMergeCandidates
-  extends SierraTransformer
+    extends SierraTransformer
     with MarcUtils
     with WellcomeImagesURLParser
     with MiroIdParser {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPhysicalDescription.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPhysicalDescription.scala
@@ -1,8 +1,11 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import uk.ac.wellcome.platform.transformer.sierra.source.SierraBibData
+import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 
-trait SierraPhysicalDescription extends MarcUtils {
+object SierraPhysicalDescription extends SierraTransformer with MarcUtils {
+
+  type Output = Option[String]
 
   // Populate wwork:physicalDescription.
   //
@@ -23,7 +26,7 @@ trait SierraPhysicalDescription extends MarcUtils {
   //
   // https://www.loc.gov/marc/bibliographic/bd300.html
   //
-  def getPhysicalDescription(bibData: SierraBibData): Option[String] = {
+  def apply(bibId: SierraBibNumber, bibData: SierraBibData) = {
     val matchingSubfields = getMatchingSubfields(
       bibData = bibData,
       marcTag = "300",

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraProduction.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraProduction.scala
@@ -10,7 +10,9 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
 }
 import uk.ac.wellcome.models.parse.Marc008Parser
 
-trait SierraProduction extends MarcUtils {
+object SierraProduction extends SierraTransformer with MarcUtils {
+
+  type Output = List[ProductionEvent[MaybeDisplayable[AbstractAgent]]]
 
   // Populate wwork:production.
   //
@@ -29,8 +31,7 @@ trait SierraProduction extends MarcUtils {
   // but it would be a cataloguing error -- we should reject it, and flag it
   // to the librarians.
   //
-  def getProduction(bibId: SierraBibNumber, bibData: SierraBibData)
-    : List[ProductionEvent[MaybeDisplayable[AbstractAgent]]] = {
+  def apply(bibId: SierraBibNumber, bibData: SierraBibData) = {
 
     val maybeMarc260fields = getMatchingVarFields(bibData, "260")
     val maybeMarc264fields = getMatchingVarFields(bibData, "264")

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraSubjects.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraSubjects.scala
@@ -13,12 +13,21 @@ import uk.ac.wellcome.platform.transformer.sierra.transformers.subjects.{
   SierraPersonSubjects
 }
 
-trait SierraSubjects
-    extends SierraConceptSubjects
+object SierraSubjects
+  extends SierraTransformer
+    with SierraConceptSubjects
     with SierraPersonSubjects
     with SierraOrganisationSubjects {
-  def getSubjects(bibId: SierraBibNumber, bibData: SierraBibData)
-    : List[MaybeDisplayable[Subject[MaybeDisplayable[AbstractRootConcept]]]] =
+
+  type Output = List[
+    MaybeDisplayable[
+      Subject[
+        MaybeDisplayable[AbstractRootConcept]
+      ]
+    ]
+  ]
+
+  def apply(bibId: SierraBibNumber, bibData: SierraBibData) =
     getSubjectswithAbstractConcepts(bibData) ++
       getSubjectsWithPerson(bibData) ++
       getSubjectsWithOrganisation(bibId, bibData)

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraSubjects.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraSubjects.scala
@@ -14,7 +14,7 @@ import uk.ac.wellcome.platform.transformer.sierra.transformers.subjects.{
 }
 
 object SierraSubjects
-  extends SierraTransformer
+    extends SierraTransformer
     with SierraConceptSubjects
     with SierraPersonSubjects
     with SierraOrganisationSubjects {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTitle.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTitle.scala
@@ -2,8 +2,11 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import uk.ac.wellcome.platform.transformer.sierra.exceptions.ShouldNotTransformException
 import uk.ac.wellcome.platform.transformer.sierra.source.SierraBibData
+import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 
-trait SierraTitle {
+object SierraTitle extends SierraTransformer {
+
+  type Output = String
 
   // Populate wwork:title.  The rules are as follows:
   //
@@ -11,7 +14,7 @@ trait SierraTitle {
   //
   // Note: Sierra populates this field from MARC field 245 subfields $a and $b.
   // http://www.loc.gov/marc/bibliographic/bd245.html
-  def getTitle(bibData: SierraBibData): String =
+  def apply(bibId: SierraBibNumber, bibData: SierraBibData) =
     bibData.title.getOrElse(
       throw new ShouldNotTransformException(s"Sierra record has no title!"))
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformer.scala
@@ -3,9 +3,9 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers
 import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 import uk.ac.wellcome.platform.transformer.sierra.source.SierraBibData
 
-/** 
- *  Trait for transforming incoming bib data to some output type
- */
+/**
+  *  Trait for transforming incoming bib data to some output type
+  */
 trait SierraTransformer {
 
   type Output

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformer.scala
@@ -1,0 +1,14 @@
+package uk.ac.wellcome.platform.transformer.sierra.transformers
+
+import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
+import uk.ac.wellcome.platform.transformer.sierra.source.SierraBibData
+
+/** 
+ *  Trait for transforming incoming bib data to some output type
+ */
+trait SierraTransformer {
+
+  type Output
+
+  def apply(bibId: SierraBibNumber, bibData: SierraBibData): Output
+}

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraWorkType.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraWorkType.scala
@@ -2,9 +2,12 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import uk.ac.wellcome.models.work.internal.WorkType
 import uk.ac.wellcome.platform.transformer.sierra.data.SierraMaterialTypes
+import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 import uk.ac.wellcome.platform.transformer.sierra.source.SierraBibData
 
-trait SierraWorkType {
+object SierraWorkType extends SierraTransformer {
+
+  type Output = Option[WorkType]
 
   /* Populate wwork:workType. Rules:
    *
@@ -21,7 +24,7 @@ trait SierraWorkType {
    *
    * Note: will map to a controlled vocabulary terms in future
    */
-  def getWorkType(bibData: SierraBibData): Option[WorkType] =
+  def apply(bibId: SierraBibNumber, bibData: SierraBibData) =
     bibData.materialType.map { t =>
       SierraMaterialTypes.fromCode(t.code)
     }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformerIntegrationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformerIntegrationTest.scala
@@ -105,7 +105,6 @@ class SierraTransformerIntegrationTest
         withSQSStream[NotificationMessage, R](queue) { sqsStream =>
           val workerService = new SierraTransformerWorkerService(
             messageReceiver = messageReceiver,
-            sierraTransformer = new SierraTransformableTransformer,
             sqsStream = sqsStream
           )
           workerService.run()

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAlternativeTitlesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAlternativeTitlesTest.scala
@@ -70,11 +70,10 @@ class SierraAlternativeTitlesTest
     getAlternativeTitles(varFields) shouldBe List("A", "B")
   }
 
-  val transformer = new SierraAlternativeTitles {}
-
   private def getAlternativeTitles(varFields: List[VarField]) =
-    transformer getAlternativeTitles (createSierraBibDataWith(
-      varFields = varFields))
+    SierraAlternativeTitles(
+      createSierraBibNumber,
+      createSierraBibDataWith(varFields = varFields))
 
   private def createVarField(
     content: String,

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraContributorsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraContributorsTest.scala
@@ -17,8 +17,6 @@ class SierraContributorsTest
     with MarcGenerators
     with SierraDataGenerators {
 
-  val transformer = new SierraContributors {}
-
   it("gets an empty contributor list from empty bib data") {
     transformAndCheckContributors(
       varFields = List(),
@@ -121,7 +119,7 @@ class SierraContributorsTest
       )
 
       val bibData = createSierraBibDataWith(varFields = varFields)
-      val contributors = transformer.getContributors(bibData)
+      val contributors = SierraContributors(createSierraBibNumber, bibData)
       contributors should have size 1
       val contributor = contributors.head
 
@@ -579,7 +577,8 @@ class SierraContributorsTest
     varFields: List[VarField],
     expectedContributors: List[Contributor[MaybeDisplayable[AbstractAgent]]]
   ) = {
+    val bibId = createSierraBibNumber
     val bibData = createSierraBibDataWith(varFields = varFields)
-    transformer.getContributors(bibData) shouldBe expectedContributors
+    SierraContributors(bibId, bibData) shouldBe expectedContributors
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraDescriptionTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraDescriptionTest.scala
@@ -88,13 +88,12 @@ class SierraDescriptionTest
     )
   }
 
-  val transformer = new SierraDescription {}
-
   private def assertFindsCorrectDescription(
     varFields: List[VarField],
     expectedDescription: Option[String]
   ) = {
     val bibData = createSierraBibDataWith(varFields = varFields)
-    transformer.getDescription(bibData = bibData) shouldBe expectedDescription
+    val bibId = createSierraBibNumber
+    SierraDescription(bibId, bibData) shouldBe expectedDescription
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraDimensionsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraDimensionsTest.scala
@@ -13,11 +13,10 @@ class SierraDimensionsTest
     with MarcGenerators
     with SierraDataGenerators {
 
-  val transformer = new SierraDimensions {}
-
   it("gets no dimensions if there is no MARC field 300 with subfield $$c") {
     val bibData = createSierraBibDataWith(varFields = List())
-    transformer.getDimensions(bibData = bibData) shouldBe None
+    val bibId  = createSierraBibNumber
+    SierraDimensions(bibId, bibData) shouldBe None
   }
 
   it("extracts dimensions from MARC field 300 subfield $$c") {
@@ -34,7 +33,8 @@ class SierraDimensionsTest
     )
 
     val bibData = createSierraBibDataWith(varFields = varFields)
-    transformer.getDimensions(bibData = bibData) shouldBe Some(dimensions)
+    val bibId  = createSierraBibNumber
+    SierraDimensions(bibId, bibData) shouldBe Some(dimensions)
   }
 
   it("extracts an dimensions where there are multiple MARC field 300 $$c") {
@@ -60,7 +60,7 @@ class SierraDimensionsTest
     )
 
     val bibData = createSierraBibDataWith(varFields = varFields)
-    transformer.getDimensions(bibData = bibData) shouldBe Some(
-      expectedDimensions)
+    val bibId  = createSierraBibNumber
+    SierraDimensions(bibId, bibData) shouldBe Some(expectedDimensions)
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraDimensionsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraDimensionsTest.scala
@@ -15,7 +15,7 @@ class SierraDimensionsTest
 
   it("gets no dimensions if there is no MARC field 300 with subfield $$c") {
     val bibData = createSierraBibDataWith(varFields = List())
-    val bibId  = createSierraBibNumber
+    val bibId = createSierraBibNumber
     SierraDimensions(bibId, bibData) shouldBe None
   }
 
@@ -33,7 +33,7 @@ class SierraDimensionsTest
     )
 
     val bibData = createSierraBibDataWith(varFields = varFields)
-    val bibId  = createSierraBibNumber
+    val bibId = createSierraBibNumber
     SierraDimensions(bibId, bibData) shouldBe Some(dimensions)
   }
 
@@ -60,7 +60,7 @@ class SierraDimensionsTest
     )
 
     val bibData = createSierraBibDataWith(varFields = varFields)
-    val bibId  = createSierraBibNumber
+    val bibId = createSierraBibNumber
     SierraDimensions(bibId, bibData) shouldBe Some(expectedDimensions)
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraEditionTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraEditionTest.scala
@@ -40,10 +40,10 @@ class SierraEditionTest
     getEdition(varFields) shouldBe Some("1st edition. 2nd edition.")
   }
 
-  val transformer = new SierraEdition {}
-
   private def getEdition(varFields: List[VarField]) =
-    transformer getEdition (createSierraBibDataWith(varFields = varFields))
+    SierraEdition(
+      createSierraBibNumber,
+      createSierraBibDataWith(varFields = varFields))
 
   private def createVarField(
     content: String,

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraExtentTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraExtentTest.scala
@@ -13,11 +13,9 @@ class SierraExtentTest
     with MarcGenerators
     with SierraDataGenerators {
 
-  val transformer = new SierraExtent {}
-
   it("gets no extent if there is no MARC field 300 with subfield $$a") {
     val bibData = createSierraBibDataWith(varFields = List())
-    transformer.getExtent(bibData = bibData) shouldBe None
+    SierraExtent(createSierraBibNumber, bibData) shouldBe None
   }
 
   it("extracts extent from MARC field 300 subfield $$a") {
@@ -34,7 +32,7 @@ class SierraExtentTest
     )
 
     val bibData = createSierraBibDataWith(varFields = varFields)
-    transformer.getExtent(bibData = bibData) shouldBe Some(extent)
+    SierraExtent(createSierraBibNumber, bibData) shouldBe Some(extent)
   }
 
   it("extracts an extent where there are multiple MARC field 300 $$a") {
@@ -71,6 +69,6 @@ class SierraExtentTest
     )
 
     val bibData = createSierraBibDataWith(varFields = varFields)
-    transformer.getExtent(bibData = bibData) shouldBe Some(expectedExtent)
+    SierraExtent(createSierraBibNumber, bibData) shouldBe Some(expectedExtent)
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraGenresTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraGenresTest.scala
@@ -251,8 +251,7 @@ class SierraGenresTest
       )
     )
 
-    val actualSourceIdentifiers = transformer
-      .getGenres(bibData)
+    val actualSourceIdentifiers = SierraGenres(createSierraBibNumber, bibData)
       .map { _.concepts.head }
       .map {
         case Identifiable(_: Concept, sourceIdentifier, _, _) =>
@@ -263,11 +262,9 @@ class SierraGenresTest
     expectedSourceIdentifiers shouldBe actualSourceIdentifiers
   }
 
-  private val transformer = new SierraGenres {}
-
   private def assertExtractsGenres(
     bibData: SierraBibData,
     expected: List[Genre[MaybeDisplayable[AbstractConcept]]]) = {
-    transformer.getGenres(bibData) shouldBe expected
+    SierraGenres(createSierraBibNumber, bibData) shouldBe expected
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiersTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiersTest.scala
@@ -16,7 +16,6 @@ class SierraIdentifiersTest
 
   it("passes through the main identifier from the bib record") {
     val bibId = createSierraBibNumber
-
     val expectedIdentifiers = List(
       SourceIdentifier(
         identifierType = IdentifierType("sierra-identifier"),
@@ -24,16 +23,11 @@ class SierraIdentifiersTest
         value = bibId.withoutCheckDigit
       )
     )
-
-    val otherIdentifiers =
-      transformer.getOtherIdentifiers(bibId, bibData = createSierraBibData)
-
-    otherIdentifiers shouldBe expectedIdentifiers
+    SierraIdentifiers(bibId, createSierraBibData) shouldBe expectedIdentifiers
   }
 
   it("passes through an ISBN identifier if present") {
     val isbn = "1785783033"
-
     val bibData = createSierraBibDataWith(
       varFields = List(
         createVarFieldWith(
@@ -44,12 +38,7 @@ class SierraIdentifiersTest
         )
       )
     )
-
-    val otherIdentifiers = transformer.getOtherIdentifiers(
-      bibId = createSierraBibNumber,
-      bibData = bibData
-    )
-
+    val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
     otherIdentifiers should contain(
       SourceIdentifier(
         identifierType = IdentifierType("isbn"),
@@ -61,7 +50,6 @@ class SierraIdentifiersTest
   it("passes through multiple ISBN identifiers if present") {
     val isbn10 = "1473647649"
     val isbn13 = "978-1473647640"
-
     val bibData = createSierraBibDataWith(
       varFields = List(
         createVarFieldWith(
@@ -78,19 +66,13 @@ class SierraIdentifiersTest
         )
       )
     )
-
-    val otherIdentifiers = transformer.getOtherIdentifiers(
-      bibId = createSierraBibNumber,
-      bibData = bibData
-    )
-
+    val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
     otherIdentifiers should contain(
       SourceIdentifier(
         identifierType = IdentifierType("isbn"),
         ontologyType = "Work",
         value = isbn10
       ))
-
     otherIdentifiers should contain(
       SourceIdentifier(
         identifierType = IdentifierType("isbn"),
@@ -98,6 +80,4 @@ class SierraIdentifiersTest
         value = isbn13
       ))
   }
-
-  val transformer = new Object with SierraIdentifiers
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsTest.scala
@@ -15,8 +15,6 @@ import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerator
 
 class SierraItemsTest extends FunSpec with Matchers with SierraDataGenerators {
 
-  val transformer = new Object with SierraItems
-
   it("creates both forms of the Sierra ID in 'identifiers'") {
     val itemData = createSierraItemData
     val itemId = createSierraItemNumber
@@ -230,9 +228,5 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataGenerators {
     bibData: SierraBibData = createSierraBibData,
     itemDataMap: Map[SierraItemNumber, SierraItemData] = Map())
     : List[MaybeDisplayable[Item]] =
-    transformer.getItems(
-      bibId = bibId,
-      bibData = bibData,
-      itemDataMap = itemDataMap
-    )
+    SierraItems(itemDataMap)(bibId, bibData)
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguageTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguageTest.scala
@@ -10,11 +10,9 @@ class SierraLanguageTest
     with Matchers
     with SierraDataGenerators {
 
-  val transformer = new SierraLanguage {}
-
   it("ignores records which don't have a lang field") {
     val bibData = createSierraBibDataWith(lang = None)
-    transformer.getLanguage(bibData = bibData) shouldBe None
+    SierraLanguage(createSierraBibNumber, bibData) shouldBe None
   }
 
   it("picks up the language from the lang field") {
@@ -26,7 +24,7 @@ class SierraLanguageTest
         ))
     )
 
-    transformer.getLanguage(bibData = bibData) shouldBe Some(
+    SierraLanguage(createSierraBibNumber, bibData) shouldBe Some(
       Language(
         id = "eng",
         label = "English"

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLetteringTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLetteringTest.scala
@@ -107,13 +107,11 @@ class SierraLetteringTest
     )
   }
 
-  val transformer = new SierraLettering {}
-
   private def assertFindsCorrectLettering(
     varFields: List[VarField],
     expectedLettering: Option[String]
   ) = {
     val bibData = createSierraBibDataWith(varFields = varFields)
-    transformer.getLettering(bibData = bibData) shouldBe expectedLettering
+    SierraLettering(createSierraBibNumber, bibData) shouldBe expectedLettering
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidatesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidatesTest.scala
@@ -23,8 +23,6 @@ class SierraMergeCandidatesTest
     with MarcGenerators
     with SierraDataGenerators {
 
-  val transformer = new SierraMergeCandidates {}
-
   val mergeCandidateBibNumber = "b21414440"
   val miroID = "A0123456"
 
@@ -36,7 +34,7 @@ class SierraMergeCandidatesTest
         )
       )
 
-      transformer.getMergeCandidates(sierraData) shouldBe
+      SierraMergeCandidates(createSierraBibNumber, sierraData) shouldBe
         physicalAndDigitalSierraMergeCandidate(mergeCandidateBibNumber)
     }
 
@@ -47,7 +45,7 @@ class SierraMergeCandidatesTest
         )
       )
 
-      transformer.getMergeCandidates(sierraData) shouldBe
+      SierraMergeCandidates(createSierraBibNumber, sierraData) shouldBe
         physicalAndDigitalSierraMergeCandidate(mergeCandidateBibNumber)
     }
 
@@ -63,7 +61,7 @@ class SierraMergeCandidatesTest
         )
       )
 
-      transformer.getMergeCandidates(sierraData) shouldBe Nil
+      SierraMergeCandidates(createSierraBibNumber, sierraData) shouldBe Nil
     }
 
     it("ignores values in 776$$w that aren't prefixed with (UkLW)") {
@@ -73,7 +71,7 @@ class SierraMergeCandidatesTest
         )
       )
 
-      transformer.getMergeCandidates(sierraData) shouldBe Nil
+      SierraMergeCandidates(createSierraBibNumber, sierraData) shouldBe Nil
     }
 
     it(
@@ -84,7 +82,7 @@ class SierraMergeCandidatesTest
         )
       )
 
-      transformer.getMergeCandidates(bibData) shouldBe List()
+      SierraMergeCandidates(createSierraBibNumber, bibData) shouldBe Nil
     }
 
     it(
@@ -99,7 +97,7 @@ class SierraMergeCandidatesTest
         )
       )
 
-      transformer.getMergeCandidates(bibData) shouldBe
+      SierraMergeCandidates(createSierraBibNumber, bibData) shouldBe
         physicalAndDigitalSierraMergeCandidate(mergeCandidateBibNumber)
     }
   }
@@ -110,8 +108,8 @@ class SierraMergeCandidatesTest
         urls = List(s"http://wellcomeimages.org/indexplus/image/$miroID.html")
       )
 
-      transformer.getMergeCandidates(bibData) shouldBe singleMiroMergeCandidate(
-        miroID)
+      SierraMergeCandidates(createSierraBibNumber, bibData) shouldBe
+        singleMiroMergeCandidate(miroID)
     }
 
     it(
@@ -123,7 +121,7 @@ class SierraMergeCandidatesTest
         )
       )
 
-      transformer.getMergeCandidates(bibData) shouldBe List()
+      SierraMergeCandidates(createSierraBibNumber, bibData) shouldBe Nil
     }
 
     it("creates a merge candidate if multiple URLs point to the same Miro ID") {
@@ -134,8 +132,8 @@ class SierraMergeCandidatesTest
         )
       )
 
-      transformer.getMergeCandidates(bibData) shouldBe singleMiroMergeCandidate(
-        miroID)
+      SierraMergeCandidates(createSierraBibNumber, bibData) shouldBe
+        singleMiroMergeCandidate(miroID)
     }
 
     it("does not create a merge candidate if the URL is unrecognised") {
@@ -144,7 +142,7 @@ class SierraMergeCandidatesTest
           "http://film.wellcome.ac.uk:15151/mediaplayer.html?fug_7340-1&pw=524ph=600.html")
       )
 
-      transformer.getMergeCandidates(bibData) shouldBe List()
+      SierraMergeCandidates(createSierraBibNumber, bibData) shouldBe Nil
     }
 
     it("creates a merge candidate if the material type is 'Picture'") {
@@ -155,7 +153,7 @@ class SierraMergeCandidatesTest
         )
       )
 
-      transformer.getMergeCandidates(bibData) shouldBe
+      SierraMergeCandidates(createSierraBibNumber, bibData) shouldBe
         singleMiroMergeCandidate(miroID)
     }
 
@@ -166,7 +164,7 @@ class SierraMergeCandidatesTest
         varFields = create089subfieldsWith(List("V 13889"))
       )
 
-      transformer.getMergeCandidates(bibData) shouldBe
+      SierraMergeCandidates(createSierraBibNumber, bibData) shouldBe
         singleMiroMergeCandidate(
           miroID = "V0013889",
           reason = "Single page Miro/Sierra work (secondary source)")
@@ -178,7 +176,7 @@ class SierraMergeCandidatesTest
         varFields = create089subfieldsWith(List("V 13889"))
       )
 
-      transformer.getMergeCandidates(bibData) shouldBe
+      SierraMergeCandidates(createSierraBibNumber, bibData) shouldBe
         singleMiroMergeCandidate(
           miroID = "V0013889",
           reason = "Single page Miro/Sierra work (secondary source)")
@@ -189,7 +187,7 @@ class SierraMergeCandidatesTest
         varFields = create089subfieldsWith(List("V 13889", "V 12"))
       )
 
-      transformer.getMergeCandidates(bibData) shouldBe List()
+      SierraMergeCandidates(createSierraBibNumber, bibData) shouldBe Nil
     }
 
     it("prefers to merge from tag 962 even if there is a 089 tag") {
@@ -199,7 +197,7 @@ class SierraMergeCandidatesTest
             ++ create089subfieldsWith(List("V 13889"))
       )
 
-      transformer.getMergeCandidates(bibData) shouldBe
+      SierraMergeCandidates(createSierraBibNumber, bibData) shouldBe
         singleMiroMergeCandidate(miroID)
     }
 
@@ -212,7 +210,7 @@ class SierraMergeCandidatesTest
             ++ create089subfieldsWith(List("V 13889"))
       )
 
-      transformer.getMergeCandidates(bibData) shouldBe List()
+      SierraMergeCandidates(createSierraBibNumber, bibData) shouldBe Nil
     }
 
     // - - - - - - -  Material type - - - - - - -
@@ -221,7 +219,7 @@ class SierraMergeCandidatesTest
         varFields = create962subfieldsForWellcomeImageUrl(miroID)
       )
 
-      transformer.getMergeCandidates(bibData) shouldBe
+      SierraMergeCandidates(createSierraBibNumber, bibData) shouldBe
         singleMiroMergeCandidate(miroID)
     }
 
@@ -230,7 +228,7 @@ class SierraMergeCandidatesTest
         varFields = create962subfieldsForWellcomeImageUrl(miroID)
       )
 
-      transformer.getMergeCandidates(bibData) shouldBe
+      SierraMergeCandidates(createSierraBibNumber, bibData) shouldBe
         singleMiroMergeCandidate(miroID)
     }
 
@@ -240,7 +238,7 @@ class SierraMergeCandidatesTest
         varFields = create962subfieldsForWellcomeImageUrl(miroID),
         materialTypeCode = 'x')
 
-      transformer.getMergeCandidates(bibData) shouldBe List()
+      SierraMergeCandidates(createSierraBibNumber, bibData) shouldBe Nil
     }
   }
 
@@ -260,12 +258,13 @@ class SierraMergeCandidatesTest
         physicalAndDigitalSierraMergeCandidate(mergeCandidateBibNumber) ++
           singleMiroMergeCandidate(miroID)
 
-      transformer.getMergeCandidates(sierraData) shouldBe expectedMergeCandidates
+      SierraMergeCandidates(createSierraBibNumber, sierraData) shouldBe
+        expectedMergeCandidates
     }
 
     it("returns an empty list if there is no MARC tag 776 or 962") {
       val sierraData = createSierraBibDataWith(varFields = List())
-      transformer.getMergeCandidates(sierraData) shouldBe Nil
+      SierraMergeCandidates(createSierraBibNumber, sierraData) shouldBe Nil
     }
   }
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPhysicalDescriptionTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPhysicalDescriptionTest.scala
@@ -13,16 +13,14 @@ class SierraPhysicalDescriptionTest
     with MarcGenerators
     with SierraDataGenerators {
 
-  val transformer = new SierraPhysicalDescription {}
-
   it(
     "gets no physical description if there is no MARC field 300 with subfield $b") {
     val bibData = createSierraBibDataWith(varFields = List())
-    transformer.getPhysicalDescription(bibData = bibData) shouldBe None
+    SierraPhysicalDescription(createSierraBibNumber, bibData) shouldBe None
   }
 
   it("extracts physical description from MARC field 300 subfield $b") {
-    val physicalDescription = "Queuing quokkas quarrel about Quirinus Quirrell"
+    val expectedDescription = "Queuing quokkas quarrel about Quirinus Quirrell"
 
     val varFields = List(
       createVarFieldWith(
@@ -34,17 +32,15 @@ class SierraPhysicalDescriptionTest
           ),
           MarcSubfield(
             tag = "b",
-            content = physicalDescription
+            content = expectedDescription
           )
         )
       )
     )
 
     val bibData = createSierraBibDataWith(varFields = varFields)
-
-    transformer
-      .getPhysicalDescription(bibData = bibData)
-      .get shouldBe physicalDescription
+    val bibId = createSierraBibNumber
+    SierraPhysicalDescription(bibId, bibData) shouldBe Some(expectedDescription)
   }
 
   it(
@@ -52,7 +48,7 @@ class SierraPhysicalDescriptionTest
     val physicalDescription1 = "The queer quolls quits and quarrels"
     val physicalDescription2 = "A quintessential quadraped is quick"
 
-    val expectedPhysicalDescription =
+    val expectedDescription =
       s"$physicalDescription1\n\n$physicalDescription2"
 
     val varFields = List(
@@ -81,9 +77,7 @@ class SierraPhysicalDescriptionTest
     )
 
     val bibData = createSierraBibDataWith(varFields = varFields)
-
-    transformer
-      .getPhysicalDescription(bibData = bibData)
-      .get shouldBe expectedPhysicalDescription
+    val bibId = createSierraBibNumber
+    SierraPhysicalDescription(bibId, bibData) shouldBe Some(expectedDescription)
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraProductionTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraProductionTest.scala
@@ -293,7 +293,7 @@ class SierraProductionTest
         val bibId = createSierraBibNumber
 
         val caught = intercept[CataloguingException] {
-          transformer.getProduction(bibId, bibData)
+          SierraProduction(bibId, bibData)
         }
 
         caught.getMessage should startWith("Problem in the Sierra data")
@@ -459,7 +459,7 @@ class SierraProductionTest
       val bibId = createSierraBibNumber
 
       val caught = intercept[CataloguingException] {
-        transformer.getProduction(bibId, bibData)
+        SierraProduction(bibId, bibData)
       }
 
       caught.getMessage should startWith("Problem in the Sierra data")
@@ -683,8 +683,6 @@ class SierraProductionTest
   private def transformToProduction(varFields: List[VarField])
     : List[ProductionEvent[MaybeDisplayable[AbstractAgent]]] = {
     val bibData = createSierraBibDataWith(varFields = varFields)
-    transformer.getProduction(bibId = createSierraBibNumber, bibData)
+    SierraProduction(createSierraBibNumber, bibData)
   }
-
-  val transformer = new SierraProduction {}
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTitleTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTitleTest.scala
@@ -17,18 +17,16 @@ class SierraTitleTest extends FunSpec with Matchers with SierraDataGenerators {
   it("throws a ShouldNotTransform exception if bibData has no title") {
     val bibData = createSierraBibDataWith(title = None)
     val caught = intercept[ShouldNotTransformException] {
-      transformer.getTitle(bibData = bibData)
+      SierraTitle(createSierraBibNumber, bibData)
     }
     caught.getMessage shouldBe "Sierra record has no title!"
   }
-
-  val transformer = new Object with SierraTitle
 
   private def assertTitleIsCorrect(
     bibDataTitle: String,
     expectedTitle: String
   ) = {
     val bibData = createSierraBibDataWith(title = Some(bibDataTitle))
-    transformer.getTitle(bibData = bibData) shouldBe expectedTitle
+    SierraTitle(createSierraBibNumber, bibData) shouldBe expectedTitle
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTestBase.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTestBase.scala
@@ -10,12 +10,10 @@ import scala.util.Try
 
 trait SierraTransformableTestBase extends Matchers {
 
-  val transformer: SierraTransformableTransformer
-
   def transformToWork(
     transformable: SierraTransformable): TransformedBaseWork = {
     val triedWork: Try[TransformedBaseWork] =
-      transformer.transform(transformable, version = 1)
+      SierraTransformableTransformer(transformable, version = 1)
 
     if (triedWork.isFailure) {
       triedWork.failed.get.printStackTrace()
@@ -31,8 +29,7 @@ trait SierraTransformableTestBase extends Matchers {
   }
 
   def assertTransformToWorkFails(transformable: SierraTransformable): Unit = {
-    transformer
-      .transform(transformable, version = 1)
+    SierraTransformableTransformer(transformable, version = 1)
       .isSuccess shouldBe false
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTestBase.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTestBase.scala
@@ -29,7 +29,6 @@ trait SierraTransformableTestBase extends Matchers {
   }
 
   def assertTransformToWorkFails(transformable: SierraTransformable): Unit = {
-    SierraTransformableTransformer(transformable, version = 1)
-      .isSuccess shouldBe false
+    SierraTransformableTransformer(transformable, version = 1).isSuccess shouldBe false
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
@@ -23,7 +23,6 @@ class SierraTransformableTransformerTest
     with SierraGenerators
     with SierraTransformableTestBase
     with WorksGenerators {
-  val transformer = new SierraTransformableTransformer
 
   it("performs a transformation on a work with physical items") {
     val itemRecords = List(
@@ -75,7 +74,7 @@ class SierraTransformableTransformerTest
       label = "Pictures"
     )
 
-    val triedWork = transformer.transform(
+    val triedWork = SierraTransformableTransformer(
       createSierraTransformableWith(id, Some(bibRecord)),
       1)
     triedWork.isSuccess shouldBe true
@@ -863,7 +862,7 @@ class SierraTransformableTransformerTest
         )
       )
 
-      val result = transformer.transform(transformable, version = 1)
+      val result = SierraTransformableTransformer(transformable, version = 1)
       result.isFailure shouldBe true
       result.failed.get shouldBe a[SierraTransformerException]
       result.failed.get
@@ -885,7 +884,7 @@ class SierraTransformableTransformerTest
         )
       )
 
-      val result = transformer.transform(transformable, version = 1)
+      val result = SierraTransformableTransformer(transformable, version = 1)
       result.isFailure shouldBe true
       result.failed.get shouldBe a[SierraTransformerException]
       result.failed.get
@@ -902,7 +901,7 @@ class SierraTransformableTransformerTest
         bibRecord = bibRecord
       )
 
-      val result = transformer.transform(transformable, version = 1)
+      val result = SierraTransformableTransformer(transformable, version = 1)
       result.isFailure shouldBe true
       result.failed.get shouldBe a[SierraTransformerException]
       result.failed.get
@@ -937,7 +936,7 @@ class SierraTransformableTransformerTest
       itemRecords = itemRecords
     )
 
-    val triedMaybeWork = transformer.transform(sierraTransformable, version = 1)
+    val triedMaybeWork = SierraTransformableTransformer(sierraTransformable, version = 1)
     triedMaybeWork.isSuccess shouldBe true
 
     triedMaybeWork.get shouldBe UnidentifiedInvisibleWork(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
@@ -936,7 +936,8 @@ class SierraTransformableTransformerTest
       itemRecords = itemRecords
     )
 
-    val triedMaybeWork = SierraTransformableTransformer(sierraTransformable, version = 1)
+    val triedMaybeWork =
+      SierraTransformableTransformer(sierraTransformable, version = 1)
     triedMaybeWork.isSuccess shouldBe true
 
     triedMaybeWork.get shouldBe UnidentifiedInvisibleWork(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraWorkTypeTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraWorkTypeTest.scala
@@ -10,11 +10,10 @@ class SierraWorkTypeTest
     with Matchers
     with SierraDataGenerators {
 
-  val transformer = new SierraWorkType {}
-
   it("extracts WorkType from bib records") {
     val workTypeId = "a"
     val sierraValue = "Books"
+    val bibId = createSierraBibNumber
 
     val bibData = createSierraBibDataWith(
       materialType = Some(
@@ -27,6 +26,6 @@ class SierraWorkTypeTest
       label = sierraValue
     )
 
-    transformer.getWorkType(bibData = bibData) shouldBe Some(expectedWorkType)
+    SierraWorkType(bibId, bibData) shouldBe Some(expectedWorkType)
   }
 }


### PR DESCRIPTION
This PR introduces a simple `SierraTransformer` trait that is used by objects transforming incoming bib data to particular fields on a work (similar to what was suggested in #100, which was closed for other reasons):

```scala
trait SierraTransformer {

  type Output

  def apply(bibId: SierraBibNumber, bibData: SierraBibData): Output
}
```
This in my opinion is cleaner and more structured than using mixins to provide transformation methods. The `SierraTransformableTransformer` logic is also tidied up a little so slightly easier to understand.

Will be used on the upcoming notes work (issue https://github.com/wellcometrust/platform/issues/3631)