### PR TITLE
Add work notes field

### DIFF
--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
@@ -172,6 +172,7 @@ object WorksIndex {
       location("thumbnail"),
       textField("dimensions"),
       textField("edition"),
+      englishTextField("notes"),
       objectField("redirect")
         .fields(sourceIdentifier, keywordField("canonicalId")),
       keywordField("type"),

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -32,6 +32,7 @@ sealed trait Work extends BaseWork with MultipleSourceIdentifiers {
   val language: Option[Language]
   val dimensions: Option[String]
   val edition: Option[String]
+  val notes: List[String]
 
   val items: List[IdentityState[Item]]
   val itemsV1: List[IdentityState[Item]]
@@ -62,6 +63,7 @@ case class UnidentifiedWork(
   language: Option[Language],
   dimensions: Option[String],
   edition: Option[String],
+  notes: List[String] = Nil,
   items: List[MaybeDisplayable[Item]],
   itemsV1: List[Identifiable[Item]],
   version: Int,
@@ -92,6 +94,7 @@ case class IdentifiedWork(
   language: Option[Language],
   dimensions: Option[String],
   edition: Option[String],
+  notes: List[String] = Nil,
   items: List[Displayable[Item]],
   itemsV1: List[Identified[Item]],
   version: Int,

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
@@ -82,6 +82,7 @@ trait WorksGenerators extends ItemsGenerators with ProductionEventGenerators {
     thumbnail: Option[Location] = None,
     contributors: List[Contributor[MaybeDisplayable[AbstractAgent]]] = List(),
     production: List[ProductionEvent[MaybeDisplayable[AbstractAgent]]] = List(),
+    notes: List[String] = Nil,
     items: List[MaybeDisplayable[Item]] = List(),
     itemsV1: List[Identifiable[Item]] = List(),
   ): UnidentifiedWork =
@@ -105,6 +106,7 @@ trait WorksGenerators extends ItemsGenerators with ProductionEventGenerators {
       language = None,
       dimensions = None,
       edition = None,
+      notes = notes,
       items = items,
       itemsV1 = itemsV1,
       version = version
@@ -134,6 +136,7 @@ trait WorksGenerators extends ItemsGenerators with ProductionEventGenerators {
     contributors: List[Contributor[Displayable[AbstractAgent]]] = List(),
     thumbnail: Option[Location] = None,
     production: List[ProductionEvent[Displayable[AbstractAgent]]] = List(),
+    notes: List[String] = Nil,
     language: Option[Language] = None,
     items: List[Displayable[Item]] = List(),
     itemsV1: List[Identified[Item]] = List(),
@@ -161,6 +164,7 @@ trait WorksGenerators extends ItemsGenerators with ProductionEventGenerators {
       language = language,
       dimensions = None,
       edition = None,
+      notes = notes,
       items = items,
       itemsV1 = itemsV1,
       version = version,

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
@@ -89,6 +89,7 @@ class SierraTransformableTransformer(sierraTransformable: SierraTransformable,
           language = SierraLanguage(bibId, bibData),
           dimensions = SierraDimensions(bibId, bibData),
           edition = SierraEdition(bibId, bibData),
+          notes = SierraNotes(bibId, bibData),
           items = SierraItems(itemDataMap)(bibId, bibData),
           itemsV1 = Nil,
           version = version

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotes.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotes.scala
@@ -1,0 +1,16 @@
+package uk.ac.wellcome.platform.transformer.sierra.transformers
+
+import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
+import uk.ac.wellcome.platform.transformer.sierra.source.SierraBibData
+
+object SierraNotes extends SierraTransformer with MarcUtils {
+
+  type Output = List[String]
+
+  val notesFields = List("500", "501", "504", "518", "536", "545", "547", "562")
+
+  def apply(bibId: SierraBibNumber, bibData: SierraBibData) =
+    notesFields
+      .flatMap(getMatchingVarFields(bibData, _))
+      .flatMap(_.content)
+}

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotesTest.scala
@@ -1,0 +1,59 @@
+package uk.ac.wellcome.platform.transformer.sierra.transformers
+
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.platform.transformer.sierra.generators.{
+  MarcGenerators,
+  SierraDataGenerators
+}
+
+class SierraNotesTest
+  extends FunSpec
+  with Matchers
+  with MarcGenerators
+  with SierraDataGenerators {
+
+  it("should extract notes from all fields") {
+    val notes = List(
+      "500" -> "note a",
+      "501" -> "note b",
+      "504" -> "note c",
+      "518" -> "note d",
+      "536" -> "note e",
+      "545" -> "note f",
+      "547" -> "note g",
+      "562" -> "note h",
+    )
+    SierraNotes(bibId, bibData(notes:_*)) shouldBe notes.map(_._2)
+  }
+
+  it("should extract all notes when duplicate fields") {
+    val notes = List(
+      "500" -> "note a",
+      "500" -> "note b",
+    )
+    SierraNotes(bibId, bibData(notes:_*)) shouldBe notes.map(_._2)
+  }
+
+  it("should not extract notes from non notes fields") {
+    val notes = List(
+      "100" -> "not a note",
+      "502" -> "not a note",
+    )
+    SierraNotes(bibId, bibData(notes:_*)) shouldBe Nil
+  }
+
+  it("should preserve html in notes fields") {
+    val note = "500" -> "<p>note</p>"
+    SierraNotes(bibId, bibData(note)) shouldBe List(note._2)
+  }
+
+  def bibId = createSierraBibNumber
+
+  def bibData(notes: (String, String)*) =
+      createSierraBibDataWith(
+        varFields =
+          notes.toList.map { case (tag, value) =>
+            createVarFieldWith(marcTag = tag, content = Some(value))
+          }
+      )
+}

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
@@ -221,7 +221,12 @@ class SierraTransformableTransformerTest
       )
     )
 
-    val marcFields = List(productionField, descriptionField, letteringField)
+    val notesField = createVarFieldWith(
+      marcTag = "500",
+      content = Some("It's a note")
+    )
+
+    val marcFields = List(productionField, descriptionField, letteringField, notesField)
 
     val data =
       s"""
@@ -255,6 +260,7 @@ class SierraTransformableTransformerTest
           function = None
         )
       ),
+      notes = List("It's a note"),
       lettering = Some(lettering)
     )
   }


### PR DESCRIPTION
### Issue

https://github.com/wellcometrust/platform/issues/3631

### Description

This adds a `notes` fields consisting of a `List[String]` to the work model, and initialises this from the sierra marc data.

There is some background work [here](https://gist.github.com/warrd/8a904f02d3eee5a78601de886091cddb) that informed the decision of how to model notes. At the moment we leave html in the notes fields unchanged.