### PR TITLE
Meeting and brand name subjects

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraSubjects.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraSubjects.scala
@@ -12,6 +12,7 @@ import uk.ac.wellcome.platform.transformer.sierra.transformers.subjects.{
   SierraOrganisationSubjects,
   SierraPersonSubjects,
   SierraMeetingSubjects,
+  SierraBrandNameSubjects
 }
 
 object SierraSubjects extends SierraTransformer {
@@ -28,7 +29,8 @@ object SierraSubjects extends SierraTransformer {
     SierraConceptSubjects,
     SierraPersonSubjects,
     SierraOrganisationSubjects,
-    SierraMeetingSubjects
+    SierraMeetingSubjects,
+    SierraBrandNameSubjects
   )
 
   def apply(bibId: SierraBibNumber, bibData: SierraBibData) =

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraSubjects.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraSubjects.scala
@@ -13,11 +13,7 @@ import uk.ac.wellcome.platform.transformer.sierra.transformers.subjects.{
   SierraPersonSubjects
 }
 
-object SierraSubjects
-    extends SierraTransformer
-    with SierraConceptSubjects
-    with SierraPersonSubjects
-    with SierraOrganisationSubjects {
+object SierraSubjects extends SierraTransformer {
 
   type Output = List[
     MaybeDisplayable[
@@ -27,8 +23,12 @@ object SierraSubjects
     ]
   ]
 
+  val subjectsTransformers = List(
+    SierraConceptSubjects,
+    SierraPersonSubjects,
+    SierraOrganisationSubjects
+  )
+
   def apply(bibId: SierraBibNumber, bibData: SierraBibData) =
-    getSubjectswithAbstractConcepts(bibData) ++
-      getSubjectsWithPerson(bibData) ++
-      getSubjectsWithOrganisation(bibId, bibData)
+    subjectsTransformers.flatMap(transform => transform(bibId, bibData))
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraSubjects.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraSubjects.scala
@@ -10,7 +10,8 @@ import uk.ac.wellcome.platform.transformer.sierra.source.SierraBibData
 import uk.ac.wellcome.platform.transformer.sierra.transformers.subjects.{
   SierraConceptSubjects,
   SierraOrganisationSubjects,
-  SierraPersonSubjects
+  SierraPersonSubjects,
+  SierraMeetingSubjects,
 }
 
 object SierraSubjects extends SierraTransformer {
@@ -26,7 +27,8 @@ object SierraSubjects extends SierraTransformer {
   val subjectsTransformers = List(
     SierraConceptSubjects,
     SierraPersonSubjects,
-    SierraOrganisationSubjects
+    SierraOrganisationSubjects,
+    SierraMeetingSubjects
   )
 
   def apply(bibId: SierraBibNumber, bibData: SierraBibData) =

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraBrandNameSubjects.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraBrandNameSubjects.scala
@@ -1,0 +1,28 @@
+package uk.ac.wellcome.platform.transformer.sierra.transformers.subjects
+
+import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
+import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.platform.transformer.sierra.source.VarField
+import uk.ac.wellcome.platform.transformer.sierra.transformers.SierraAgents
+
+// Populate wwork:subject
+//
+// Use MARC field "652". This is not documented but is a custom field used to
+// represent brand names
+object SierraBrandNameSubjects extends SierraSubjectsTransformer with SierraAgents {
+
+  val subjectVarFields = List("652")
+
+  def getSubjectsFromVarFields(bibId: SierraBibNumber, varFields: List[VarField]) =
+    varFields.flatMap { varField =>
+      varField.content.map {
+        label =>
+          Unidentifiable(
+            Subject(
+              label = label,
+              concepts = List(Unidentifiable(Concept(label = label)))
+            )
+          )
+      }
+    }
+}

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraConceptSubjects.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraConceptSubjects.scala
@@ -3,68 +3,62 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers.subjects
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
-  SierraBibData,
   VarField
 }
 import uk.ac.wellcome.platform.transformer.sierra.transformers.{
   MarcUtils,
   SierraConcepts
 }
+import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 
-trait SierraConceptSubjects extends MarcUtils with SierraConcepts {
+// Populate wwork:subject
+//
+// Use MARC field "650", "648" and "651" where the second indicator is not 7.
+//
+// Within these MARC tags, we have:
+//
+//    - a primary concept (subfield $a); and
+//    - subdivisions (subfields $v, $x, $y and $z)
+//
+// The primary concept can be identified, and the subdivisions serve
+// to add extra context.
+//
+// We construct the Subject as follows:
+//
+//    - label is the concatenation of $a, $v, $x, $y and $z in order,
+//      separated by a hyphen ' - '.
+//    - concepts is a List[Concept] populated in order of the subfields:
+//
+//        * $a => {Concept, Period, Place}
+//          Optionally with an identifier.  We look in subfield $0 for the
+//          identifier value, then second indicator for the authority.
+//          These are decided as follows:
+//
+//            - 650 => Concept
+//            - 648 => Period
+//            - 651 => Place
+//
+//        * $v => Concept
+//        * $x => Concept
+//        * $y => Period
+//        * $z => Place
+//
+//      Note that only concepts from subfield $a are identified; everything
+//      else is unidentified.
+//
+object SierraConceptSubjects
+  extends SierraSubjectsTransformer with MarcUtils with SierraConcepts {
 
-  // Populate wwork:subject
-  //
-  // Use MARC field "650", "648" and "651" where the second indicator is not 7.
-  //
-  // Within these MARC tags, we have:
-  //
-  //    - a primary concept (subfield $a); and
-  //    - subdivisions (subfields $v, $x, $y and $z)
-  //
-  // The primary concept can be identified, and the subdivisions serve
-  // to add extra context.
-  //
-  // We construct the Subject as follows:
-  //
-  //    - label is the concatenation of $a, $v, $x, $y and $z in order,
-  //      separated by a hyphen ' - '.
-  //    - concepts is a List[Concept] populated in order of the subfields:
-  //
-  //        * $a => {Concept, Period, Place}
-  //          Optionally with an identifier.  We look in subfield $0 for the
-  //          identifier value, then second indicator for the authority.
-  //          These are decided as follows:
-  //
-  //            - 650 => Concept
-  //            - 648 => Period
-  //            - 651 => Place
-  //
-  //        * $v => Concept
-  //        * $x => Concept
-  //        * $y => Period
-  //        * $z => Place
-  //
-  //      Note that only concepts from subfield $a are identified; everything
-  //      else is unidentified.
-  //
-  def getSubjectswithAbstractConcepts(bibData: SierraBibData)
-    : List[MaybeDisplayable[Subject[MaybeDisplayable[AbstractConcept]]]] =
-    getSubjectsForMarcTag(bibData, "650") ++
-      getSubjectsForMarcTag(bibData, "648") ++
-      getSubjectsForMarcTag(bibData, "651")
+  val subjectVarFields = List("650", "648", "651")
 
-  private def getSubjectsForMarcTag(bibData: SierraBibData, marcTag: String)
-    : List[MaybeDisplayable[Subject[MaybeDisplayable[AbstractConcept]]]] = {
-    val marcVarFields = getMatchingVarFields(bibData, marcTag = marcTag)
-
+  def getSubjectsFromVarFields(bibId: SierraBibNumber, varFields: List[VarField]): Output = {
     // Second indicator 7 means that the subject authority is something other
     // than library of congress or mesh. Some MARC records have duplicated subjects
     // when the same subject has more than one authority (for example mesh and FAST),
     // which causes duplicated subjects to appear in the API.
     //
     // So let's filter anything that is from another authority for now.
-    marcVarFields.filterNot(_.indicator2.contains("7")).map { varField =>
+    varFields.filterNot(_.indicator2.contains("7")).map { varField =>
       val subfields = filterSubfields(varField, List("a", "v", "x", "y", "z"))
       val (primarySubfields, subdivisionSubfields) = subfields.partition {
         _.tag == "a"

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraMeetingSubjects.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraMeetingSubjects.scala
@@ -27,19 +27,24 @@ object SierraMeetingSubjects
 
   val subjectVarFields = List("611")
 
+  val labelSubfields = List("a", "b", "c")
+
   def getSubjectsFromVarFields(bibId: SierraBibNumber,
                                varFields: List[VarField]) =
-    varFields.map { varField =>
-      val label = createLabel(varField, subfieldTags = List("a", "c", "d"))
-
-      val subject = Subject(
-        label = label,
-        concepts = List(Unidentifiable(Meeting(label = label)))
-      )
-
-      varField.indicator2 match {
-        case Some("0") => identify(varField.subfields, subject, "Meeting")
-        case _         => Unidentifiable(subject)
+    varFields.flatMap { varField =>
+      createLabel(varField, subfieldTags = List("a", "c", "d")) match {
+        case "" => None
+        case label =>
+          val subject = Subject(
+            label = label,
+            concepts = List(Unidentifiable(Meeting(label = label)))
+          )
+          Some(
+            varField.indicator2 match {
+              case Some("0") => identify(varField.subfields, subject, "Meeting")
+              case _         => Unidentifiable(subject)
+            }
+          )
       }
     }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraMeetingSubjects.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraMeetingSubjects.scala
@@ -1,0 +1,43 @@
+package uk.ac.wellcome.platform.transformer.sierra.transformers.subjects
+
+import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
+import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.platform.transformer.sierra.source.VarField
+import uk.ac.wellcome.platform.transformer.sierra.transformers.SierraAgents
+
+// Populate wwork:subject
+//
+// Use MARC field "611".
+//
+// *  Populate the platform "label" with the concatenated values of
+//    subfields a, c, and d.
+//
+// *  Populate "concepts" with a single value:
+//
+//    -   Create "label" from subfields a, c and d
+//    -   Set "type" to "Meeting"
+//    -   Use subfield 0 to populate "identifiers", if present.  Note the
+//        identifierType should be "lc-names".
+//
+// https://www.loc.gov/marc/bibliographic/bd611.html
+//
+object SierraMeetingSubjects extends SierraSubjectsTransformer with SierraAgents {
+
+  val subjectVarFields = List("611")
+
+  def getSubjectsFromVarFields(bibId: SierraBibNumber, varFields: List[VarField]) =
+    varFields.map { varField =>
+
+      val label = createLabel(varField, subfieldTags = List("a", "c", "d"))
+
+      val subject = Subject(
+        label = label,
+        concepts = List(Unidentifiable(Meeting(label = label)))
+      )
+
+      varField.indicator2 match {
+        case Some("0") => identify(varField.subfields, subject, "Meeting")
+        case _         => Unidentifiable(subject)
+      }
+    }
+}

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraOrganisationSubjects.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraOrganisationSubjects.scala
@@ -3,37 +3,31 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers.subjects
 import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.sierra.exceptions.CataloguingException
-import uk.ac.wellcome.platform.transformer.sierra.source.{
-  SierraBibData,
-  VarField
-}
-import uk.ac.wellcome.platform.transformer.sierra.transformers.{
-  MarcUtils,
-  SierraAgents
-}
+import uk.ac.wellcome.platform.transformer.sierra.source.VarField
+import uk.ac.wellcome.platform.transformer.sierra.transformers.SierraAgents
 
-trait SierraOrganisationSubjects extends SierraAgents with MarcUtils {
+// Populate wwork:subject
+//
+// Use MARC field "610".
+//
+// *  Populate the platform "label" with the concatenated values of
+//    subfields a, b, c, d and e.
+//
+// *  Populate "concepts" with a single value:
+//
+//    -   Create "label" from subfields a and b
+//    -   Set "type" to "Organisation"
+//    -   Use subfield 0 to populate "identifiers", if present.  Note the
+//        identifierType should be "lc-names".
+//
+// https://www.loc.gov/marc/bibliographic/bd610.html
+//
+object SierraOrganisationSubjects extends SierraSubjectsTransformer with SierraAgents {
 
-  // Populate wwork:subject
-  //
-  // Use MARC field "610".
-  //
-  // *  Populate the platform "label" with the concatenated values of
-  //    subfields a, b, c, d and e.
-  //
-  // *  Populate "concepts" with a single value:
-  //
-  //    -   Create "label" from subfields a and b
-  //    -   Set "type" to "Organisation"
-  //    -   Use subfield 0 to populate "identifiers", if present.  Note the
-  //        identifierType should be "lc-names".
-  //
-  // https://www.loc.gov/marc/bibliographic/bd610.html
-  //
-  def getSubjectsWithOrganisation(bibId: SierraBibNumber,
-                                  bibData: SierraBibData)
-    : List[MaybeDisplayable[Subject[MaybeDisplayable[Organisation]]]] =
-    getMatchingVarFields(bibData, marcTag = "610").map { varField =>
+  val subjectVarFields = List("610")
+
+  def getSubjectsFromVarFields(bibId: SierraBibNumber, varFields: List[VarField]): Output =
+    varFields.map { varField =>
       val label =
         createLabel(varField, subfieldTags = List("a", "b", "c", "d", "e"))
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraOrganisationSubjects.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraOrganisationSubjects.scala
@@ -60,19 +60,4 @@ object SierraOrganisationSubjects extends SierraSubjectsTransformer with SierraA
 
     Unidentifiable(Organisation(label = label))
   }
-
-  /** Given a varField and a list of subfield tags, create a label by
-    * concatenating the contents of every subfield with one of the given tags.
-    *
-    * The order is the same as that in the original MARC.
-    *
-    */
-  private def createLabel(varField: VarField,
-                          subfieldTags: List[String]): String =
-    varField.subfields
-      .filter { vf =>
-        subfieldTags.contains(vf.tag)
-      }
-      .map { _.content }
-      .mkString(" ")
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraPersonSubjects.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraPersonSubjects.scala
@@ -3,43 +3,39 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers.subjects
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
-  SierraBibData,
   VarField
 }
-import uk.ac.wellcome.platform.transformer.sierra.transformers.{
-  MarcUtils,
-  SierraAgents
-}
+import uk.ac.wellcome.platform.transformer.sierra.transformers.SierraAgents
+import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 
-trait SierraPersonSubjects extends MarcUtils with SierraAgents {
+// Populate wwork:subject
+//
+// Use MARC field "600" where the second indicator is not 7.
+//
+// The concepts come from:
+//
+//    - The person
+//    - The contents of subfields $t and $x (title and general subdivision),
+//      both as Concepts
+//
+// The label is constructed concatenating subfields $a, $b, $c, $d, $e,
+// where $d and $e represent the person's dates and roles respectively.
+//
+// The person can be identified if there is an identifier in subfield $0 and the second indicator is "0".
+// If second indicator is anything other than 0, we don't expose the identifier for now.
+//
+object SierraPersonSubjects extends SierraSubjectsTransformer with SierraAgents {
 
-  // Populate wwork:subject
-  //
-  // Use MARC field "600" where the second indicator is not 7.
-  //
-  // The concepts come from:
-  //
-  //    - The person
-  //    - The contents of subfields $t and $x (title and general subdivision),
-  //      both as Concepts
-  //
-  // The label is constructed concatenating subfields $a, $b, $c, $d, $e,
-  // where $d and $e represent the person's dates and roles respectively.
-  //
-  // The person can be identified if there is an identifier in subfield $0 and the second indicator is "0".
-  // If second indicator is anything other than 0, we don't expose the identifier for now.
-  //
-  def getSubjectsWithPerson(bibData: SierraBibData)
-    : List[MaybeDisplayable[Subject[MaybeDisplayable[AbstractRootConcept]]]] = {
-    val marcVarFields = getMatchingVarFields(bibData, marcTag = "600")
+  val subjectVarFields = List("600")
 
+  def getSubjectsFromVarFields(bibId: SierraBibNumber, varFields: List[VarField]): Output = {
     // Second indicator 7 means that the subject authority is something other
     // than library of congress or mesh. Some MARC records have duplicated subjects
     // when the same subject has more than one authority (for example mesh and FAST),
     // which causes duplicated subjects to appear in the API.
     //
     // So let's filter anything that is from another authority for now.
-    marcVarFields
+    varFields
       .filterNot { _.indicator2.contains("7") }
       .flatMap { varField: VarField =>
         val subfields = varField.subfields

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraSubjectsTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraSubjectsTransformer.scala
@@ -28,4 +28,18 @@ trait SierraSubjectsTransformer extends SierraTransformer with MarcUtils {
     )
 
   def getSubjectsFromVarFields(bibId: SierraBibNumber, varFields: List[VarField]): Output
+
+  /** Given a varField and a list of subfield tags, create a label by
+    * concatenating the contents of every subfield with one of the given tags.
+    *
+    * The order is the same as that in the original MARC.
+    *
+    */
+  def createLabel(varField: VarField, subfieldTags: List[String]): String =
+    varField.subfields
+      .filter { vf =>
+        subfieldTags.contains(vf.tag)
+      }
+      .map { _.content }
+      .mkString(" ")
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraSubjectsTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraSubjectsTransformer.scala
@@ -1,0 +1,31 @@
+package uk.ac.wellcome.platform.transformer.sierra.transformers.subjects
+
+import uk.ac.wellcome.platform.transformer.sierra.transformers.{SierraTransformer, MarcUtils}
+import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
+import uk.ac.wellcome.platform.transformer.sierra.source.{SierraBibData, VarField}
+import uk.ac.wellcome.models.work.internal.{
+  AbstractRootConcept,
+  MaybeDisplayable,
+  Subject
+}
+
+trait SierraSubjectsTransformer extends SierraTransformer with MarcUtils {
+
+  type Output = List[
+    MaybeDisplayable[
+      Subject[
+        MaybeDisplayable[AbstractRootConcept]
+      ]
+    ]
+  ]
+
+  val subjectVarFields: List[String]
+
+  def apply(bibId: SierraBibNumber, bibData: SierraBibData) =
+    getSubjectsFromVarFields(
+      bibId,
+      subjectVarFields.flatMap(getMatchingVarFields(bibData, _))
+    )
+
+  def getSubjectsFromVarFields(bibId: SierraBibNumber, varFields: List[VarField]): Output
+}

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraSubjectsTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraSubjectsTransformer.scala
@@ -43,8 +43,7 @@ trait SierraSubjectsTransformer extends SierraTransformer with MarcUtils {
     *
     */
   def createLabel(varField: VarField, subfieldTags: List[String]): String =
-    varField
-      .subfields
+    varField.subfields
       .filter { subfield =>
         subfieldTags.contains(subfield.tag)
       }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraSubjectsTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraSubjectsTransformer.scala
@@ -43,10 +43,12 @@ trait SierraSubjectsTransformer extends SierraTransformer with MarcUtils {
     *
     */
   def createLabel(varField: VarField, subfieldTags: List[String]): String =
-    varField.subfields
-      .filter { vf =>
-        subfieldTags.contains(vf.tag)
+    varField
+      .subfields
+      .filter { subfield =>
+        subfieldTags.contains(subfield.tag)
       }
+      .sortBy { _.tag }
       .map { _.content }
       .mkString(" ")
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
@@ -611,6 +611,75 @@ class SierraTransformableTransformerTest
     )
   }
 
+  it("extracts meeting subjects if present") {
+    val id = createSierraBibNumber
+    val content = "Big Meeting"
+
+    val data =
+      s"""
+         | {
+         |   "id": "$id",
+         |   "title": "Proceedings of 3rd Big Meeting",
+         |   "varFields": [
+         |     {
+         |       "fieldTag": "",
+         |       "marcTag": "611",
+         |       "ind1": " ",
+         |       "ind2": " ",
+         |       "subfields": [
+         |         {
+         |           "tag": "a",
+         |           "content": "$content"
+         |         }
+         |       ]
+         |     }
+         |   ]
+         | }
+      """.stripMargin
+
+    val work = transformDataToUnidentifiedWork(id = id, data = data)
+    work.subjects shouldBe List(
+      Unidentifiable(
+        Subject(
+          label = content,
+          List(Unidentifiable(Meeting(content)))
+        )
+      )
+    )
+  }
+
+  it("extracts brand name subjects if present") {
+    val id = createSierraBibNumber
+    val content = "ACME"
+
+    val data =
+      s"""
+         | {
+         |   "id": "$id",
+         |   "title": "Wacky Racers",
+         |   "varFields": [
+         |     {
+         |       "fieldTag": "",
+         |       "marcTag": "652",
+         |       "ind1": " ",
+         |       "ind2": " ",
+         |       "content": "$content"
+         |     }
+         |   ]
+         | }
+      """.stripMargin
+
+    val work = transformDataToUnidentifiedWork(id = id, data = data)
+    work.subjects shouldBe List(
+      Unidentifiable(
+        Subject(
+          label = content,
+          List(Unidentifiable(Concept(content)))
+        )
+      )
+    )
+  }
+
   it("adds production events if possible") {
     val id = createSierraBibNumber
     val placeLabel = "London"

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraBrandNameSubjectsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraBrandNameSubjectsTest.scala
@@ -1,0 +1,72 @@
+package uk.ac.wellcome.platform.transformer.sierra.transformers.subjects
+
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.platform.transformer.sierra.source.{MarcSubfield, VarField}
+import uk.ac.wellcome.platform.transformer.sierra.generators.{
+  MarcGenerators,
+  SierraDataGenerators
+}
+
+class SierraBrandNameSubjectsTest
+    extends FunSpec
+    with Matchers
+    with MarcGenerators
+    with SierraDataGenerators {
+
+  def bibId = createSierraBibNumber
+
+  def bibData(varFields: VarField*) =
+    createSierraBibDataWith(varFields = varFields.toList)
+
+  def varField(tag: String, content: Option[String], subfields: MarcSubfield*) =
+    createVarFieldWith(marcTag = tag, content = content, subfields = subfields.toList)
+
+  it("returns zero subjects if there are none") {
+    SierraBrandNameSubjects(bibId, bibData()) shouldBe Nil
+  }
+
+  it("returns subjects for varfield 652") {
+    val data = bibData(
+      varField("600", Some("Not Content")),
+      varField("652", Some("Content")),
+    )
+    SierraBrandNameSubjects(bibId, data) shouldBe List(
+      Unidentifiable(
+        Subject(
+          label = "Content",
+          concepts = List(Unidentifiable(Concept(label = "Content")))
+        )
+      )
+    )
+  }
+
+  it("does not used subfields to parse the content") {
+    val data = bibData(
+      varField("652", None, MarcSubfield(tag = "x", content = "Hmmm"))
+    )
+    SierraBrandNameSubjects(bibId, data) shouldBe Nil
+  }
+
+  it("returns multiple subjects if multiple 652") {
+    val data = bibData(
+      varField("652", Some("First")),
+      varField("652", Some("Second")),
+    )
+    SierraBrandNameSubjects(bibId, data) shouldBe List(
+      Unidentifiable(
+        Subject(
+          label = "First",
+          concepts = List(Unidentifiable(Concept(label = "First")))
+        )
+      ),
+      Unidentifiable(
+        Subject(
+          label = "Second",
+          concepts = List(Unidentifiable(Concept(label = "Second")))
+        )
+      )
+    )
+  }
+}
+

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraBrandNameSubjectsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraBrandNameSubjectsTest.scala
@@ -2,7 +2,10 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers.subjects
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.platform.transformer.sierra.source.{MarcSubfield, VarField}
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  MarcSubfield,
+  VarField
+}
 import uk.ac.wellcome.platform.transformer.sierra.generators.{
   MarcGenerators,
   SierraDataGenerators
@@ -20,7 +23,10 @@ class SierraBrandNameSubjectsTest
     createSierraBibDataWith(varFields = varFields.toList)
 
   def varField(tag: String, content: Option[String], subfields: MarcSubfield*) =
-    createVarFieldWith(marcTag = tag, content = content, subfields = subfields.toList)
+    createVarFieldWith(
+      marcTag = tag,
+      content = content,
+      subfields = subfields.toList)
 
   it("returns zero subjects if there are none") {
     SierraBrandNameSubjects(bibId, bibData()) shouldBe Nil
@@ -69,4 +75,3 @@ class SierraBrandNameSubjectsTest
     )
   }
 }
-

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraConceptSubjectsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraConceptSubjectsTest.scala
@@ -13,15 +13,16 @@ class SierraConceptSubjectsTest
     with Matchers
     with MarcGenerators
     with SierraDataGenerators {
-  private val transformer = new SierraConceptSubjects {}
+
+  def bibId = createSierraBibNumber
 
   it("returns zero subjects if there are none") {
-    val bibData = createSierraBibDataWith(varFields = List())
-    transformer.getSubjectswithAbstractConcepts(bibData) shouldBe Nil
+    val bibData = createSierraBibDataWith(varFields = Nil)
+    SierraConceptSubjects(bibId, bibData) shouldBe Nil
   }
 
   it("returns subjects for tag 650 with only subfield a") {
-    val sierraBibData = createSierraBibDataWith(
+    val bibData = createSierraBibDataWith(
       varFields = List(
         createVarFieldWith(
           marcTag = "650",
@@ -32,7 +33,7 @@ class SierraConceptSubjectsTest
       )
     )
 
-    transformer.getSubjectswithAbstractConcepts(sierraBibData) shouldBe List(
+    SierraConceptSubjects(bibId, bibData) shouldBe List(
       Unidentifiable(
         Subject(
           label = "A Content",
@@ -44,7 +45,7 @@ class SierraConceptSubjectsTest
   }
 
   it("returns subjects for tag 650 with only subfields a and v") {
-    val sierraBibData = createSierraBibDataWith(
+    val bibData = createSierraBibDataWith(
       varFields = List(
         createVarFieldWith(
           marcTag = "650",
@@ -56,7 +57,7 @@ class SierraConceptSubjectsTest
       )
     )
 
-    transformer.getSubjectswithAbstractConcepts(sierraBibData) shouldBe List(
+    SierraConceptSubjects(bibId, bibData) shouldBe List(
       Unidentifiable(
         Subject(
           label = "A Content - V Content",
@@ -70,7 +71,7 @@ class SierraConceptSubjectsTest
 
   it(
     "subfield a is always first concept when returning subjects for tag 650 with subfields a, v") {
-    val sierraBibData = createSierraBibDataWith(
+    val bibData = createSierraBibDataWith(
       varFields = List(
         createVarFieldWith(
           marcTag = "650",
@@ -81,7 +82,7 @@ class SierraConceptSubjectsTest
         )
       )
     )
-    transformer.getSubjectswithAbstractConcepts(sierraBibData) shouldBe List(
+    SierraConceptSubjects(bibId, bibData) shouldBe List(
       Unidentifiable(
         Subject(
           label = "A Content - V Content",
@@ -94,7 +95,7 @@ class SierraConceptSubjectsTest
   }
 
   it("returns subjects for tag 650 subfields a, v, and x") {
-    val sierraBibData = createSierraBibDataWith(
+    val bibData = createSierraBibDataWith(
       varFields = List(
         createVarFieldWith(
           marcTag = "650",
@@ -107,7 +108,7 @@ class SierraConceptSubjectsTest
       )
     )
 
-    transformer.getSubjectswithAbstractConcepts(sierraBibData) shouldBe List(
+    SierraConceptSubjects(bibId, bibData) shouldBe List(
       Unidentifiable(
         Subject(
           label = "A Content - X Content - V Content",
@@ -122,7 +123,7 @@ class SierraConceptSubjectsTest
   }
 
   it("returns subjects for tag 650 with subfields a, y") {
-    val sierraBibData = createSierraBibDataWith(
+    val bibData = createSierraBibDataWith(
       varFields = List(
         createVarFieldWith(
           marcTag = "650",
@@ -134,7 +135,7 @@ class SierraConceptSubjectsTest
       )
     )
 
-    transformer.getSubjectswithAbstractConcepts(sierraBibData) shouldBe List(
+    SierraConceptSubjects(bibId, bibData) shouldBe List(
       Unidentifiable(
         Subject(
           label = "A Content - Y Content",
@@ -148,7 +149,7 @@ class SierraConceptSubjectsTest
   }
 
   it("returns subjects for tag 650 with subfields a, z") {
-    val sierraBibData = createSierraBibDataWith(
+    val bibData = createSierraBibDataWith(
       varFields = List(
         createVarFieldWith(
           marcTag = "650",
@@ -159,7 +160,7 @@ class SierraConceptSubjectsTest
         )
       )
     )
-    transformer.getSubjectswithAbstractConcepts(sierraBibData) shouldBe List(
+    SierraConceptSubjects(bibId, bibData) shouldBe List(
       Unidentifiable(
         Subject(
           label = "A Content - Z Content",
@@ -192,7 +193,7 @@ class SierraConceptSubjectsTest
       )
     )
 
-    transformer.getSubjectswithAbstractConcepts(bibData) shouldBe List(
+    SierraConceptSubjects(bibId, bibData) shouldBe List(
       Unidentifiable(
         Subject(
           label = "A1 Content - Z1 Content",
@@ -215,7 +216,7 @@ class SierraConceptSubjectsTest
   }
 
   it("returns subjects with primary concept Period for tag 648") {
-    val sierraBibData = createSierraBibDataWith(
+    val bibData = createSierraBibDataWith(
       varFields = List(
         createVarFieldWith(
           marcTag = "648",
@@ -228,7 +229,7 @@ class SierraConceptSubjectsTest
       )
     )
 
-    transformer.getSubjectswithAbstractConcepts(sierraBibData) shouldBe List(
+    SierraConceptSubjects(bibId, bibData) shouldBe List(
       Unidentifiable(
         Subject(
           label = "A Content - X Content - V Content",
@@ -243,7 +244,7 @@ class SierraConceptSubjectsTest
   }
 
   it("returns subjects with primary concept Place for tag 651") {
-    val sierraBibData = createSierraBibDataWith(
+    val bibData = createSierraBibDataWith(
       varFields = List(
         createVarFieldWith(
           marcTag = "651",
@@ -256,7 +257,7 @@ class SierraConceptSubjectsTest
       )
     )
 
-    transformer.getSubjectswithAbstractConcepts(sierraBibData) shouldBe List(
+    SierraConceptSubjects(bibId, bibData) shouldBe List(
       Unidentifiable(
         Subject(
           label = "A Content - X Content - V Content",
@@ -307,15 +308,9 @@ class SierraConceptSubjectsTest
       )
     )
 
-    val actualSourceIdentifiers = transformer
-      .getSubjectswithAbstractConcepts(bibData)
+    val actualSourceIdentifiers = SierraConceptSubjects(bibId, bibData)
       .map {
-        case Identifiable(
-            _: Subject[MaybeDisplayable[AbstractConcept]],
-            sourceIdentifier,
-            _,
-            _) =>
-          sourceIdentifier
+        case Identifiable(_, sourceIdentifier, _, _) => sourceIdentifier
         case other => assert(false, other)
       }
 
@@ -351,8 +346,7 @@ class SierraConceptSubjectsTest
       ontologyType = "Subject"
     )
 
-    transformer
-      .getSubjectswithAbstractConcepts(bibData) shouldBe List(
+    SierraConceptSubjects(bibId, bibData) shouldBe List(
       Identifiable(
         Subject(
           label = "abolition",
@@ -378,7 +372,6 @@ class SierraConceptSubjectsTest
       )
     )
 
-    transformer
-      .getSubjectswithAbstractConcepts(bibData) shouldBe List()
+    SierraConceptSubjects(bibId, bibData) shouldBe Nil
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraConceptSubjectsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraConceptSubjectsTest.scala
@@ -311,7 +311,7 @@ class SierraConceptSubjectsTest
     val actualSourceIdentifiers = SierraConceptSubjects(bibId, bibData)
       .map {
         case Identifiable(_, sourceIdentifier, _, _) => sourceIdentifier
-        case other => assert(false, other)
+        case other                                   => assert(false, other)
       }
 
     expectedSourceIdentifiers shouldBe actualSourceIdentifiers

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraMeetingSubjectsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraMeetingSubjectsTest.scala
@@ -1,0 +1,114 @@
+package uk.ac.wellcome.platform.transformer.sierra.transformers.subjects
+
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.platform.transformer.sierra.source.{MarcSubfield, VarField}
+import uk.ac.wellcome.platform.transformer.sierra.generators.{
+  MarcGenerators,
+  SierraDataGenerators
+}
+
+class SierraMeetingSubjectsTest
+    extends FunSpec
+    with Matchers
+    with MarcGenerators
+    with SierraDataGenerators {
+
+  def bibId = createSierraBibNumber
+
+  def bibData(varFields: VarField*) =
+    createSierraBibDataWith(varFields = varFields.toList)
+
+  def varField(tag: String, subfields: MarcSubfield*) =
+    createVarFieldWith(marcTag = tag, subfields = subfields.toList, indicator2 = "0")
+
+  it("returns zero subjects if there are none") {
+    SierraMeetingSubjects(bibId, bibData()) shouldBe Nil
+  }
+
+  it("returns subjects for varfield 611, subfield $$a") {
+    val data = bibData(
+      varField("600", MarcSubfield(tag = "a", content = "Not content")),
+      varField("611", MarcSubfield(tag = "a", content = "Content")),
+    )
+    SierraMeetingSubjects(bibId, data) shouldBe List(
+      Unidentifiable(
+        Subject(
+          label = "Content",
+          concepts = List(Unidentifiable(Meeting(label = "Content")))
+        )
+      )
+    )
+  }
+
+  it("returns subjects with subfields $$a, $$c and $$d concatenated in order") {
+    val data = bibData(
+      varField(
+        "611",
+        MarcSubfield(tag = "c", content = "C"),
+        MarcSubfield(tag = "a", content = "A"),
+        MarcSubfield(tag = "d", content = "D"),
+      )
+    )
+    SierraMeetingSubjects(bibId, data) shouldBe List(
+      Unidentifiable(
+        Subject(
+          label = "A C D",
+          concepts = List(Unidentifiable(Meeting(label = "A C D")))
+        )
+      )
+    )
+  }
+
+  it("returns zero subjects if subfields all $$a, $$c and $$d are missing") {
+    val data = bibData(
+      varField("611", MarcSubfield(tag = "x", content = "Hmmm"))
+    )
+    SierraMeetingSubjects(bibId, data) shouldBe Nil
+  }
+
+  it("creates an identifiable subject if subfield 0") {
+    val data = bibData(
+      varField(
+        "600",
+        MarcSubfield(tag = "a", content = "Content"),
+        MarcSubfield(tag = "0", content = "lcsh7212")
+      )
+    )
+    val sourceIdentifier = SourceIdentifier(
+      identifierType = IdentifierType("lc-names"),
+      ontologyType = "Subject",
+      value = "lcsh7212"
+    )
+    SierraPersonSubjects(bibId, data) shouldBe List(
+      Identifiable(
+        Subject(
+          label = "Content",
+          concepts = List(Unidentifiable(Person(label = "Content")))
+        ),
+        sourceIdentifier = sourceIdentifier
+      )
+    )
+  }
+
+  it("returns multiple subjects if multiple 611") {
+    val data = bibData(
+      varField("611", MarcSubfield(tag = "a", content = "First")),
+      varField("611", MarcSubfield(tag = "a", content = "Second")),
+    )
+    SierraMeetingSubjects(bibId, data) shouldBe List(
+      Unidentifiable(
+        Subject(
+          label = "First",
+          concepts = List(Unidentifiable(Meeting(label = "First")))
+        )
+      ),
+      Unidentifiable(
+        Subject(
+          label = "Second",
+          concepts = List(Unidentifiable(Meeting(label = "Second")))
+        )
+      )
+    )
+  }
+}

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraMeetingSubjectsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraMeetingSubjectsTest.scala
@@ -2,7 +2,10 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers.subjects
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.platform.transformer.sierra.source.{MarcSubfield, VarField}
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  MarcSubfield,
+  VarField
+}
 import uk.ac.wellcome.platform.transformer.sierra.generators.{
   MarcGenerators,
   SierraDataGenerators
@@ -20,7 +23,10 @@ class SierraMeetingSubjectsTest
     createSierraBibDataWith(varFields = varFields.toList)
 
   def varField(tag: String, subfields: MarcSubfield*) =
-    createVarFieldWith(marcTag = tag, subfields = subfields.toList, indicator2 = "0")
+    createVarFieldWith(
+      marcTag = tag,
+      subfields = subfields.toList,
+      indicator2 = "0")
 
   it("returns zero subjects if there are none") {
     SierraMeetingSubjects(bibId, bibData()) shouldBe Nil

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraOrganisationSubjectsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraOrganisationSubjectsTest.scala
@@ -16,10 +16,8 @@ class SierraOrganisationSubjectsTest
     with Matchers
     with SierraDataGenerators {
   it("returns an empty list if there are no instances of MARC tag 610") {
-    val bibData = createSierraBibDataWith(varFields = List())
-    transformer.getSubjectsWithOrganisation(
-      bibId = createSierraBibNumber,
-      bibData) shouldBe List()
+    val bibData = createSierraBibDataWith(varFields = Nil)
+    getOrganisationSubjects(bibData) shouldBe Nil
   }
 
   describe("label") {
@@ -235,10 +233,8 @@ class SierraOrganisationSubjectsTest
       subfields = subfields
     )
 
-  val transformer = new SierraOrganisationSubjects {}
-
   private def getOrganisationSubjects(bibData: SierraBibData,
                                       bibId: SierraBibNumber =
                                         createSierraBibNumber) =
-    transformer.getSubjectsWithOrganisation(bibId = bibId, bibData = bibData)
+    SierraOrganisationSubjects(bibId, bibData)
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraPersonSubjectsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraPersonSubjectsTest.scala
@@ -13,15 +13,16 @@ class SierraPersonSubjectsTest
     with Matchers
     with MarcGenerators
     with SierraDataGenerators {
-  private val transformer = new SierraPersonSubjects {}
+
+  def bibId = createSierraBibNumber
 
   it("returns zero subjects if there are none") {
     val bibData = createSierraBibDataWith(varFields = List())
-    transformer.getSubjectsWithPerson(bibData) shouldBe Nil
+    SierraPersonSubjects(bibId, bibData) shouldBe Nil
   }
 
   it("returns subjects for tag 600 with only subfield a") {
-    val sierraBibData = createSierraBibDataWith(
+    val bibData = createSierraBibDataWith(
       varFields = List(
         createVarFieldWith(
           marcTag = "600",
@@ -32,7 +33,7 @@ class SierraPersonSubjectsTest
       )
     )
 
-    transformer.getSubjectsWithPerson(sierraBibData) shouldBe List(
+    SierraPersonSubjects(bibId, bibData) shouldBe List(
       Unidentifiable(
         Subject(
           label = "A Content",
@@ -43,7 +44,7 @@ class SierraPersonSubjectsTest
   }
 
   it("returns subjects for tag 600 with only subfields a and c") {
-    val sierraBibData = createSierraBibDataWith(
+    val bibData = createSierraBibDataWith(
       varFields = List(
         createVarFieldWith(
           marcTag = "600",
@@ -55,7 +56,7 @@ class SierraPersonSubjectsTest
       )
     )
 
-    transformer.getSubjectsWithPerson(sierraBibData) shouldBe List(
+    SierraPersonSubjects(bibId, bibData) shouldBe List(
       Unidentifiable(
         Subject(
           label = "Larrey, D. J. baron",
@@ -69,7 +70,7 @@ class SierraPersonSubjectsTest
   }
 
   it("returns subjects for tag 600 with only subfields a and multiple c") {
-    val sierraBibData = createSierraBibDataWith(
+    val bibData = createSierraBibDataWith(
       varFields = List(
         createVarFieldWith(
           marcTag = "600",
@@ -82,7 +83,7 @@ class SierraPersonSubjectsTest
       )
     )
 
-    transformer.getSubjectsWithPerson(sierraBibData) shouldBe List(
+    SierraPersonSubjects(bibId, bibData) shouldBe List(
       Unidentifiable(
         Subject(
           label = "David Attenborough sir doctor",
@@ -94,7 +95,7 @@ class SierraPersonSubjectsTest
   }
 
   it("returns subjects for tag 600 with only subfields a and b") {
-    val sierraBibData = createSierraBibDataWith(
+    val bibData = createSierraBibDataWith(
       varFields = List(
         createVarFieldWith(
           marcTag = "600",
@@ -106,7 +107,7 @@ class SierraPersonSubjectsTest
       )
     )
 
-    transformer.getSubjectsWithPerson(sierraBibData) shouldBe List(
+    SierraPersonSubjects(bibId, bibData) shouldBe List(
       Unidentifiable(
         Subject(
           label = "David Attenborough II",
@@ -118,7 +119,7 @@ class SierraPersonSubjectsTest
   }
 
   it("returns subjects for tag 600 with subfields a and e") {
-    val sierraBibData = createSierraBibDataWith(
+    val bibData = createSierraBibDataWith(
       varFields = List(
         createVarFieldWith(
           marcTag = "600",
@@ -130,7 +131,7 @@ class SierraPersonSubjectsTest
       )
     )
 
-    transformer.getSubjectsWithPerson(sierraBibData) shouldBe List(
+    SierraPersonSubjects(bibId, bibData) shouldBe List(
       Unidentifiable(
         Subject(
           label = "David Attenborough, author",
@@ -141,7 +142,7 @@ class SierraPersonSubjectsTest
   }
 
   it("returns subjects for tag 600 with subfields a and d") {
-    val sierraBibData = createSierraBibDataWith(
+    val bibData = createSierraBibDataWith(
       varFields = List(
         createVarFieldWith(
           marcTag = "600",
@@ -155,7 +156,7 @@ class SierraPersonSubjectsTest
       )
     )
 
-    transformer.getSubjectsWithPerson(sierraBibData) shouldBe List(
+    SierraPersonSubjects(bibId, bibData) shouldBe List(
       Unidentifiable(
         Subject(
           label = "Rita Levi Montalcini, 22 April 1909 – 30 December 2012",
@@ -167,7 +168,7 @@ class SierraPersonSubjectsTest
   }
 
   it("returns subjects for tag 600 with subfields a and multiple e") {
-    val sierraBibData = createSierraBibDataWith(
+    val bibData = createSierraBibDataWith(
       varFields = List(
         createVarFieldWith(
           marcTag = "600",
@@ -180,7 +181,7 @@ class SierraPersonSubjectsTest
       )
     )
 
-    transformer.getSubjectsWithPerson(sierraBibData) shouldBe List(
+    SierraPersonSubjects(bibId, bibData) shouldBe List(
       Unidentifiable(
         Subject(
           label = "David Attenborough, author, editor",
@@ -194,7 +195,7 @@ class SierraPersonSubjectsTest
   // error, but all the person will do is delete the field, so we can avoid
   // throwing an error.
   it("errors transforming a subject 600 if subfield a is missing") {
-    val sierraBibData = createSierraBibDataWith(
+    val bibData = createSierraBibDataWith(
       varFields = List(
         createVarFieldWith(
           marcTag = "600",
@@ -203,7 +204,7 @@ class SierraPersonSubjectsTest
       )
     )
 
-    transformer.getSubjectsWithPerson(sierraBibData) shouldBe List()
+    SierraPersonSubjects(bibId, bibData) shouldBe Nil
   }
 
   it(
@@ -211,7 +212,7 @@ class SierraPersonSubjectsTest
     val name = "Gerry the Garlic"
     val lcshCode = "lcsh7212"
 
-    val sierraBibData = createSierraBibDataWith(
+    val bibData = createSierraBibDataWith(
       varFields = List(
         createVarFieldWith(
           marcTag = "600",
@@ -230,7 +231,7 @@ class SierraPersonSubjectsTest
       value = lcshCode
     )
 
-    transformer.getSubjectsWithPerson(sierraBibData) shouldBe List(
+    SierraPersonSubjects(bibId, bibData) shouldBe List(
       Identifiable(
         Subject(
           label = "Gerry the Garlic",
@@ -245,7 +246,7 @@ class SierraPersonSubjectsTest
 
   it("creates an unidentifiable person concept if second indicator is not 0") {
     val name = "Gerry the Garlic"
-    val sierraBibData = createSierraBibDataWith(
+    val bibData = createSierraBibDataWith(
       varFields = List(
         createVarFieldWith(
           marcTag = "600",
@@ -258,7 +259,7 @@ class SierraPersonSubjectsTest
       )
     )
 
-    transformer.getSubjectsWithPerson(sierraBibData) shouldBe List(
+    SierraPersonSubjects(bibId, bibData) shouldBe List(
       Unidentifiable(
         Subject(
           label = "Gerry the Garlic",
@@ -284,7 +285,8 @@ class SierraPersonSubjectsTest
       )
     )
 
-    val actualSubjects = transformer.getSubjectsWithPerson(bibData)
+    
+    val actualSubjects = SierraPersonSubjects(bibId, bibData)
     actualSubjects should have size 1
     val subject = actualSubjects.head
 
@@ -316,7 +318,8 @@ class SierraPersonSubjectsTest
       )
     )
 
-    val actualSubjects = transformer.getSubjectsWithPerson(bibData)
+    
+    val actualSubjects = SierraPersonSubjects(bibId, bibData)
     actualSubjects should have size 1
     val subject = actualSubjects.head
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraPersonSubjectsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraPersonSubjectsTest.scala
@@ -285,7 +285,6 @@ class SierraPersonSubjectsTest
       )
     )
 
-    
     val actualSubjects = SierraPersonSubjects(bibId, bibData)
     actualSubjects should have size 1
     val subject = actualSubjects.head
@@ -318,7 +317,6 @@ class SierraPersonSubjectsTest
       )
     )
 
-    
     val actualSubjects = SierraPersonSubjects(bibId, bibData)
     actualSubjects should have size 1
     val subject = actualSubjects.head


### PR DESCRIPTION
### Issues

https://github.com/wellcometrust/platform/issues/3633
https://github.com/wellcometrust/platform/issues/3634

### Description

Add "meeting" (as `Meeting`) and "brand name" (as `Concept`) subjects from marc fields 611 / 652.