### PR TITLE
[WIP] Structured Note type

### DIFF
--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
@@ -32,6 +32,12 @@ object WorksIndex {
       keywordField("id")
     )
 
+  val notes = objectField("notes")
+    .fields(
+      keywordField("type"),
+      englishTextField("content")
+    )
+
   def location(fieldName: String = "locations") =
     objectField(fieldName).fields(
       keywordField("type"),
@@ -170,7 +176,7 @@ object WorksIndex {
       language,
       location("thumbnail"),
       textField("edition"),
-      englishTextField("notes"),
+      notes,
       englishTextField("dissertation"),
       englishTextField("locationOfOriginal"),
       englishTextField("citeAs"),

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/Implicits.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/Implicits.scala
@@ -25,6 +25,7 @@ import uk.ac.wellcome.models.work.internal.{
   Location,
   MaybeDisplayable,
   MergeCandidate,
+  Note,
   Period,
   Person,
   PhysicalLocation,
@@ -36,7 +37,7 @@ import uk.ac.wellcome.models.work.internal.{
   UnidentifiedInvisibleWork,
   UnidentifiedRedirectedWork,
   UnidentifiedWork,
-  WorkType,
+  WorkType
 }
 import uk.ac.wellcome.models.transformable.SierraTransformable
 import uk.ac.wellcome.models.transformable.SierraTransformable._
@@ -52,6 +53,7 @@ object Implicits {
   // flamegraphs using the scalac-profiling plugin. See this blog post for
   // info: https://www.scala-lang.org/blog/2018/06/04/scalac-profiling.html
 
+  implicit val _dec01: Decoder[Note] = deriveDecoder
   implicit val _dec02: Decoder[SourceIdentifier] = deriveDecoder
   implicit val _dec03: Decoder[Identifiable[AbstractConcept]] = deriveDecoder
   implicit val _dec04: Decoder[Unidentifiable[AbstractConcept]] = deriveDecoder
@@ -127,6 +129,7 @@ object Implicits {
   implicit val _dec54: Decoder[BaseWork] = deriveDecoder
   implicit val _dec55: Decoder[SierraTransformable] = deriveDecoder
 
+  implicit val _enc01: Encoder[Note] = deriveEncoder
   implicit val _enc02: Encoder[SourceIdentifier] = deriveEncoder
   implicit val _enc03: Encoder[Identifiable[AbstractConcept]] = deriveEncoder
   implicit val _enc04: Encoder[Unidentifiable[AbstractConcept]] = deriveEncoder

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Note.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Note.scala
@@ -5,3 +5,9 @@ sealed trait Note {
 }
 
 case class GeneralNote(val content: String) extends Note
+
+case class BibliographicalInformation(val content: String) extends Note
+
+case class FundingInformation(val content: String) extends Note
+
+case class TimeAndPlaceNote(val content: String) extends Note

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Note.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Note.scala
@@ -1,0 +1,7 @@
+package uk.ac.wellcome.models.work.internal
+
+sealed trait Note {
+  val content: String
+}
+
+case class GeneralNote(val content: String) extends Note

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -30,7 +30,7 @@ sealed trait Work extends BaseWork with MultipleSourceIdentifiers {
   val production: List[ProductionEvent[IdentityState[AbstractAgent]]]
   val language: Option[Language]
   val edition: Option[String]
-  val notes: List[String]
+  val notes: List[Note]
   val dissertation: Option[String]
   val locationOfOriginal: Option[String]
   val citeAs: Option[String]
@@ -62,7 +62,7 @@ case class UnidentifiedWork(
   production: List[ProductionEvent[MaybeDisplayable[AbstractAgent]]],
   language: Option[Language],
   edition: Option[String],
-  notes: List[String] = Nil,
+  notes: List[Note] = Nil,
   dissertation: Option[String] = None,
   locationOfOriginal: Option[String] = None,
   citeAs: Option[String] = None,
@@ -94,7 +94,7 @@ case class IdentifiedWork(
   production: List[ProductionEvent[Displayable[AbstractAgent]]],
   language: Option[Language],
   edition: Option[String],
-  notes: List[String] = Nil,
+  notes: List[Note] = Nil,
   dissertation: Option[String] = None,
   locationOfOriginal: Option[String] = None,
   citeAs: Option[String] = None,

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
@@ -82,7 +82,7 @@ trait WorksGenerators extends ItemsGenerators with ProductionEventGenerators {
     thumbnail: Option[Location] = None,
     contributors: List[Contributor[MaybeDisplayable[AbstractAgent]]] = List(),
     production: List[ProductionEvent[MaybeDisplayable[AbstractAgent]]] = List(),
-    notes: List[String] = Nil,
+    notes: List[Note] = Nil,
     items: List[MaybeDisplayable[Item]] = List(),
     itemsV1: List[Identifiable[Item]] = List(),
   ): UnidentifiedWork =
@@ -133,7 +133,7 @@ trait WorksGenerators extends ItemsGenerators with ProductionEventGenerators {
     contributors: List[Contributor[Displayable[AbstractAgent]]] = List(),
     thumbnail: Option[Location] = None,
     production: List[ProductionEvent[Displayable[AbstractAgent]]] = List(),
-    notes: List[String] = Nil,
+    notes: List[Note] = Nil,
     language: Option[Language] = None,
     items: List[Displayable[Item]] = List(),
     itemsV1: List[Identified[Item]] = List(),

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotes.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotes.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
+import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 import uk.ac.wellcome.platform.transformer.sierra.source.{
   SierraBibData,
@@ -8,10 +9,26 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
 
 object SierraNotes extends SierraTransformer with SierraQueryOps {
 
-  type Output = List[String]
+  type Output = List[Note]
+
+  val notesFields: List[(String, String => Note)] =
+    List(
+      "500" -> GeneralNote.apply,
+      "501" -> GeneralNote.apply,
+      "504" -> GeneralNote.apply,
+      "518" -> GeneralNote.apply,
+      "536" -> GeneralNote.apply,
+      "545" -> GeneralNote.apply,
+      "547" -> GeneralNote.apply,
+      "562" -> GeneralNote.apply
+    )
 
   def apply(bibId: SierraBibNumber, bibData: SierraBibData) =
-    bibData
-      .varfieldsWithTags("500", "501", "504", "518", "536", "545", "547", "562")
-      .subfieldContents
+    notesFields
+      .flatMap { case (tag, createNote) =>
+        bibData
+          .varfieldsWithTags(tag)
+          .subfieldContents
+          .map(createNote)
+      }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotes.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotes.scala
@@ -15,10 +15,10 @@ object SierraNotes extends SierraTransformer with SierraQueryOps {
     List(
       "500" -> GeneralNote.apply,
       "501" -> GeneralNote.apply,
-      "504" -> GeneralNote.apply,
-      "518" -> GeneralNote.apply,
-      "536" -> GeneralNote.apply,
-      "545" -> GeneralNote.apply,
+      "504" -> BibliographicalInformation.apply,
+      "518" -> TimeAndPlaceNote.apply,
+      "536" -> FundingInformation.apply,
+      "545" -> BibliographicalInformation.apply,
       "547" -> GeneralNote.apply,
       "562" -> GeneralNote.apply
     )

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotesTest.scala
@@ -21,10 +21,10 @@ class SierraNotesTest
     val notes = List(
       "500" -> GeneralNote("note a"),
       "501" -> GeneralNote("note b"),
-      "504" -> GeneralNote("note c"),
-      "518" -> GeneralNote("note d"),
-      "536" -> GeneralNote("note e"),
-      "545" -> GeneralNote("note f"),
+      "504" -> BibliographicalInformation("note c"),
+      "518" -> TimeAndPlaceNote("note d"),
+      "536" -> FundingInformation("note e"),
+      "545" -> BibliographicalInformation("note f"),
       "547" -> GeneralNote("note g"),
       "562" -> GeneralNote("note h"),
     )

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotesTest.scala
@@ -1,11 +1,12 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
+import uk.ac.wellcome.models.work.internal._
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.transformer.sierra.generators.{
   MarcGenerators,
   SierraDataGenerators
 }
-import uk.ac.wellcome.platform.transformer.sierra.source.MarcSubfield
+import uk.ac.wellcome.platform.transformer.sierra.source.{MarcSubfield, SierraBibData}
 
 class SierraNotesTest
     extends FunSpec
@@ -15,24 +16,24 @@ class SierraNotesTest
 
   it("should extract notes from all fields") {
     val notes = List(
-      "500" -> "note a",
-      "501" -> "note b",
-      "504" -> "note c",
-      "518" -> "note d",
-      "536" -> "note e",
-      "545" -> "note f",
-      "547" -> "note g",
-      "562" -> "note h",
+      "500" -> GeneralNote("note a"),
+      "501" -> GeneralNote("note b"),
+      "504" -> GeneralNote("note c"),
+      "518" -> GeneralNote("note d"),
+      "536" -> GeneralNote("note e"),
+      "545" -> GeneralNote("note f"),
+      "547" -> GeneralNote("note g"),
+      "562" -> GeneralNote("note h"),
     )
-    SierraNotes(bibId, bibData(notes: _*)) shouldBe notes.map(_._2)
+    SierraNotes(bibId, bibData(notes)) shouldBe notes.map(_._2)
   }
 
   it("should extract all notes when duplicate fields") {
     val notes = List(
-      "500" -> "note a",
-      "500" -> "note b",
+      "500" -> GeneralNote("note a"),
+      "500" -> GeneralNote("note b"),
     )
-    SierraNotes(bibId, bibData(notes: _*)) shouldBe notes.map(_._2)
+    SierraNotes(bibId, bibData(notes)) shouldBe notes.map(_._2)
   }
 
   it("should not extract notes from non notes fields") {
@@ -44,19 +45,22 @@ class SierraNotesTest
   }
 
   it("should preserve html in notes fields") {
-    val note = "500" -> "<p>note</p>"
-    SierraNotes(bibId, bibData(note)) shouldBe List(note._2)
+    val notes = List("500" -> GeneralNote("<p>note</p>"))
+    SierraNotes(bibId, bibData(notes)) shouldBe notes.map(_._2)
   }
 
   def bibId = createSierraBibNumber
 
-  def bibData(notes: (String, String)*) =
+  def bibData(contents: List[(String, Note)]): SierraBibData =
+    bibData(contents.map { case (tag, note) => (tag, note.content) }: _*)
+
+  def bibData(contents: (String, String)*): SierraBibData =
     createSierraBibDataWith(
-      varFields = notes.toList.map {
-        case (tag, value) =>
+      varFields = contents.toList.map {
+        case (tag, content) =>
           createVarFieldWith(
             marcTag = tag,
-            subfields = List(MarcSubfield(tag = "a", content = value))
+            subfields = List(MarcSubfield(tag = "a", content = content))
           )
       }
     )

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
@@ -263,7 +263,7 @@ class SierraTransformableTransformerTest
           function = None
         )
       ),
-      notes = List("It's a note"),
+      notes = List(GeneralNote("It's a note")),
       lettering = Some(lettering)
     )
   }


### PR DESCRIPTION
### Issue

https://github.com/wellcometrust/platform/issues/3909

### Description

Instead of just storing notes as strings, we include information about the type of note that is stored. For example

```js
// notes
[
  {
    "content": "note content",
    "type": "GeneralNote"
  },
  ...
]
```

Currently the mapping is:

[`500` "general note"](https://www.loc.gov/marc/bibliographic/bd500.html) -> `GeneralNote`
[`501` "with note"](https://www.loc.gov/marc/bibliographic/bd501.html) -> `GeneralNote`?
[`504` "bibliography etc, note"](https://www.loc.gov/marc/bibliographic/bd504.html) -> `BibliographicalInformation`?
[`518` "date/time and place of event note"](https://www.loc.gov/marc/bibliographic/bd518.html) -> `TimeAndPlaceNote`?
[`536` "funding information note"](https://www.loc.gov/marc/bibliographic/bd536.html) -> `FundingInformation`?
[`545` "biographical or historical data"](https://www.loc.gov/marc/bibliographic/bd545.html) -> `BibliographicalInformation`?
[`547` "former title complexity note"](https://www.loc.gov/marc/bibliographic/bd547.html) -> `GeneralNote`?
[`562` "copy and version identification note"](https://www.loc.gov/marc/bibliographic/bd562.html) -> `GeneralNote`?

There are also upcoming notes fields (used primarily for audiovisual works):

[`505` "formatted contents note"](https://www.loc.gov/marc/bibliographic/bd500.html) -> `ContentsNote`?
[`508` "creation / production credits note"](https://www.loc.gov/marc/bibliographic/bd501.html) -> `CreditsNote`?
[`511` "participant or performer note"](https://www.loc.gov/marc/bibliographic/bd501.html) -> `CreditsNote`?

For reference [here](https://gist.github.com/warrd/8a904f02d3eee5a78601de886091cddb) is the analysis of different notes  fields.