### PR TITLE
Update note display model

### DIFF
--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksIncludesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksIncludesTest.scala
@@ -397,7 +397,7 @@ class ApiV2WorksIncludesTest
             notes = List(GeneralNote("A"), FundingInformation("B"))),
           createIdentifiedWorkWith(
             canonicalId = "B",
-            notes = List(GeneralNote("C"))),
+            notes = List(GeneralNote("C"), GeneralNote("D"))),
         )
         insertIntoElasticsearch(indexV2, works: _*)
         eventually {
@@ -413,8 +413,24 @@ class ApiV2WorksIncludesTest
               |       "id": "${works(0).canonicalId}",
               |       "title": "${works(0).title}",
               |       "notes": [
-              |         { "type": "GeneralNote", "content": "A" },
-              |         { "type": "FundingInformation", "content": "B" }
+              |         {
+              |           "noteType": {
+              |             "id": "funding-info",
+              |             "label": "Funding information",
+              |             "type": "NoteType"
+              |           },
+              |           "contents": ["B"],
+              |           "type": "Note"
+              |         },
+              |         {
+              |           "noteType": {
+              |             "id": "general-note",
+              |             "label": "General note",
+              |             "type": "NoteType"
+              |           },
+              |           "contents": ["A"],
+              |           "type": "Note"
+              |         }
               |       ]
               |     },
               |     {
@@ -422,7 +438,15 @@ class ApiV2WorksIncludesTest
               |       "id": "${works(1).canonicalId}",
               |       "title": "${works(1).title}",
               |       "notes": [
-              |         { "type": "GeneralNote", "content": "C" }
+              |         {
+              |           "noteType": {
+              |             "id": "general-note",
+              |             "label": "General note",
+              |             "type": "NoteType"
+              |           },
+              |           "contents": ["C", "D"],
+              |           "type": "Note"
+              |         }
               |       ]
               |    }
               |  ]
@@ -437,7 +461,7 @@ class ApiV2WorksIncludesTest
     withV2Api {
       case (indexV2, server: EmbeddedHttpServer) =>
         val work = createIdentifiedWorkWith(
-          notes = List(GeneralNote("A"), FundingInformation("B")))
+          notes = List(GeneralNote("A"), GeneralNote("B")))
         insertIntoElasticsearch(indexV2, work)
         eventually {
           server.httpGet(
@@ -449,8 +473,15 @@ class ApiV2WorksIncludesTest
               |  "id": "${work.canonicalId}",
               |  "title": "${work.title}",
               |  "notes": [
-              |    { "type": "GeneralNote", "content": "A" },
-              |    { "type": "FundingInformation", "content": "B" }
+              |     {
+              |       "noteType": {
+              |         "id": "general-note",
+              |         "label": "General note",
+              |         "type": "NoteType"
+              |       },
+              |       "contents": ["A", "B"],
+              |       "type": "Note"
+              |     }
               |  ]
               |}
           """.stripMargin

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayNote.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayNote.scala
@@ -4,19 +4,57 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import io.circe.generic.extras.JsonKey
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
 
-import uk.ac.wellcome.models.work.internal.Note
+import uk.ac.wellcome.models.work.internal._
 
 @ApiModel(
   value = "Note",
   description = "A note associated with the work."
 )
 case class DisplayNote(
-  @ApiModelProperty(value = "The note content.") content: String,
-  @JsonProperty("type") @JsonKey("type") noteType: String
+  @ApiModelProperty(value = "The note contents.") contents: List[String],
+  @ApiModelProperty(value = "The type of note.") noteType: DisplayNoteType,
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "Note"
+)
+
+case class DisplayNoteType(
+  @ApiModelProperty(
+    dataType = "String"
+  ) id: String,
+  @ApiModelProperty(
+    dataType = "String"
+  ) label: String,
+  @JsonProperty("type") @JsonKey("type") ontologyType: String = "NoteType"
 )
 
 object DisplayNote {
 
   def apply(note: Note): DisplayNote =
-    DisplayNote(note.content, note.getClass.getSimpleName)
+    DisplayNote(List(note.content), DisplayNoteType(note))
+
+  def merge(notes: List[DisplayNote]): List[DisplayNote] =
+    notes
+      .groupBy(_.noteType)
+      .toList
+      .map { case (noteType, notes) =>
+        DisplayNote(notes.flatMap(_.contents), noteType)
+      }
+}
+
+object DisplayNoteType {
+
+  def apply(note: Note): DisplayNoteType =
+    note match {
+      case GeneralNote(_) =>
+        DisplayNoteType("general-note", "General note")
+      case BibliographicalInformation(_) =>
+        DisplayNoteType("bibliographical-info", "Bibliographical information")
+      case FundingInformation(_) =>
+        DisplayNoteType("fuding-info", "Funding information")
+      case TimeAndPlaceNote(_) =>
+        DisplayNoteType("time-and-place-note", "Time and place note")
+      case CreditsNote(_) =>
+        DisplayNoteType("credits-note", "Credits note")
+      case ContentsNote(_) =>
+        DisplayNoteType("contents-note", "Contents note")
+    }
 }

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayNote.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayNote.scala
@@ -49,7 +49,7 @@ object DisplayNoteType {
       case BibliographicalInformation(_) =>
         DisplayNoteType("bibliographical-info", "Bibliographical information")
       case FundingInformation(_) =>
-        DisplayNoteType("fuding-info", "Funding information")
+        DisplayNoteType("funding-info", "Funding information")
       case TimeAndPlaceNote(_) =>
         DisplayNoteType("time-and-place-note", "Time and place note")
       case CreditsNote(_) =>

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2.scala
@@ -160,7 +160,7 @@ case object DisplayWorkV2 {
       edition = work.edition,
       notes =
         if (includes.notes && work.notes.nonEmpty)
-          Some(work.notes.map(DisplayNote(_)))
+          Some(DisplayNote.merge(work.notes.map(DisplayNote(_))))
         else None,
       dissertation = if (includes.dissertation) work.dissertation else None,
       locationOfOriginal = work.locationOfOriginal,

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
@@ -237,7 +237,8 @@ class DisplayWorkV2SerialisationTest
     )
   }
 
-  it("includes 'notes' if the notes include is present, with similar notes grouped together") {
+  it(
+    "includes 'notes' if the notes include is present, with similar notes grouped together") {
     val work = createIdentifiedWorkWith(
       notes = List(GeneralNote("A"), FundingInformation("B"), GeneralNote("C"))
     )

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2SerialisationTest.scala
@@ -237,19 +237,38 @@ class DisplayWorkV2SerialisationTest
     )
   }
 
-  it("includes 'notes' if the notes include is present") {
+  it("includes 'notes' if the notes include is present, with similar notes grouped together") {
     val work = createIdentifiedWorkWith(
-      notes = List(GeneralNote("A note"))
+      notes = List(GeneralNote("A"), FundingInformation("B"), GeneralNote("C"))
     )
 
     val expectedJson = s"""
-                          |{
-                          | "type": "Work",
-                          | "id": "${work.canonicalId}",
-                          | "title": "${work.title}",
-                          | "notes": [{"type": "GeneralNote", "content": "A note"}]
-                          |}
-          """.stripMargin
+      |{
+      | "type": "Work",
+      | "id": "${work.canonicalId}",
+      | "title": "${work.title}",
+      | "notes": [
+      |   {
+      |     "noteType": {
+      |       "id": "funding-info",
+      |       "label": "Funding information",
+      |       "type": "NoteType"
+      |     },
+      |     "contents": ["B"],
+      |     "type": "Note"
+      |   },
+      |   {
+      |     "noteType": {
+      |       "id": "general-note",
+      |       "label": "General note",
+      |       "type": "NoteType"
+      |     },
+      |     "contents": ["A", "C"],
+      |     "type": "Note"
+      |   }
+      | ]
+      |}
+    """.stripMargin
 
     assertObjectMapsToJson(
       DisplayWorkV2(work, includes = V2WorksIncludes(notes = true)),


### PR DESCRIPTION
### Issue

https://github.com/wellcometrust/platform/issues/3909

### Description

Following on from discussion in #190, the note display model has been updated:

```json
"notes": [
  {
    "noteType": {
      "id": "contents-note",
      "label": "Contents note",
      "type": "NoteType"
    },
    "type": "Note",
    "contents": [
      "This short film shows footage of a Brazilian settlement",
      "Time start: 00:00:00:00",
      "Time end: 00:09:23:00"
    ]
  },
  {
    "noteType": {
      "id": "credits-note",
      "label": "Credits note",
      "type": "NoteType"
    },
    "type": "Note",
    "contents": [
      "No production credits."
    ]
  }
]
```