### PR TITLE
search on work and items ids

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkQuery.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkQuery.scala
@@ -24,9 +24,6 @@ object WorkQuery {
     ("genres.label", Some(8.0)),
     ("description", Some(3.0)),
     ("contributors.*", Some(2.0)),
-    ("canonicalId", None),
-    ("sourceIdentifier.value", None),
-    ("otherIdentifiers.value", None),
     ("alternativeTitles", None),
     ("physicalDescription", None),
     ("lettering", None),
@@ -36,6 +33,13 @@ object WorkQuery {
     ("dissertation", None),
     ("locationOfOriginal", None),
     ("citeAs", None),
+    // Identifiers
+    ("canonicalId", None),
+    ("sourceIdentifier.value", None),
+    ("otherIdentifiers.value", None),
+    ("items.canonicalId", None),
+    ("items.sourceIdentifier.value", None),
+    ("items.otherIdentifiers.value", None),
   )
 
   case class MSMBoostQuery(queryString: String) extends WorkQuery {

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ItemsGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ItemsGenerators.scala
@@ -6,11 +6,13 @@ trait ItemsGenerators extends IdentifiersGenerators {
   def createIdentifiedItemWith(
     canonicalId: String = createCanonicalId,
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
+    otherIdentifiers: List[SourceIdentifier] = Nil,
     locations: List[Location] = List(defaultLocation)
   ): Identified[Item] =
     Identified(
       canonicalId = canonicalId,
       sourceIdentifier = sourceIdentifier,
+      otherIdentifiers = otherIdentifiers,
       agent = Item(locations = locations)
     )
 


### PR DESCRIPTION
I was thinking we could make this standard for all IDs - but would like to approach that piece of work if that is the requirement, as we might land up with a solution of creating the Items API, which is maybe better though about in context of ingesting the METS.

For now, all I need for the requests service is to be able to search for an item ID.