### PR TITLE
Statically typed error variant

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/MissingPathController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/MissingPathController.scala
@@ -4,7 +4,7 @@ import com.google.inject.{Inject, Singleton}
 import com.twitter.finagle.http.Request
 import com.twitter.finatra.http.Controller
 import uk.ac.wellcome.platform.api.ContextHelper.buildContextUri
-import uk.ac.wellcome.platform.api.models.{ApiConfig, DisplayError, Error}
+import uk.ac.wellcome.platform.api.models.{ApiConfig, DisplayError, Error, ErrorVariant}
 import uk.ac.wellcome.platform.api.responses.ResultResponse
 
 /** This controller returns a 404 to any requests for an undefined path.
@@ -24,7 +24,7 @@ class MissingPathController @Inject()(apiConfig: ApiConfig) extends Controller {
 
   get("/:*") { request: Request =>
     val result = Error(
-      variant = "http-404",
+      variant = ErrorVariant.http404,
       description = Some(s"Page not found for URL ${request.uri}")
     )
 

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/MissingPathController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/MissingPathController.scala
@@ -4,7 +4,12 @@ import com.google.inject.{Inject, Singleton}
 import com.twitter.finagle.http.Request
 import com.twitter.finatra.http.Controller
 import uk.ac.wellcome.platform.api.ContextHelper.buildContextUri
-import uk.ac.wellcome.platform.api.models.{ApiConfig, DisplayError, Error, ErrorVariant}
+import uk.ac.wellcome.platform.api.models.{
+  ApiConfig,
+  DisplayError,
+  Error,
+  ErrorVariant
+}
 import uk.ac.wellcome.platform.api.responses.ResultResponse
 
 /** This controller returns a 404 to any requests for an undefined path.

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V1GoneController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V1GoneController.scala
@@ -4,7 +4,12 @@ import com.google.inject.{Inject, Singleton}
 import com.twitter.finagle.http.Request
 import com.twitter.finatra.http.Controller
 import uk.ac.wellcome.display.models.ApiVersions
-import uk.ac.wellcome.platform.api.models.{ApiConfig, DisplayError, Error, ErrorVariant}
+import uk.ac.wellcome.platform.api.models.{
+  ApiConfig,
+  DisplayError,
+  Error,
+  ErrorVariant
+}
 import uk.ac.wellcome.platform.api.responses.ResultResponse
 import uk.ac.wellcome.platform.api.ContextHelper.buildContextUri
 

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V1GoneController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/V1GoneController.scala
@@ -4,7 +4,7 @@ import com.google.inject.{Inject, Singleton}
 import com.twitter.finagle.http.Request
 import com.twitter.finatra.http.Controller
 import uk.ac.wellcome.display.models.ApiVersions
-import uk.ac.wellcome.platform.api.models.{ApiConfig, DisplayError, Error}
+import uk.ac.wellcome.platform.api.models.{ApiConfig, DisplayError, Error, ErrorVariant}
 import uk.ac.wellcome.platform.api.responses.ResultResponse
 import uk.ac.wellcome.platform.api.ContextHelper.buildContextUri
 
@@ -21,7 +21,7 @@ class V1GoneController @Inject()(apiConfig: ApiConfig) extends Controller {
         ResultResponse(
           context = buildContextUri(apiConfig, version),
           result = DisplayError(Error(
-            "http-410",
+            ErrorVariant.http410,
             Some("This API is now decommissioned. Please use https://api.wellcomecollection.org/catalogue/v2/works.")))
         ))
     }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -251,7 +251,7 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
 
   private def respondWithGoneError(contextUri: String) = {
     val result = Error(
-      variant = "http-410",
+      variant = ErrorVariant.http410,
       description = Some("This work has been deleted")
     )
     response.gone.json(
@@ -264,7 +264,7 @@ abstract class WorksController[M <: MultipleResultsRequest[W],
 
   private def respondWithNotFoundError(request: S, contextUri: String) = {
     val result = Error(
-      variant = "http-404",
+      variant = ErrorVariant.http404,
       description = Some(s"Work not found for identifier ${request.id}")
     )
     response.notFound.json(

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ElasticErrorHandler.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ElasticErrorHandler.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.api.elasticsearch
 
 import com.sksamuel.elastic4s.ElasticError
 import grizzled.slf4j.Logging
-import uk.ac.wellcome.platform.api.models.{DisplayError, Error}
+import uk.ac.wellcome.platform.api.models.{DisplayError, Error, ErrorVariant}
 
 object ElasticErrorHandler extends Logging {
 
@@ -56,20 +56,20 @@ object ElasticErrorHandler extends Logging {
                         elasticError: ElasticError): DisplayError = {
     warn(
       s"Sending HTTP 400 from ${this.getClass.getSimpleName} ($message; $elasticError)")
-    DisplayError(Error(variant = "http-400", description = Some(message)))
+    DisplayError(Error(ErrorVariant.http400, description = Some(message)))
   }
 
   private def notFound(message: String,
                        elasticError: ElasticError): DisplayError = {
     warn(
       s"Sending HTTP 404 from ${this.getClass.getSimpleName} ($message; $elasticError)")
-    DisplayError(Error(variant = "http-404", description = Some(message)))
+    DisplayError(Error(ErrorVariant.http404, description = Some(message)))
   }
 
   private def serverError(message: String,
                           elasticError: ElasticError): DisplayError = {
     error(
       s"Sending HTTP 500 from ${this.getClass.getSimpleName} ($message; $elasticError)")
-    DisplayError(Error(variant = "http-500", description = None))
+    DisplayError(Error(ErrorVariant.http500, description = None))
   }
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/CaseClassMappingExceptionWrapper.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/CaseClassMappingExceptionWrapper.scala
@@ -8,7 +8,7 @@ import com.twitter.finatra.json.internal.caseclass.exceptions.CaseClassMappingEx
 import com.twitter.inject.Logging
 
 import uk.ac.wellcome.platform.api.ContextHelper.buildContextUri
-import uk.ac.wellcome.platform.api.models.{ApiConfig, DisplayError, Error}
+import uk.ac.wellcome.platform.api.models.{ApiConfig, DisplayError, Error, ErrorVariant}
 import uk.ac.wellcome.platform.api.responses.ResultResponse
 
 @Singleton
@@ -28,7 +28,7 @@ class CaseClassMappingExceptionWrapper @Inject()(response: ResponseBuilder,
       .mkString(", ")
     error(s"Sending HTTP 400 for $errorString")
     val result = DisplayError(
-      Error(variant = "http-400", description = Some(errorString)))
+      Error(variant = ErrorVariant.http400, description = Some(errorString)))
     val errorResponse = ResultResponse(
       context = buildContextUri(apiConfig = apiConfig, version = version),
       result = result

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/CaseClassMappingExceptionWrapper.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/CaseClassMappingExceptionWrapper.scala
@@ -8,7 +8,12 @@ import com.twitter.finatra.json.internal.caseclass.exceptions.CaseClassMappingEx
 import com.twitter.inject.Logging
 
 import uk.ac.wellcome.platform.api.ContextHelper.buildContextUri
-import uk.ac.wellcome.platform.api.models.{ApiConfig, DisplayError, Error, ErrorVariant}
+import uk.ac.wellcome.platform.api.models.{
+  ApiConfig,
+  DisplayError,
+  Error,
+  ErrorVariant
+}
 import uk.ac.wellcome.platform.api.responses.ResultResponse
 
 @Singleton

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/GeneralExceptionMapper.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/GeneralExceptionMapper.scala
@@ -6,7 +6,12 @@ import com.twitter.finatra.http.exceptions.ExceptionMapper
 import com.twitter.finatra.http.response.ResponseBuilder
 import com.twitter.inject.Logging
 import uk.ac.wellcome.platform.api.ContextHelper.buildContextUri
-import uk.ac.wellcome.platform.api.models.{ApiConfig, DisplayError, Error, ErrorVariant}
+import uk.ac.wellcome.platform.api.models.{
+  ApiConfig,
+  DisplayError,
+  Error,
+  ErrorVariant
+}
 import uk.ac.wellcome.platform.api.responses.ResultResponse
 
 @Singleton

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/GeneralExceptionMapper.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/exceptions/GeneralExceptionMapper.scala
@@ -6,7 +6,7 @@ import com.twitter.finatra.http.exceptions.ExceptionMapper
 import com.twitter.finatra.http.response.ResponseBuilder
 import com.twitter.inject.Logging
 import uk.ac.wellcome.platform.api.ContextHelper.buildContextUri
-import uk.ac.wellcome.platform.api.models.{ApiConfig, DisplayError, Error}
+import uk.ac.wellcome.platform.api.models.{ApiConfig, DisplayError, Error, ErrorVariant}
 import uk.ac.wellcome.platform.api.responses.ResultResponse
 
 @Singleton
@@ -25,7 +25,7 @@ class GeneralExceptionMapper @Inject()(response: ResponseBuilder,
       exception)
     val result = DisplayError(
       Error(
-        variant = "http-500",
+        variant = ErrorVariant.http500,
         description = None
       ))
     val errorResponse = ResultResponse(context = context, result = result)

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/Error.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/Error.scala
@@ -10,38 +10,39 @@ case class Error(
 }
 
 case object Error {
-  def apply(variant: String, description: Option[String]): Error = {
-    variant match {
-      case "http-400" =>
-        Error(
-          errorType = "http",
-          httpStatus = Some(400),
-          label = "Bad Request",
-          description = description
-        )
-      case "http-404" =>
-        Error(
-          errorType = "http",
-          httpStatus = Some(404),
-          label = "Not Found",
-          description = description
-        )
-      case "http-410" =>
-        Error(
-          errorType = "http",
-          httpStatus = Some(410),
-          label = "Gone",
-          description = description
-        )
-      case "http-500" =>
-        Error(
-          errorType = "http",
-          httpStatus = Some(500),
-          label = "Internal Server Error",
-          description = description
-        )
-      case unknownVariant =>
-        throw new Exception(s"$unknownVariant is not a valid error variant")
-    }
+  def apply(variant: ErrorVariant, description: Option[String]): Error =
+    Error(
+      errorType = "http",
+      httpStatus = Some(variant.status),
+      label = variant.label,
+      description = description
+    )
+}
+
+sealed trait ErrorVariant {
+  val status: Int
+  val label: String
+}
+
+object ErrorVariant {
+
+  val http400 = new ErrorVariant {
+    val status = 400
+    val label = "Bad Request"
+  }
+
+  val http404 = new ErrorVariant {
+    val status = 404
+    val label = "Not Found"
+  }
+
+  val http410 = new ErrorVariant {
+    val status = 410
+    val label = "Gone"
+  }
+
+  val http500 = new ErrorVariant {
+    val status = 500
+    val label = "Internal Server Error"
   }
 }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/models/ErrorTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/models/ErrorTest.scala
@@ -6,7 +6,7 @@ class ErrorTest extends FunSpec with Matchers {
   it("creates an HTTP 404 error response") {
     val description = "Work not found for identifier 1234"
     val error: Error =
-      Error(variant = "http-404", description = Some(description))
+      Error(variant = ErrorVariant.http404, description = Some(description))
 
     error.errorType shouldBe "http"
     error.httpStatus.get shouldBe 404


### PR DESCRIPTION
Make the `variant` argument for `Error` statically typed instead of stringly typed.

Came across this when working on the akka-http stuff, but splitting things out to make things more manageable. 