### PR TITLE
Python script for diffing live APIs

### DIFF
--- a/api/live_testing/.gitignore
+++ b/api/live_testing/.gitignore
@@ -1,0 +1,1 @@
+custom.json

--- a/api/live_testing/main.py
+++ b/api/live_testing/main.py
@@ -18,22 +18,27 @@ routes = [
     ("a22au6yn", {"include": "items,genres,identifiers"}),
 ]
 
+
 class ApiDiffer:
 
-    prod = 'api.wellcomecollection.org'
-    stage = 'api-stage.wellcomecollection.org'
+    prod = "api.wellcomecollection.org"
+    stage = "api-stage.wellcomecollection.org"
 
-    def  __init__(self, work_id=None, params=None, show_colour=True):
-        suffix = f'/{work_id}' if work_id else ''
-        self.path = f'/catalogue/v2/works{suffix}'
+    def __init__(self, work_id=None, params=None, show_colour=True):
+        suffix = f"/{work_id}" if work_id else ""
+        self.path = f"/catalogue/v2/works{suffix}"
         self.params = params or {}
         self.show_colour = show_colour
 
     def display_diff(self):
-        click.echo(f"================================================================================")
+        click.echo(
+            f"================================================================================"
+        )
         click.echo(f"Performing diff on {self.path} with params:")
         click.echo(self.params)
-        click.echo(f"================================================================================")
+        click.echo(
+            f"================================================================================"
+        )
         click.echo()
         click.echo("* Calling prod API")
         (prod_status, prod_json) = self.call_api(self.prod)
@@ -49,25 +54,25 @@ class ApiDiffer:
                 "stage:",
                 f"{json.dumps(stage_json, indent=2)}",
             ]
-            msg = '\n'.join(lines)
+            msg = "\n".join(lines)
             if self.show_colour:
-                msg = click.style(msg, fg='red')
+                msg = click.style(msg, fg="red")
             click.echo(msg)
         else:
             click.echo(f"* Recived {prod_status} status from both APIs")
             click.echo("* Generating diff")
             click.echo()
-            differ = ObjDiffer(prod_json, stage_json, 'prod', 'stage', self.show_colour)
+            differ = ObjDiffer(prod_json, stage_json, "prod", "stage", self.show_colour)
             differ.display_diff()
         click.echo()
 
     def call_api(self, api_base):
-        url = f'https://{api_base}{self.path}'
+        url = f"https://{api_base}{self.path}"
         response = requests.get(url, params=self.params)
         return (response.status_code, response.json())
 
-class ObjDiffer:
 
+class ObjDiffer:
     def __init__(self, obj_a, obj_b, name_a, name_b, show_colour=True):
         self.obj_a = dict(self.flatten(obj_a))
         self.obj_b = dict(self.flatten(obj_b))
@@ -88,18 +93,18 @@ class ObjDiffer:
             if obj is None:
                 return "null"
             return str(obj)
+
         if a == b:
-            msg = f'unchanged between {self.name_a} and {self.name_b}'
-            col = 'green'
+            msg = f"unchanged between {self.name_a} and {self.name_b}"
+            col = "green"
         else:
-            msg = f'changed from {self.name_b}={fmt(a)} to {self.name_b}={fmt(b)}'
-            col = 'red'
+            msg = f"changed from {self.name_b}={fmt(a)} to {self.name_b}={fmt(b)}"
+            col = "red"
         if self.show_colour:
             msg = click.style(msg, fg=col)
-        click.echo(f'{key}: {msg}')
+        click.echo(f"{key}: {msg}")
 
     def flatten(self, obj):
-
         def flatten_tupled(obj):
             nested = [join_subitems(key, self.flatten(value)) for key, value in obj]
             flattened = sum(nested, [])
@@ -114,17 +119,19 @@ class ObjDiffer:
             return flatten_tupled(obj.items())
         return [(Key(), obj)]
 
-class Key:
 
+class Key:
     def __init__(self, parts=None):
         self.parts = parts or ()
 
     def prepend(self, prefix):
-        prefix = prefix.parts if isinstance(prefix, Key) else (prefix, )
+        prefix = prefix.parts if isinstance(prefix, Key) else (prefix,)
         return Key(prefix + self.parts)
 
     def __str__(self):
-        return ".".join(f"[{part}]" if isinstance(part, int) else part for part in self.parts)
+        return ".".join(
+            f"[{part}]" if isinstance(part, int) else part for part in self.parts
+        )
 
     def __repr__(self):
         return str(self)
@@ -138,11 +145,13 @@ class Key:
     def __eq__(self, other):
         return self.parts == other.parts
 
+
 @click.command()
 def main():
     for work_id, params in routes:
         differ = ApiDiffer(work_id, params)
         differ.display_diff()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/api/live_testing/main.py
+++ b/api/live_testing/main.py
@@ -4,20 +4,6 @@ import requests
 import click
 import json
 
-routes = [
-    (None, {"include": "notes"}),
-    (None, {"page": 4, "pageSize": 5}),
-    (None, {"query": "botany"}),
-    (None, {"dateFrom": "1890-12-03", "dateTo": "1896-03-03"}),
-    (None, {"sort": "production.dates", "sortOrder": "desc"}),
-    (None, {"sort": "INVALID"}),
-    (None, {"aggregations": "workType,genres"}),
-    (None, {"language": "ger"}),
-    (None, {"workType": "b"}),
-    ("a224tb56", {"include": "notes"}),
-    ("a22au6yn", {"include": "items,genres,identifiers"}),
-]
-
 
 class ApiDiffer:
 
@@ -98,7 +84,7 @@ class ObjDiffer:
             msg = f"unchanged between {self.name_a} and {self.name_b}"
             col = "green"
         else:
-            msg = f"changed from {self.name_b}={fmt(a)} to {self.name_b}={fmt(b)}"
+            msg = f"changed from {fmt(a)} on {self.name_a} to {fmt(b)} on {self.name_b}"
             col = "red"
         if self.show_colour:
             msg = click.style(msg, fg=col)
@@ -146,11 +132,20 @@ class Key:
         return self.parts == other.parts
 
 
+def load_routes(filename):
+    with open(filename) as f:
+        return [(route.get("workId"), route.get("params")) for route in json.load(f)]
+
+
 @click.command()
-def main():
-    for work_id, params in routes:
-        differ = ApiDiffer(work_id, params)
-        differ.display_diff()
+@click.option("--colour/--no-colour", default=True)
+@click.option("--routes-file", default="routes.json")
+@click.option("--repeats", default=1)
+def main(colour, routes_file, repeats):
+    for work_id, params in load_routes(routes_file):
+        for _ in range(repeats):
+            differ = ApiDiffer(work_id, params, show_colour=colour)
+            differ.display_diff()
 
 
 if __name__ == "__main__":

--- a/api/live_testing/main.py
+++ b/api/live_testing/main.py
@@ -1,0 +1,148 @@
+#!/bin/env python3
+
+import requests
+import click
+import json
+
+routes = [
+    (None, {"include": "notes"}),
+    (None, {"page": 4, "pageSize": 5}),
+    (None, {"query": "botany"}),
+    (None, {"dateFrom": "1890-12-03", "dateTo": "1896-03-03"}),
+    (None, {"sort": "production.dates", "sortOrder": "desc"}),
+    (None, {"sort": "INVALID"}),
+    (None, {"aggregations": "workType,genres"}),
+    (None, {"language": "ger"}),
+    (None, {"workType": "b"}),
+    ("a224tb56", {"include": "notes"}),
+    ("a22au6yn", {"include": "items,genres,identifiers"}),
+]
+
+class ApiDiffer:
+
+    prod = 'api.wellcomecollection.org'
+    stage = 'api-stage.wellcomecollection.org'
+
+    def  __init__(self, work_id=None, params=None, show_colour=True):
+        suffix = f'/{work_id}' if work_id else ''
+        self.path = f'/catalogue/v2/works{suffix}'
+        self.params = params or {}
+        self.show_colour = show_colour
+
+    def display_diff(self):
+        click.echo(f"================================================================================")
+        click.echo(f"Performing diff on {self.path} with params:")
+        click.echo(self.params)
+        click.echo(f"================================================================================")
+        click.echo()
+        click.echo("* Calling prod API")
+        (prod_status, prod_json) = self.call_api(self.prod)
+        click.echo("* Calling stage API")
+        (stage_status, stage_json) = self.call_api(self.stage)
+        if prod_status != stage_status:
+            lines = [
+                f"* Received {prod_status} on prod and {stage_status} on stage",
+                "",
+                "prod:",
+                f"{json.dumps(prod_json, indent=2)}",
+                "",
+                "stage:",
+                f"{json.dumps(stage_json, indent=2)}",
+            ]
+            msg = '\n'.join(lines)
+            if self.show_colour:
+                msg = click.style(msg, fg='red')
+            click.echo(msg)
+        else:
+            click.echo(f"* Recived {prod_status} status from both APIs")
+            click.echo("* Generating diff")
+            click.echo()
+            differ = ObjDiffer(prod_json, stage_json, 'prod', 'stage', self.show_colour)
+            differ.display_diff()
+        click.echo()
+
+    def call_api(self, api_base):
+        url = f'https://{api_base}{self.path}'
+        response = requests.get(url, params=self.params)
+        return (response.status_code, response.json())
+
+class ObjDiffer:
+
+    def __init__(self, obj_a, obj_b, name_a, name_b, show_colour=True):
+        self.obj_a = dict(self.flatten(obj_a))
+        self.obj_b = dict(self.flatten(obj_b))
+        self.name_a = name_a
+        self.name_b = name_b
+        self.show_colour = show_colour
+
+    def display_diff(self):
+        combined_keys = sorted(set(self.obj_a.keys()) | set(self.obj_b.keys()))
+        for key in combined_keys:
+            a, b = self.obj_a.get(key), self.obj_b.get(key)
+            self.display_diff_line(key, a, b)
+
+    def display_diff_line(self, key, a, b):
+        def fmt(obj):
+            if isinstance(obj, str):
+                return f'"{obj}"'
+            if obj is None:
+                return "null"
+            return str(obj)
+        if a == b:
+            msg = f'unchanged between {self.name_a} and {self.name_b}'
+            col = 'green'
+        else:
+            msg = f'changed from {self.name_b}={fmt(a)} to {self.name_b}={fmt(b)}'
+            col = 'red'
+        if self.show_colour:
+            msg = click.style(msg, fg=col)
+        click.echo(f'{key}: {msg}')
+
+    def flatten(self, obj):
+
+        def flatten_tupled(obj):
+            nested = [join_subitems(key, self.flatten(value)) for key, value in obj]
+            flattened = sum(nested, [])
+            return sorted(flattened)
+
+        def join_subitems(key, subitems):
+            return [(subkey.prepend(key), value) for (subkey, value) in subitems]
+
+        if isinstance(obj, list):
+            return flatten_tupled(enumerate(obj))
+        if isinstance(obj, dict):
+            return flatten_tupled(obj.items())
+        return [(Key(), obj)]
+
+class Key:
+
+    def __init__(self, parts=None):
+        self.parts = parts or ()
+
+    def prepend(self, prefix):
+        prefix = prefix.parts if isinstance(prefix, Key) else (prefix, )
+        return Key(prefix + self.parts)
+
+    def __str__(self):
+        return ".".join(f"[{part}]" if isinstance(part, int) else part for part in self.parts)
+
+    def __repr__(self):
+        return str(self)
+
+    def __lt__(self, other):
+        return self.parts < other.parts
+
+    def __hash__(self):
+        return hash(self.parts)
+
+    def __eq__(self, other):
+        return self.parts == other.parts
+
+@click.command()
+def main():
+    for work_id, params in routes:
+        differ = ApiDiffer(work_id, params)
+        differ.display_diff()
+
+if __name__ == '__main__':
+    main()

--- a/api/live_testing/requirements.txt
+++ b/api/live_testing/requirements.txt
@@ -1,0 +1,2 @@
+requests==2.22.0
+click==7.0

--- a/api/live_testing/routes.json
+++ b/api/live_testing/routes.json
@@ -1,0 +1,62 @@
+[
+  {
+    "params": {
+      "include": "notes"
+    }
+  },
+  {
+    "params": {
+      "page": 4,
+      "pageSize": 5
+    }
+  },
+  {
+    "params": {
+      "query": "botany"
+    }
+  },
+  {
+    "params": {
+      "dateFrom": "1890-12-03",
+      "dateTo": "1896-03-03"
+    }
+  },
+  {
+    "params": {
+      "sort": "production.dates",
+      "sortOrder": "desc"
+    }
+  },
+  {
+    "params": {
+      "sort": "INVALID"
+    }
+  },
+  {
+    "params": {
+      "aggregations": "workType,genres"
+    }
+  },
+  {
+    "params": {
+      "language": "ger"
+    }
+  },
+  {
+    "params": {
+      "workType": "b"
+    }
+  },
+  {
+    "workId": "a224tb56",
+    "params": {
+      "include": "notes"
+    }
+  },
+  {
+    "workId": "a22au6yn",
+    "params": {
+      "include": "items,genres,identifiers"
+    }
+  }
+]


### PR DESCRIPTION
### Issue

https://github.com/wellcometrust/platform/issues/3968

### Description

Contains a python script which allows us to test how the responses from `prod` and `stage` APIs differ, which should help us switch more across confidently.

![2019-10-29-172729_1164x1398_scrot](https://user-images.githubusercontent.com/921101/67793388-9f756f00-fa72-11e9-8c16-2bf8faabb6b2.png)


Note: It only really makes sense to run this when both are pointing at the same index.