### PR TITLE
add vhs_miro_inventory_read_policy to terraform outputs

### DIFF
--- a/infrastructure/critical/outputs.tf
+++ b/infrastructure/critical/outputs.tf
@@ -19,6 +19,9 @@ output "vhs_miro_assumable_read_role" {
 }
 
 # Miro Inventory Hybrid Store
+output "vhs_miro_inventory_read_policy" {
+  value = "${module.vhs_miro_inventory.read_policy}"
+}
 
 output "vhs_miro_inventory_table_name" {
   value = "${module.vhs_miro_migration.table_name}"

--- a/infrastructure/critical/outputs.tf
+++ b/infrastructure/critical/outputs.tf
@@ -20,7 +20,7 @@ output "vhs_miro_assumable_read_role" {
 
 # Miro Inventory Hybrid Store
 output "vhs_miro_inventory_read_policy" {
-  value = "${module.vhs_miro_inventory.read_policy}"
+  value = "${module.vhs_miro_migration.read_policy}"
 }
 
 output "vhs_miro_inventory_table_name" {


### PR DESCRIPTION
reporting tf (`lambda_miro_inventory_transformer`) needs access to the `vhs_miro_inventory_read_policy` from the catalogue's `infra_critical` outputs