### PR TITLE
Fix API page links

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/Router.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/Router.scala
@@ -94,7 +94,7 @@ class Router(elasticClient: ElasticClient,
                 resultList,
                 searchOptions,
                 params.include.getOrElse(V2WorksIncludes()),
-                uri,
+                uri.withHost(apiConfig.host),
                 contextUri
               )
             )


### PR DESCRIPTION
Currently displaying host as `localhost:8888`, so change this to `apiConfig.host`.

There is already a test for this [here](https://github.com/wellcometrust/catalogue/blob/master/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala#L82-L109), but it doesn't catch the issue when the `apiConfig.host` is set to `localhost` anyway.