### PR TITLE
Binding information note

### DIFF
--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayNote.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayNote.scala
@@ -64,5 +64,7 @@ object DisplayNoteType {
         DisplayNoteType(
           "location-of-original-note",
           "Location of original note")
+      case BindingInformation(_) =>
+        DisplayNoteType("binding-information", "Binding information")
     }
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Note.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Note.scala
@@ -21,3 +21,5 @@ case class DissertationNote(val content: String) extends Note
 case class CiteAsNote(val content: String) extends Note
 
 case class LocationOfOriginalNote(val content: String) extends Note
+
+case class BindingInformation(val content: String) extends Note

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotes.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotes.scala
@@ -26,7 +26,8 @@ object SierraNotes extends SierraTransformer with SierraQueryOps {
       "536" -> FundingInformation.apply,
       "545" -> BibliographicalInformation.apply,
       "547" -> GeneralNote.apply,
-      "562" -> GeneralNote.apply
+      "562" -> GeneralNote.apply,
+      "563" -> BindingInformation.apply
     )
 
   def apply(bibId: SierraBibNumber, bibData: SierraBibData) =

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotes.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotes.scala
@@ -36,7 +36,7 @@ object SierraNotes extends SierraTransformer with SierraQueryOps {
         case (tag, createNote) =>
           bibData
             .varfieldsWithTags(tag)
-            .subfieldContents
+            .map(_.subfieldContents.mkString(" "))
             .map(createNote)
       }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPhysicalDescription.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPhysicalDescription.scala
@@ -8,7 +8,8 @@ import uk.ac.wellcome.models.transformable.sierra.SierraBibNumber
 
 // Populate wwork:physicalDescription.
 //
-// We use MARC field 300 and subfield $b.
+// We use MARC field 300 and subfields $a, $b and $c.
+//
 //
 // Notes:
 //
@@ -35,7 +36,6 @@ object SierraPhysicalDescription extends SierraTransformer with SierraQueryOps {
         "300" -> "a",
         "300" -> "b",
         "300" -> "c",
-        "563" -> "a"
       )
       .contentString("\n")
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotesTest.scala
@@ -33,6 +33,7 @@ class SierraNotesTest
       "545" -> BibliographicalInformation("bib info b"),
       "547" -> GeneralNote("general note c"),
       "562" -> GeneralNote("general note d"),
+      "563" -> BindingInformation("binding info note"),
     )
     SierraNotes(bibId, bibData(notes)) shouldBe notes.map(_._2)
   }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotesTest.scala
@@ -59,6 +59,32 @@ class SierraNotesTest
     SierraNotes(bibId, bibData(notes)) shouldBe notes.map(_._2)
   }
 
+  it("should concatenate subfields into a single note") {
+    val bibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "500",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "1st part."),
+            MarcSubfield(tag = "b", content = "2nd part."),
+            MarcSubfield(tag = "c", content = "3rd part."),
+          )
+        )
+      )
+    )
+    SierraNotes(bibId, bibData) shouldBe List(
+      GeneralNote("1st part. 2nd part. 3rd part.")
+    )
+  }
+
+  it("should not concatenate seperate varfields") {
+    val notes = List(
+      "500" -> GeneralNote("1st note."),
+      "500" -> GeneralNote("2nd note."),
+    )
+    SierraNotes(bibId, bibData(notes)) shouldBe notes.map(_._2)
+  }
+
   def bibId = createSierraBibNumber
 
   def bibData(contents: List[(String, Note)]): SierraBibData =

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPhysicalDescriptionTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPhysicalDescriptionTest.scala
@@ -17,9 +17,9 @@ class SierraPhysicalDescriptionTest
     with MarcGenerators
     with SierraDataGenerators {
 
-  it("gets no physical description if there is no MARC field 300 / 563") {
+  it("gets no physical description if there is no MARC field 300") {
     val field = varField(
-      "500",
+      "563",
       MarcSubfield("b", "The edifying extent of early emus")
     )
     SierraPhysicalDescription(bibId, bibData(field)) shouldBe None
@@ -47,27 +47,6 @@ class SierraPhysicalDescriptionTest
         MarcSubfield("b", descriptionB),
         MarcSubfield("d", "Egad!  An early eagle is eating the earwig."),
       ),
-    )
-    SierraPhysicalDescription(bibId, data) shouldBe Some(expectedDescription)
-  }
-
-  it(f"extracts physical description from MARC field 563 subfield $$a") {
-    val description = "Queuing quokkas quarrel about Quirinus Quirrell"
-    val field = varField(
-      "563",
-      MarcSubfield("b", "The edifying extent of early emus"),
-      MarcSubfield("a", description)
-    )
-    SierraPhysicalDescription(bibId, bibData(field)) shouldBe Some(description)
-  }
-
-  it("extracts a physical description where there both MARC field 300 and 563") {
-    val descriptionA = "The queer quolls quits and quarrels"
-    val descriptionB = "A quintessential quadraped is quick"
-    val expectedDescription = s"$descriptionA\n$descriptionB"
-    val data = bibData(
-      varField("563", MarcSubfield("a", descriptionB)),
-      varField("300", MarcSubfield("b", descriptionA)),
     )
     SierraPhysicalDescription(bibId, data) shouldBe Some(expectedDescription)
   }


### PR DESCRIPTION
## Issue

https://github.com/wellcometrust/platform/issues/3995

## Description

Instead of appending Marc 563 to `physicalDescription` field, instead pull it out into a `binding-information` note, as we do with other 5XX fields.