### PR TITLE
Aggregate date buckets dynamically

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/Aggregation.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/Aggregation.scala
@@ -28,7 +28,8 @@ object Aggregations extends Logging {
               workType = getAggregation[WorkType](esAggs.workType),
               genres = getAggregation[Genre[Displayable[AbstractConcept]]](
                 esAggs.genres),
-              productionDates = getAggregation[Period](esAggs.productionDates),
+              productionDates = getAggregation[Period](esAggs.productionDates)
+                .map(DateAggregationMerger(_)),
               language = getAggregation[Language](esAggs.language),
               subjects =
                 getAggregation[Subject[Displayable[AbstractRootConcept]]](

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DateAggregationMerger.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DateAggregationMerger.scala
@@ -1,0 +1,73 @@
+package uk.ac.wellcome.platform.api.models
+
+import java.time.{LocalDateTime, ZoneOffset}
+
+import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.models.parse.DateHelpers
+
+sealed trait PeriodRange
+
+object PeriodRange {
+  object Decade extends PeriodRange
+  object HalfCentury extends PeriodRange
+  object Century extends PeriodRange
+}
+
+object DateAggregationMerger extends DateHelpers {
+
+  import PeriodRange._
+
+  /** Dynamically merges a set of date aggregation results based on the range
+   *  of dates covered. Merging happens recursively until the number of buckets
+   *  is no greater than maxBuckets, or we reach the broadest aggregation
+   *  granularity (i.e. centuries)
+   */
+  def apply(agg: Aggregation[Period],
+            maxBuckets: Int = 20,
+            range: PeriodRange = Decade): Aggregation[Period] =
+    if (agg.buckets.length > maxBuckets)
+      range match {
+        case Decade =>
+          DateAggregationMerger(
+            Aggregation(mergeBuckets(agg.buckets, 10)),
+            maxBuckets,
+            HalfCentury)
+        case HalfCentury =>
+          DateAggregationMerger(
+            Aggregation(mergeBuckets(agg.buckets, 50)),
+            maxBuckets,
+            Century)
+        case Century =>
+          Aggregation(mergeBuckets(agg.buckets, 100))
+      }
+    else agg
+
+  private def mergeBuckets(
+    buckets: List[AggregationBucket[Period]],
+    yearRange: Int): List[AggregationBucket[Period]] =
+    buckets
+      .foldLeft(Map.empty[Int, Int]) { case (map, bucket) =>
+        yearFromPeriod(bucket.data) match {
+          case Some(year) =>
+            val key = year / yearRange
+            map.updated(key, map.getOrElse(key, 0) + bucket.count)
+          case None => map
+        }
+      }
+      .toList
+      .sortBy(_._1)
+      .map { case (key, count) =>
+        val startYear = key * yearRange
+        val endYear = startYear + yearRange - 1
+        val label = s"$startYear-$endYear"
+        val range = InstantRange(yearStart(startYear), yearEnd(endYear), label)
+        AggregationBucket(Period(label, Some(range)), count)
+      }
+
+  private def yearFromPeriod(period: Period): Option[Int] =
+    period.range.map { range =>
+      LocalDateTime
+        .ofInstant(range.from, ZoneOffset.UTC)
+        .getYear
+    }
+}

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DateAggregationMerger.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DateAggregationMerger.scala
@@ -5,17 +5,17 @@ import java.time.{LocalDateTime, ZoneOffset}
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.parse.DateHelpers
 
-sealed trait PeriodRange
+sealed trait DateBucketRange
 
-object PeriodRange {
-  object Decade extends PeriodRange
-  object HalfCentury extends PeriodRange
-  object Century extends PeriodRange
+object DateBucketRange {
+  object Decade extends DateBucketRange
+  object HalfCentury extends DateBucketRange
+  object Century extends DateBucketRange
 }
 
 object DateAggregationMerger extends DateHelpers {
 
-  import PeriodRange._
+  import DateBucketRange._
 
   /** Dynamically merges a set of date aggregation results based on the range
     *  of dates covered. Merging happens recursively until the number of buckets
@@ -24,7 +24,7 @@ object DateAggregationMerger extends DateHelpers {
     */
   def apply(agg: Aggregation[Period],
             maxBuckets: Int = 20,
-            range: PeriodRange = Decade): Aggregation[Period] =
+            range: DateBucketRange = Decade): Aggregation[Period] =
     if (agg.buckets.length > maxBuckets)
       range match {
         case Decade =>

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/models/DateAggregationMergerTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/models/DateAggregationMergerTest.scala
@@ -17,7 +17,7 @@ class DateAggregationMergerTest extends FunSpec with Matchers {
         AggregationBucket(Period("1983"), 2),
       )
     )
-    DateAggregationMerger(aggregation, maxBuckets=5) shouldBe Aggregation(
+    DateAggregationMerger(aggregation, maxBuckets = 5) shouldBe Aggregation(
       List(
         AggregationBucket(Period("1950-1959"), 3),
         AggregationBucket(Period("1960-1969"), 6),
@@ -39,7 +39,7 @@ class DateAggregationMergerTest extends FunSpec with Matchers {
         AggregationBucket(Period("1983"), 2),
       )
     )
-    DateAggregationMerger(aggregation, maxBuckets=5) shouldBe Aggregation(
+    DateAggregationMerger(aggregation, maxBuckets = 5) shouldBe Aggregation(
       List(
         AggregationBucket(Period("1850-1899"), 2),
         AggregationBucket(Period("1900-1949"), 2),
@@ -47,7 +47,7 @@ class DateAggregationMergerTest extends FunSpec with Matchers {
       )
     )
   }
- 
+
   it("aggregates by century when too many buckets") {
     val aggregation = Aggregation(
       List(
@@ -61,7 +61,7 @@ class DateAggregationMergerTest extends FunSpec with Matchers {
         AggregationBucket(Period("2012"), 3),
       )
     )
-    DateAggregationMerger(aggregation, maxBuckets=5) shouldBe Aggregation(
+    DateAggregationMerger(aggregation, maxBuckets = 5) shouldBe Aggregation(
       List(
         AggregationBucket(Period("1400-1499"), 1),
         AggregationBucket(Period("1600-1699"), 1),

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/models/DateAggregationMergerTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/models/DateAggregationMergerTest.scala
@@ -1,0 +1,75 @@
+package uk.ac.wellcome.platform.api.models
+
+import org.scalatest.{FunSpec, Matchers}
+
+import uk.ac.wellcome.models.work.internal.Period
+
+class DateAggregationMergerTest extends FunSpec with Matchers {
+
+  it("aggregates by decade when too many buckets") {
+    val aggregation = Aggregation(
+      List(
+        AggregationBucket(Period("1954"), 2),
+        AggregationBucket(Period("1958"), 1),
+        AggregationBucket(Period("1960"), 1),
+        AggregationBucket(Period("1969"), 5),
+        AggregationBucket(Period("1982"), 4),
+        AggregationBucket(Period("1983"), 2),
+      )
+    )
+    DateAggregationMerger(aggregation, maxBuckets=5) shouldBe Aggregation(
+      List(
+        AggregationBucket(Period("1950-1959"), 3),
+        AggregationBucket(Period("1960-1969"), 6),
+        AggregationBucket(Period("1980-1989"), 6),
+      )
+    )
+  }
+
+  it("aggregates by half century when too many buckets") {
+    val aggregation = Aggregation(
+      List(
+        AggregationBucket(Period("1898"), 2),
+        AggregationBucket(Period("1900"), 1),
+        AggregationBucket(Period("1940"), 1),
+        AggregationBucket(Period("1958"), 5),
+        AggregationBucket(Period("1960"), 1),
+        AggregationBucket(Period("1969"), 5),
+        AggregationBucket(Period("1982"), 4),
+        AggregationBucket(Period("1983"), 2),
+      )
+    )
+    DateAggregationMerger(aggregation, maxBuckets=5) shouldBe Aggregation(
+      List(
+        AggregationBucket(Period("1850-1899"), 2),
+        AggregationBucket(Period("1900-1949"), 2),
+        AggregationBucket(Period("1950-1999"), 17),
+      )
+    )
+  }
+ 
+  it("aggregates by century when too many buckets") {
+    val aggregation = Aggregation(
+      List(
+        AggregationBucket(Period("1409"), 1),
+        AggregationBucket(Period("1608"), 1),
+        AggregationBucket(Period("1740"), 1),
+        AggregationBucket(Period("1798"), 4),
+        AggregationBucket(Period("1800"), 4),
+        AggregationBucket(Period("1824"), 4),
+        AggregationBucket(Period("1934"), 1),
+        AggregationBucket(Period("2012"), 3),
+      )
+    )
+    DateAggregationMerger(aggregation, maxBuckets=5) shouldBe Aggregation(
+      List(
+        AggregationBucket(Period("1400-1499"), 1),
+        AggregationBucket(Period("1600-1699"), 1),
+        AggregationBucket(Period("1700-1799"), 5),
+        AggregationBucket(Period("1800-1899"), 8),
+        AggregationBucket(Period("1900-1999"), 1),
+        AggregationBucket(Period("2000-2099"), 3),
+      )
+    )
+  }
+}


### PR DESCRIPTION
## Issue

https://github.com/wellcometrust/platform/issues/3977

## Description

Instead of returning an unbounded number of aggregation buckets when aggregating by date, here we dynamically group into progressively less granular buckets:

* Year
* Decade
* Half century
* Century

Note we have to do this in scala land rather than elasticsearch, as the broadest date aggregation it supports is year.