### PR TITLE
Correct the env_vars_length variable in the Terraform

### DIFF
--- a/api/terraform/catalogue_api/services/service/main.tf
+++ b/api/terraform/catalogue_api/services/service/main.tf
@@ -48,7 +48,7 @@ module "task" {
     es_index_v2 = "${var.es_config["index_v2"]}"
   }
 
-  app_env_vars_length = 3
+  app_env_vars_length = 2
 
   sidecar_env_vars = {
     APP_HOST = "localhost"

--- a/api/terraform/data_api/main.tf
+++ b/api/terraform/data_api/main.tf
@@ -19,7 +19,7 @@ module "snapshot_generator" {
     metric_namespace = "snapshot_generator"
   }
 
-  env_vars_length = "5"
+  env_vars_length = 4
 
   secret_env_vars = {
     es_host     = "catalogue/api/es_host"
@@ -29,7 +29,7 @@ module "snapshot_generator" {
     es_password = "catalogue/api/es_password"
   }
 
-  secret_env_vars_length = "5"
+  secret_env_vars_length = 5
 
   service_egress_security_group_id = "${aws_security_group.service_egress_security_group.id}"
 


### PR DESCRIPTION
If env_vars_length is longer than env_vars, it will cause Terraform to forever re-plan these resources, causing unnecessary deployment churn.

That we need these two variables is a bit annoying; an artefact of Terraform limitations. I'm hoping we can ditch it when we upgrade to newer versions of Terraform.
