### PR TITLE
Swagger fixes

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayAggregations.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayAggregations.scala
@@ -16,8 +16,8 @@ import uk.ac.wellcome.display.models.Implicits._
 import uk.ac.wellcome.display.json.DisplayJsonUtil._
 
 @Schema(
-  name = "AggregationMap",
-  description = "A map of the different aggregations on the ResultList."
+  name = "Aggregations",
+  description = "A map containing the requested aggregations."
 )
 case class DisplayAggregations(
   @Schema(
@@ -39,12 +39,20 @@ case class DisplayAggregations(
   @JsonKey("type") ontologyType: String = "Aggregations"
 )
 
+@Schema(
+  name = "Aggregation",
+  description = "An aggregation over the results."
+)
 case class DisplayAggregation[T](
   @Schema(description = "An aggregation on a set of results") buckets: List[
     DisplayAggregationBucket[T]],
   @JsonKey("type") ontologyType: String = "Aggregation"
 )
 
+@Schema(
+  name = "AggregationBucket",
+  description = "An individual bucket within an aggregation."
+)
 case class DisplayAggregationBucket[T](
   @Schema(
     description = "The data that this aggregation is of."

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
@@ -69,7 +69,13 @@ trait SingleWorkSwagger {
         name = "include",
         in = ParameterIn.QUERY,
         description = "A comma-separated list of extra fields to include",
-        schema = new Schema(implementation = classOf[V2WorksIncludes]),
+        schema = new Schema(allowableValues = Array("identifiers",
+                                                    "items",
+                                                    "subjects",
+                                                    "genres",
+                                                    "contributors",
+                                                    "production",
+                                                    "notes")),
         required = false,
       ),
     )
@@ -125,7 +131,13 @@ trait MultipleWorksSwagger {
         name = "include",
         in = ParameterIn.QUERY,
         description = "A comma-separated list of extra fields to include",
-        schema = new Schema(implementation = classOf[V2WorksIncludes]),
+        schema = new Schema(allowableValues = Array("identifiers",
+                                                    "items",
+                                                    "subjects",
+                                                    "genres",
+                                                    "contributors",
+                                                    "production",
+                                                    "notes")),
         required = false,
       ),
       new Parameter(
@@ -146,6 +158,11 @@ trait MultipleWorksSwagger {
         in = ParameterIn.QUERY,
         description =
           "What aggregated data in correlation to the results should we return.",
+        schema = new Schema(allowableValues = Array("workType",
+                                                    "genres",
+                                                    "production.dates",
+                                                    "subjects",
+                                                    "language")),
         required = false
       ),
       new Parameter(

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
@@ -69,13 +69,15 @@ trait SingleWorkSwagger {
         name = "include",
         in = ParameterIn.QUERY,
         description = "A comma-separated list of extra fields to include",
-        schema = new Schema(allowableValues = Array("identifiers",
-                                                    "items",
-                                                    "subjects",
-                                                    "genres",
-                                                    "contributors",
-                                                    "production",
-                                                    "notes")),
+        schema = new Schema(
+          allowableValues = Array(
+            "identifiers",
+            "items",
+            "subjects",
+            "genres",
+            "contributors",
+            "production",
+            "notes")),
         required = false,
       ),
     )
@@ -131,13 +133,15 @@ trait MultipleWorksSwagger {
         name = "include",
         in = ParameterIn.QUERY,
         description = "A comma-separated list of extra fields to include",
-        schema = new Schema(allowableValues = Array("identifiers",
-                                                    "items",
-                                                    "subjects",
-                                                    "genres",
-                                                    "contributors",
-                                                    "production",
-                                                    "notes")),
+        schema = new Schema(
+          allowableValues = Array(
+            "identifiers",
+            "items",
+            "subjects",
+            "genres",
+            "contributors",
+            "production",
+            "notes")),
         required = false,
       ),
       new Parameter(
@@ -158,11 +162,13 @@ trait MultipleWorksSwagger {
         in = ParameterIn.QUERY,
         description =
           "What aggregated data in correlation to the results should we return.",
-        schema = new Schema(allowableValues = Array("workType",
-                                                    "genres",
-                                                    "production.dates",
-                                                    "subjects",
-                                                    "language")),
+        schema = new Schema(
+          allowableValues = Array(
+            "workType",
+            "genres",
+            "production.dates",
+            "subjects",
+            "language")),
         required = false
       ),
       new Parameter(

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayNote.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayNote.scala
@@ -15,6 +15,10 @@ case class DisplayNote(
   @JsonKey("type") ontologyType: String = "Note"
 )
 
+@Schema(
+  name = "NoteType",
+  description = "Indicates the type of note associated with the work."
+)
 case class DisplayNoteType(
   @Schema(
     `type` = "String"


### PR DESCRIPTION
## Issues

https://github.com/wellcometrust/platform/issues/3979
https://github.com/wellcometrust/platform/issues/3980
https://github.com/wellcometrust/platform/issues/3981
https://github.com/wellcometrust/platform/issues/3982
https://github.com/wellcometrust/platform/issues/3984
https://github.com/wellcometrust/platform/issues/3985
https://github.com/wellcometrust/platform/issues/3994

## Description

Fixes:

* Remove Display prefix from aggregation models in API docs 
* Aggregation comes out as AggregationMap in API docs
* Remove explicit aggregation subtypes from API docs
* Remove explicit aggregation bucket subtypes from API docs
* Add all valid aggregations to aggregations query parameter docs 
* Use Swagger allowed values for query parameter valid values in API docs, don't put in description
* Note type not documented in the API docs