### PR TITLE
Filter works just by from date

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkFilter.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkFilter.scala
@@ -6,15 +6,8 @@ sealed trait WorkFilter
 
 case class ItemLocationTypeFilter(locationTypeIds: Seq[String])
     extends WorkFilter
-object ItemLocationTypeFilter
-    extends ApplyCommaSeperated[ItemLocationTypeFilter] {
-  val fromSeq = ItemLocationTypeFilter(_)
-}
 
 case class WorkTypeFilter(workTypeIds: Seq[String]) extends WorkFilter
-object WorkTypeFilter extends ApplyCommaSeperated[WorkTypeFilter] {
-  val fromSeq = WorkTypeFilter(_)
-}
 
 case class DateRangeFilter(fromDate: Option[LocalDate],
                            toDate: Option[LocalDate])
@@ -23,18 +16,7 @@ case class DateRangeFilter(fromDate: Option[LocalDate],
 case object IdentifiedWorkFilter extends WorkFilter
 
 case class LanguageFilter(languageIds: Seq[String]) extends WorkFilter
-object LanguageFilter extends ApplyCommaSeperated[LanguageFilter] {
-  val fromSeq = LanguageFilter(_)
-}
 
 case class GenreFilter(genreQuery: String) extends WorkFilter
 
 case class SubjectFilter(subjectQuery: String) extends WorkFilter
-
-trait ApplyCommaSeperated[T] {
-
-  protected val fromSeq: Seq[String] => T
-
-  def apply(str: String): T =
-    fromSeq(str.split(',').map(_.trim))
-}

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElastsearchSearchRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElastsearchSearchRequestBuilder.scala
@@ -121,10 +121,7 @@ case class ElastsearchSearchRequestBuilder(
       case DateRangeFilter(fromDate, toDate) =>
         val (gte, lte) =
           (fromDate map ElasticDate.apply, toDate map ElasticDate.apply)
-        boolQuery should (
-          RangeQuery("production.dates.range.from", lte = lte, gte = gte),
-          RangeQuery("production.dates.range.to", lte = lte, gte = gte)
-        )
+        RangeQuery("production.dates.range.from", lte = lte, gte = gte)
       case LanguageFilter(languageIds) =>
         termsQuery(field = "language.id", values = languageIds)
       case GenreFilter(genreQuery) =>

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -23,12 +23,12 @@ import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.json.JsonUtil._
 
 case class WorksSearchOptions(
-  filters: List[WorkFilter],
-  pageSize: Int,
-  pageNumber: Int,
-  aggregations: List[AggregationRequest],
-  sortBy: List[SortRequest],
-  sortOrder: SortingOrder,
+  filters: List[WorkFilter] = Nil,
+  pageSize: Int = 10,
+  pageNumber: Int = 1,
+  aggregations: List[AggregationRequest] = Nil,
+  sortBy: List[SortRequest] = Nil,
+  sortOrder: SortingOrder = SortingOrder.Ascending,
 )
 
 class WorksService(searchService: ElasticsearchService)(

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -70,7 +70,7 @@ class ElasticsearchServiceTest
           index = index,
           workQuery = WorkQuery("artichokes", MSMBoostQuery),
           queryOptions = createElasticsearchQueryOptionsWith(
-            filters = List(WorkTypeFilter("b"))
+            filters = List(WorkTypeFilter(Seq("b")))
           ),
           expectedWorks = List(workWithCorrectWorkType)
         )
@@ -137,7 +137,7 @@ class ElasticsearchServiceTest
           index = index,
           workQuery = WorkQuery("tangerines", MSMBoostQuery),
           queryOptions = createElasticsearchQueryOptionsWith(
-            filters = List(ItemLocationTypeFilter("iiif-image"))
+            filters = List(ItemLocationTypeFilter(Seq("iiif-image")))
           ),
           expectedWorks = List(work)
         )
@@ -708,7 +708,7 @@ class ElasticsearchServiceTest
         insertIntoElasticsearch(index, work1, work2, workWithWrongWorkType)
 
         val queryOptions = createElasticsearchQueryOptionsWith(
-          filters = List(WorkTypeFilter("b"))
+          filters = List(WorkTypeFilter(Seq("b")))
         )
 
         assertListResultsAreCorrect(

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -92,7 +92,7 @@ class WorksServiceTest
         expectedWorks = Seq(work1, work2),
         expectedTotalResults = 2,
         worksSearchOptions = createWorksSearchOptionsWith(
-          filters = List(WorkTypeFilter("b"))
+          filters = List(WorkTypeFilter(Seq("b")))
         )
       )
     }
@@ -295,7 +295,7 @@ class WorksServiceTest
         expectedWorks = List(matchingWork),
         expectedTotalResults = 1,
         worksSearchOptions = createWorksSearchOptionsWith(
-          filters = List(WorkTypeFilter("b"))
+          filters = List(WorkTypeFilter(Seq("b")))
         )
       )
     }


### PR DESCRIPTION
## Issues

https://github.com/wellcometrust/platform/issues/4027

## Description

Update filtering so that just uses `from` date. This is to preserve consistency between filtering / sorting / aggregation.