### PR TITLE
Use {id} not :id in Swagger path parameters

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
@@ -49,13 +49,13 @@ class SwaggerDocs(apiConfig: ApiConfig) extends Logging {
     Json.pretty(new Reader(config).read(apiClasses.asJava))
 }
 
-@Path("/works/:id")
+@Path("/works/{id}")
 trait SingleWorkSwagger {
 
   @GET
   @Tag(name = "Works")
   @Operation(
-    summary = "/works/:id",
+    summary = "/works/{id}",
     description = "Returns a single work",
     tags = Array("Works"),
     parameters = Array(

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
@@ -41,7 +41,7 @@ class ApiSwaggerTest extends ApiV2WorksTestBase with Matchers {
   it("should contain single work endpoint in paths") {
     checkSwaggerJson { json =>
       val endpoint = getKey(json, "paths")
-        .flatMap(paths => getKey(paths, "/works/:id"))
+        .flatMap(paths => getKey(paths, "/works/{id}"))
         .flatMap(path => getKey(path, "get"))
       endpoint.isEmpty shouldBe false
       getKey(endpoint.get, "description").isEmpty shouldBe false


### PR DESCRIPTION
Path parameters should be curl brackets and not colons, see: https://swagger.io/docs/specification/paths-and-operations/

This change allow generated clients to function as expected.

For https://github.com/wellcomecollection/stacks-service