### PR TITLE
return empty notes if you've asked for them

### DIFF
--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2.scala
@@ -140,7 +140,7 @@ case object DisplayWorkV2 {
       language = work.language.map { DisplayLanguage(_) },
       edition = work.edition,
       notes =
-        if (includes.notes && work.notes.nonEmpty)
+        if (includes.notes)
           Some(DisplayNote.merge(work.notes.map(DisplayNote(_))))
         else None,
       duration = work.duration,


### PR DESCRIPTION
With lists we return empty if it is empty, otherwise clients permanently have to null check.