### PR TITLE
Matcher does not ignore invisible works

### DIFF
--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -11,7 +11,9 @@ sealed trait IdentifiedBaseWork extends BaseWork {
   val canonicalId: String
 }
 
-sealed trait TransformedBaseWork extends BaseWork
+sealed trait TransformedBaseWork extends BaseWork {
+  val data: WorkData[MaybeDisplayable]
+}
 
 sealed trait InvisibleWork extends BaseWork
 

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcher.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcher.scala
@@ -2,14 +2,23 @@ package uk.ac.wellcome.platform.matcher.matcher
 
 import cats.implicits._
 import grizzled.slf4j.Logging
-import uk.ac.wellcome.models.matcher.{MatchedIdentifiers, MatcherResult, WorkIdentifier, WorkNode}
+import uk.ac.wellcome.models.matcher.{
+  MatchedIdentifiers,
+  MatcherResult,
+  WorkIdentifier,
+  WorkNode
+}
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.platform.matcher.exceptions.MatcherException
 import uk.ac.wellcome.platform.matcher.models._
 import uk.ac.wellcome.platform.matcher.storage.WorkGraphStore
 import uk.ac.wellcome.platform.matcher.workgraph.WorkGraphUpdater
 import uk.ac.wellcome.storage.locking.dynamo.DynamoLockingService
-import uk.ac.wellcome.storage.locking.{FailedLockingServiceOp, FailedProcess, FailedUnlock}
+import uk.ac.wellcome.storage.locking.{
+  FailedLockingServiceOp,
+  FailedProcess,
+  FailedUnlock
+}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -21,7 +30,8 @@ class WorkMatcher(
 
   type Out = Set[MatchedIdentifiers]
 
-  def matchWork(work: TransformedBaseWork): Future[MatcherResult] = doMatch(work).map(MatcherResult)
+  def matchWork(work: TransformedBaseWork): Future[MatcherResult] =
+    doMatch(work).map(MatcherResult)
 
   private def doMatch(work: TransformedBaseWork): Future[Out] = {
     val update = WorkUpdate(work)

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcher.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcher.scala
@@ -1,31 +1,17 @@
 package uk.ac.wellcome.platform.matcher.matcher
 
-import scala.concurrent.{ExecutionContext, Future}
-import grizzled.slf4j.Logging
 import cats.implicits._
-
-import uk.ac.wellcome.models.matcher.{
-  MatchedIdentifiers,
-  MatcherResult,
-  WorkIdentifier,
-  WorkNode
-}
-import uk.ac.wellcome.models.work.internal.{
-  TransformedBaseWork,
-  UnidentifiedInvisibleWork,
-  UnidentifiedWork
-}
+import grizzled.slf4j.Logging
+import uk.ac.wellcome.models.matcher.{MatchedIdentifiers, MatcherResult, WorkIdentifier, WorkNode}
+import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.platform.matcher.exceptions.MatcherException
 import uk.ac.wellcome.platform.matcher.models._
 import uk.ac.wellcome.platform.matcher.storage.WorkGraphStore
 import uk.ac.wellcome.platform.matcher.workgraph.WorkGraphUpdater
-
 import uk.ac.wellcome.storage.locking.dynamo.DynamoLockingService
-import uk.ac.wellcome.storage.locking.{
-  FailedLockingServiceOp,
-  FailedProcess,
-  FailedUnlock
-}
+import uk.ac.wellcome.storage.locking.{FailedLockingServiceOp, FailedProcess, FailedUnlock}
+
+import scala.concurrent.{ExecutionContext, Future}
 
 class WorkMatcher(
   workGraphStore: WorkGraphStore,
@@ -35,14 +21,9 @@ class WorkMatcher(
 
   type Out = Set[MatchedIdentifiers]
 
-  def matchWork(work: TransformedBaseWork): Future[MatcherResult] = work match {
-    case w: UnidentifiedWork =>
-      doMatch(w).map(MatcherResult)
-    case w: UnidentifiedInvisibleWork =>
-      Future.successful(singleMatchedIdentifier(w))
-  }
+  def matchWork(work: TransformedBaseWork): Future[MatcherResult] = doMatch(work).map(MatcherResult)
 
-  private def doMatch(work: UnidentifiedWork): Future[Out] = {
+  private def doMatch(work: TransformedBaseWork): Future[Out] = {
     val update = WorkUpdate(work)
     val updateAffectedIdentifiers = update.referencedWorkIds + update.workId
     withLocks(update, updateAffectedIdentifiers) {
@@ -69,14 +50,6 @@ class WorkMatcher(
       case FailedProcess(_, e)   => e
       case _                     => new RuntimeException(failure.toString)
     }
-
-  private def singleMatchedIdentifier(work: UnidentifiedInvisibleWork) = {
-    MatcherResult(
-      Set(
-        MatchedIdentifiers(Set(WorkIdentifier(work)))
-      )
-    )
-  }
 
   private def withUpdateLocked(
     update: WorkUpdate,

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/models/WorkUpdate.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/models/WorkUpdate.scala
@@ -1,13 +1,13 @@
 package uk.ac.wellcome.platform.matcher.models
 
-import uk.ac.wellcome.models.work.internal.UnidentifiedWork
+import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 
 case class WorkUpdate(workId: String,
                       version: Int,
                       referencedWorkIds: Set[String])
 
 case object WorkUpdate {
-  def apply(work: UnidentifiedWork): WorkUpdate = {
+  def apply(work: TransformedBaseWork): WorkUpdate = {
     val id = work.sourceIdentifier.toString
     val referencedWorkIds = work.data.mergeCandidates
       .map { mergeCandidate =>

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
@@ -10,7 +10,12 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{EitherValues, FunSpec, Matchers}
 import org.scanamo.syntax._
-import uk.ac.wellcome.models.matcher.{MatchedIdentifiers, MatcherResult, WorkIdentifier, WorkNode}
+import uk.ac.wellcome.models.matcher.{
+  MatchedIdentifiers,
+  MatcherResult,
+  WorkIdentifier,
+  WorkNode
+}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.MergeCandidate
 import uk.ac.wellcome.platform.matcher.exceptions.MatcherException
@@ -25,7 +30,8 @@ class WorkMatcherTest
     with MatcherFixtures
     with ScalaFutures
     with MockitoSugar
-    with WorksGenerators with EitherValues {
+    with WorksGenerators
+    with EitherValues {
 
   private val identifierA = createSierraSystemSourceIdentifierWith(value = "A")
   private val identifierB = createSierraSystemSourceIdentifierWith(value = "B")
@@ -69,7 +75,8 @@ class WorkMatcherTest
               matcherResult shouldBe
                 MatcherResult(
                   Set(MatchedIdentifiers(Set(WorkIdentifier(workId, 1)))))
-              get[WorkNode](dynamoClient, graphTable.name)('id -> workId).map(_.right.get) shouldBe Some(
+              get[WorkNode](dynamoClient, graphTable.name)('id -> workId)
+                .map(_.right.get) shouldBe Some(
                 WorkNode(workId, 1, Nil, ciHash(workId)))
             }
           }

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
@@ -8,15 +8,9 @@ import org.mockito.Matchers.any
 import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.{EitherValues, FunSpec, Matchers}
 import org.scanamo.syntax._
-
-import uk.ac.wellcome.models.matcher.{
-  MatchedIdentifiers,
-  MatcherResult,
-  WorkIdentifier,
-  WorkNode
-}
+import uk.ac.wellcome.models.matcher.{MatchedIdentifiers, MatcherResult, WorkIdentifier, WorkNode}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.MergeCandidate
 import uk.ac.wellcome.platform.matcher.exceptions.MatcherException
@@ -31,7 +25,7 @@ class WorkMatcherTest
     with MatcherFixtures
     with ScalaFutures
     with MockitoSugar
-    with WorksGenerators {
+    with WorksGenerators with EitherValues {
 
   private val identifierA = createSierraSystemSourceIdentifierWith(value = "A")
   private val identifierB = createSierraSystemSourceIdentifierWith(value = "B")
@@ -53,7 +47,7 @@ class WorkMatcherTest
 
               val savedLinkedWork =
                 get[WorkNode](dynamoClient, graphTable.name)('id -> workId)
-                  .map(_.right.get)
+                  .map(_.right.value)
 
               savedLinkedWork shouldBe Some(
                 WorkNode(workId, 1, Nil, ciHash(workId)))

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
@@ -64,7 +64,7 @@ class WorkMatcherTest
     }
   }
 
-  it("doesn't store an invisible work and sends the work id") {
+  it("stores an invisible work and sends the work id") {
     withLockTable { lockTable =>
       withWorkGraphTable { graphTable =>
         withWorkGraphStore(graphTable) { workGraphStore =>
@@ -75,7 +75,8 @@ class WorkMatcherTest
               matcherResult shouldBe
                 MatcherResult(
                   Set(MatchedIdentifiers(Set(WorkIdentifier(workId, 1)))))
-              get[WorkNode](dynamoClient, graphTable.name)('id -> workId) shouldBe None
+              get[WorkNode](dynamoClient, graphTable.name)('id -> workId).map(_.right.get) shouldBe Some(
+                WorkNode(workId, 1, Nil, ciHash(workId)))
             }
           }
         }


### PR DESCRIPTION
Part of https://github.com/wellcometrust/platform/issues/3921
It won't have any effect until we start sending mets through the pipeline, but it's a simple enough change and it has simplified the code a bit, so I figured it was worth doing it