### PR TITLE
Merger can redirect invisible works

### DIFF
--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -11,7 +11,9 @@ sealed trait IdentifiedBaseWork extends BaseWork {
   val canonicalId: String
 }
 
-sealed trait TransformedBaseWork extends BaseWork with MultipleSourceIdentifiers {
+sealed trait TransformedBaseWork
+    extends BaseWork
+    with MultipleSourceIdentifiers {
   val data: WorkData[MaybeDisplayable]
   val otherIdentifiers = data.otherIdentifiers
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -11,8 +11,9 @@ sealed trait IdentifiedBaseWork extends BaseWork {
   val canonicalId: String
 }
 
-sealed trait TransformedBaseWork extends BaseWork {
+sealed trait TransformedBaseWork extends BaseWork with MultipleSourceIdentifiers {
   val data: WorkData[MaybeDisplayable]
+  val otherIdentifiers = data.otherIdentifiers
 }
 
 sealed trait InvisibleWork extends BaseWork
@@ -50,9 +51,7 @@ case class UnidentifiedWork(
   data: WorkData[MaybeDisplayable],
   ontologyType: String = "Work",
   identifiedType: String = classOf[IdentifiedWork].getSimpleName
-) extends TransformedBaseWork
-    with MultipleSourceIdentifiers {
-  val otherIdentifiers = data.otherIdentifiers
+) extends TransformedBaseWork {
 
   def withData(f: WorkData[MaybeDisplayable] => WorkData[MaybeDisplayable]) =
     this.copy(data = f(data))

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
@@ -16,7 +16,7 @@ trait WorksGenerators extends ItemsGenerators with ProductionEventGenerators {
     )
 
   def createUnidentifiedRedirectedWork(
-    source: UnidentifiedWork,
+    source: TransformedBaseWork,
     target: UnidentifiedWork): UnidentifiedRedirectedWork =
     UnidentifiedRedirectedWork(
       sourceIdentifier = source.sourceIdentifier,

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/logging/MergerLogging.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/logging/MergerLogging.scala
@@ -1,6 +1,9 @@
 package uk.ac.wellcome.platform.merger.logging
 
-import uk.ac.wellcome.models.work.internal.{TransformedBaseWork, UnidentifiedWork}
+import uk.ac.wellcome.models.work.internal.{
+  TransformedBaseWork,
+  UnidentifiedWork
+}
 
 trait MergerLogging {
   def describeWorkPair(workA: UnidentifiedWork, workB: TransformedBaseWork) =

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/logging/MergerLogging.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/logging/MergerLogging.scala
@@ -1,13 +1,13 @@
 package uk.ac.wellcome.platform.merger.logging
 
-import uk.ac.wellcome.models.work.internal.UnidentifiedWork
+import uk.ac.wellcome.models.work.internal.{TransformedBaseWork, UnidentifiedWork}
 
 trait MergerLogging {
-  def describeWorkPair(workA: UnidentifiedWork, workB: UnidentifiedWork) =
+  def describeWorkPair(workA: UnidentifiedWork, workB: TransformedBaseWork) =
     s"(id=${workA.sourceIdentifier.value}) and (id=${workB.sourceIdentifier.value})"
 
   def describeWorkPairWithItems(workA: UnidentifiedWork,
-                                workB: UnidentifiedWork): String =
+                                workB: TransformedBaseWork): String =
     s"(id=${workA.sourceIdentifier.value}, itemsCount=${workA.data.items.size}) and " +
       s"(id=${workB.sourceIdentifier.value}, itemsCount=${workB.data.items.size})"
 }

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/MergerRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/MergerRule.scala
@@ -1,5 +1,5 @@
 package uk.ac.wellcome.platform.merger.rules
-import uk.ac.wellcome.models.work.internal.{BaseWork, UnidentifiedWork}
+import uk.ac.wellcome.models.work.internal.{BaseWork, TransformedBaseWork, UnidentifiedWork}
 import uk.ac.wellcome.platform.merger.model.MergedWork
 
 trait MergerRule { this: Partitioner with WorkPairMerger =>
@@ -31,7 +31,7 @@ trait MergerRule { this: Partitioner with WorkPairMerger =>
 }
 
 case class Partition(firstWork: UnidentifiedWork,
-                     secondWork: UnidentifiedWork,
+                     secondWork: TransformedBaseWork,
                      otherWorks: Seq[BaseWork])
 
 trait Partitioner {
@@ -41,5 +41,5 @@ trait Partitioner {
 trait WorkPairMerger {
   protected def mergeAndRedirectWorkPair(
     firstWork: UnidentifiedWork,
-    secondWork: UnidentifiedWork): Option[MergedWork]
+    secondWork: TransformedBaseWork): Option[MergedWork]
 }

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/MergerRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/MergerRule.scala
@@ -1,5 +1,9 @@
 package uk.ac.wellcome.platform.merger.rules
-import uk.ac.wellcome.models.work.internal.{BaseWork, TransformedBaseWork, UnidentifiedWork}
+import uk.ac.wellcome.models.work.internal.{
+  BaseWork,
+  TransformedBaseWork,
+  UnidentifiedWork
+}
 import uk.ac.wellcome.platform.merger.model.MergedWork
 
 trait MergerRule { this: Partitioner with WorkPairMerger =>

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/physicaldigital/SierraPhysicalDigitalMergeRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/physicaldigital/SierraPhysicalDigitalMergeRule.scala
@@ -24,7 +24,7 @@ object SierraPhysicalDigitalMergeRule
     with SierraPhysicalDigitalPartitioner {
   override protected def mergeAndRedirectWorkPair(
     physicalWork: UnidentifiedWork,
-    digitalWork: UnidentifiedWork): Option[MergedWork] =
+    digitalWork: TransformedBaseWork): Option[MergedWork] =
     (physicalWork.data.items, digitalWork.data.items) match {
       case (
           List(physicalItem: Identifiable[Item]),

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/singlepagemiro/SierraMiroMergeRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/singlepagemiro/SierraMiroMergeRule.scala
@@ -28,7 +28,7 @@ object SierraMiroMergeRule
 
   override protected def mergeAndRedirectWorkPair(
     sierraWork: UnidentifiedWork,
-    miroWork: UnidentifiedWork): Option[MergedWork] = {
+    miroWork: TransformedBaseWork): Option[MergedWork] = {
     (sierraWork.data.items, miroWork.data.items) match {
       case (
           List(sierraItem: MaybeDisplayable[Item]),
@@ -95,7 +95,7 @@ object SierraMiroMergeRule
   val doNotMergeIdentifierTypes =
     List("sierra-identifier", "sierra-system-number")
   private def mergeIdentifiers(sierraWork: UnidentifiedWork,
-                               miroWork: UnidentifiedWork) = {
+                               miroWork: TransformedBaseWork) = {
     sierraWork.otherIdentifiers ++
       miroWork.identifiers.filterNot(sourceIdentifier =>
         doNotMergeIdentifierTypes.contains(sourceIdentifier.identifierType.id))

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
@@ -6,7 +6,7 @@ import uk.ac.wellcome.platform.merger.rules.physicaldigital.SierraPhysicalDigita
 import uk.ac.wellcome.platform.merger.rules.singlepagemiro.SierraMiroMergeRule
 
 class Merger(rules: List[MergerRule]) {
-  def merge(works: Seq[UnidentifiedWork]): Seq[BaseWork] = {
+  def merge(works: Seq[TransformedBaseWork]): Seq[BaseWork] = {
     rules.foldLeft(works: Seq[BaseWork])((works, rule) =>
       rule.mergeAndRedirectWorks(works))
   }

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerManager.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerManager.scala
@@ -1,10 +1,6 @@
 package uk.ac.wellcome.platform.merger.services
 
-import uk.ac.wellcome.models.work.internal.{
-  BaseWork,
-  TransformedBaseWork,
-  UnidentifiedWork
-}
+import uk.ac.wellcome.models.work.internal.{BaseWork, TransformedBaseWork}
 
 class MergerManager(mergerRules: Merger) {
 
@@ -16,13 +12,13 @@ class MergerManager(mergerRules: Merger) {
     */
   def applyMerge(
     maybeWorks: Seq[Option[TransformedBaseWork]]): Seq[BaseWork] = {
-    val unidentifiedWorks = maybeWorks
+    val transformedBaseWorks = maybeWorks
       .collect {
-        case Some(unidentifiedWork: UnidentifiedWork) => unidentifiedWork
+        case Some(transformedBaseWork: TransformedBaseWork) => transformedBaseWork
       }
 
-    if (unidentifiedWorks.size == maybeWorks.size) {
-      mergerRules.merge(unidentifiedWorks)
+    if (transformedBaseWorks.size == maybeWorks.size) {
+      mergerRules.merge(transformedBaseWorks)
     } else {
       maybeWorks.flatten
     }

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerManager.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerManager.scala
@@ -14,7 +14,8 @@ class MergerManager(mergerRules: Merger) {
     maybeWorks: Seq[Option[TransformedBaseWork]]): Seq[BaseWork] = {
     val transformedBaseWorks = maybeWorks
       .collect {
-        case Some(transformedBaseWork: TransformedBaseWork) => transformedBaseWork
+        case Some(transformedBaseWork: TransformedBaseWork) =>
+          transformedBaseWork
       }
 
     if (transformedBaseWorks.size == maybeWorks.size) {

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/MergerRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/MergerRuleTest.scala
@@ -1,12 +1,7 @@
 package uk.ac.wellcome.platform.merger.rules
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
-import uk.ac.wellcome.models.work.internal.{
-  BaseWork,
-  IdentifiableRedirect,
-  UnidentifiedRedirectedWork,
-  UnidentifiedWork
-}
+import uk.ac.wellcome.models.work.internal.{BaseWork, IdentifiableRedirect, TransformedBaseWork, UnidentifiedRedirectedWork, UnidentifiedWork}
 import uk.ac.wellcome.platform.merger.model.MergedWork
 
 class MergerRuleTest extends FunSpec with WorksGenerators with Matchers {
@@ -16,7 +11,7 @@ class MergerRuleTest extends FunSpec with WorksGenerators with Matchers {
         works: Seq[BaseWork]): Option[Partition] = None
       override protected def mergeAndRedirectWorkPair(
         firstWork: UnidentifiedWork,
-        secondWork: UnidentifiedWork): Option[MergedWork] = None
+        secondWork: TransformedBaseWork): Option[MergedWork] = None
     }
 
     val works = createUnidentifiedWorks(5)
@@ -35,7 +30,7 @@ class MergerRuleTest extends FunSpec with WorksGenerators with Matchers {
             works.tail.tail))
       override protected def mergeAndRedirectWorkPair(
         firstWork: UnidentifiedWork,
-        secondWork: UnidentifiedWork): Option[MergedWork] = None
+        secondWork: TransformedBaseWork): Option[MergedWork] = None
     }
 
     val works = createUnidentifiedWorks(5)
@@ -53,7 +48,7 @@ class MergerRuleTest extends FunSpec with WorksGenerators with Matchers {
             works.tail.tail))
       override protected def mergeAndRedirectWorkPair(
         firstWork: UnidentifiedWork,
-        secondWork: UnidentifiedWork): Option[MergedWork] =
+        secondWork: TransformedBaseWork): Option[MergedWork] =
         Some(
           MergedWork(
             firstWork,

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/MergerRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/MergerRuleTest.scala
@@ -1,7 +1,13 @@
 package uk.ac.wellcome.platform.merger.rules
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
-import uk.ac.wellcome.models.work.internal.{BaseWork, IdentifiableRedirect, TransformedBaseWork, UnidentifiedRedirectedWork, UnidentifiedWork}
+import uk.ac.wellcome.models.work.internal.{
+  BaseWork,
+  IdentifiableRedirect,
+  TransformedBaseWork,
+  UnidentifiedRedirectedWork,
+  UnidentifiedWork
+}
 import uk.ac.wellcome.platform.merger.model.MergedWork
 
 class MergerRuleTest extends FunSpec with WorksGenerators with Matchers {

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerManagerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerManagerTest.scala
@@ -2,12 +2,7 @@ package uk.ac.wellcome.platform.merger.services
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
-import uk.ac.wellcome.models.work.internal.{
-  BaseWork,
-  IdentifiableRedirect,
-  UnidentifiedRedirectedWork,
-  UnidentifiedWork
-}
+import uk.ac.wellcome.models.work.internal.{BaseWork, IdentifiableRedirect, TransformedBaseWork, UnidentifiedRedirectedWork, UnidentifiedWork}
 
 class MergerManagerTest extends FunSpec with Matchers with WorksGenerators {
 
@@ -54,7 +49,7 @@ class MergerManagerTest extends FunSpec with Matchers with WorksGenerators {
     /** Make every work a redirect to the first work in the list, and leave
       * the first work intact.
       */
-    override def merge(works: Seq[UnidentifiedWork]): Seq[BaseWork] =
+    override def merge(works: Seq[TransformedBaseWork]): Seq[BaseWork] =
       works.head +: works.tail.map { work =>
         UnidentifiedRedirectedWork(
           sourceIdentifier = work.sourceIdentifier,

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerManagerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerManagerTest.scala
@@ -2,7 +2,13 @@ package uk.ac.wellcome.platform.merger.services
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
-import uk.ac.wellcome.models.work.internal.{BaseWork, IdentifiableRedirect, TransformedBaseWork, UnidentifiedRedirectedWork, UnidentifiedWork}
+import uk.ac.wellcome.models.work.internal.{
+  BaseWork,
+  IdentifiableRedirect,
+  TransformedBaseWork,
+  UnidentifiedRedirectedWork,
+  UnidentifiedWork
+}
 
 class MergerManagerTest extends FunSpec with Matchers with WorksGenerators {
 


### PR DESCRIPTION
Part of https://github.com/wellcometrust/platform/issues/3921
Depends on #257 

Still to do 
- [x] Ensure that merger never redirects to an invisible work (This can never happen because the class [`MergedWork`](https://github.com/wellcometrust/catalogue/blob/master/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/model/MergedWork.scala) enforces that the target node is a `UnidentifiedWork`