### PR TITLE
Recorder should send VHS key rather than S3 location to matcher

### DIFF
--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.bigmessaging
 
 import java.util.UUID
-import scala.util.{Failure, Success, Try}
 
 import uk.ac.wellcome.storage.store.{
   HybridIndexedStoreEntry,
@@ -11,7 +10,6 @@ import uk.ac.wellcome.storage.store.{
   VersionedHybridStore
 }
 import uk.ac.wellcome.storage.{
-  Identified,
   ObjectLocation,
   ObjectLocationPrefix,
   Version
@@ -19,10 +17,6 @@ import uk.ac.wellcome.storage.{
 import uk.ac.wellcome.storage.maxima.Maxima
 
 case class EmptyMetadata()
-
-trait GetLocation {
-  def getLocation(key: Version[String, Int]): Try[ObjectLocation]
-}
 
 class VHS[T, Metadata](val hybridStore: VHSInternalStore[T, Metadata])
     extends VersionedHybridStore[
@@ -32,14 +26,6 @@ class VHS[T, Metadata](val hybridStore: VHSInternalStore[T, Metadata])
       T,
       Metadata
     ](hybridStore)
-    with GetLocation {
-
-  def getLocation(key: Version[String, Int]): Try[ObjectLocation] =
-    hybridStore.indexedStore.get(key) match {
-      case Right(Identified(_, entry)) => Success(entry.typedStoreId)
-      case Left(error)                 => Failure(error.e)
-    }
-}
 
 class VHSInternalStore[T, Metadata](
   prefix: ObjectLocationPrefix,

--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
@@ -9,11 +9,7 @@ import uk.ac.wellcome.storage.store.{
   TypedStore,
   VersionedHybridStore
 }
-import uk.ac.wellcome.storage.{
-  ObjectLocation,
-  ObjectLocationPrefix,
-  Version
-}
+import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix, Version}
 import uk.ac.wellcome.storage.maxima.Maxima
 
 case class EmptyMetadata()

--- a/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/fixtures/VHSFixture.scala
+++ b/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/fixtures/VHSFixture.scala
@@ -1,17 +1,10 @@
 package uk.ac.wellcome.bigmessaging.fixtures
 
-import scala.util.{Success, Try}
-
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.bigmessaging.{EmptyMetadata, GetLocation}
+import uk.ac.wellcome.bigmessaging.EmptyMetadata
 
 import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryVersionedStore}
-import uk.ac.wellcome.storage.{
-  ObjectLocation,
-  StoreReadError,
-  StoreWriteError,
-  Version
-}
+import uk.ac.wellcome.storage.{StoreReadError, StoreWriteError, Version}
 import uk.ac.wellcome.storage.store.{HybridStoreEntry, VersionedStore}
 import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
@@ -20,7 +13,7 @@ trait VHSFixture[T] extends BigMessagingFixture {
 
   type Entry = HybridStoreEntry[T, EmptyMetadata]
 
-  type VHS = VersionedStore[String, Int, Entry] with GetLocation
+  type VHS = VersionedStore[String, Int, Entry]
 
   type InternalStore =
     MemoryStore[Version[String, Int], Entry] with MemoryMaxima[String, Entry]
@@ -30,11 +23,6 @@ trait VHSFixture[T] extends BigMessagingFixture {
       new MemoryStore[Version[String, Int], Entry](Map.empty)
       with MemoryMaxima[String, Entry]
   ) extends MemoryVersionedStore[String, Entry](internalStore)
-      with GetLocation {
-
-    def getLocation(key: Version[String, Int]): Try[ObjectLocation] =
-      Success(ObjectLocation("test", s"${key.id}/${key.version}"))
-  }
 
   class BrokenMemoryVHS extends MemoryVHS() {
     override def put(id: Version[String, Int])(entry: Entry): WriteEither =

--- a/pipeline/matcher/src/main/resources/application.conf
+++ b/pipeline/matcher/src/main/resources/application.conf
@@ -5,3 +5,6 @@ aws.dynamo.tableName=${?dynamo_table}
 aws.dynamo.tableIndex=${?dynamo_index}
 aws.locking.service.dynamo.tableName=${?dynamo_lock_table}
 aws.locking.service.dynamo.tableIndex=${?dynamo_lock_table_index}
+aws.vhs.dynamo.tableName=${?vhs_recorder_dynamo_table_name}
+aws.vhs.s3.bucketName=${?vhs_recorder_bucket_name}
+aws.vhs.s3.globalPrefix=recorder

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/Main.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/Main.scala
@@ -16,7 +16,9 @@ import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 import uk.ac.wellcome.models.Implicits._
 
-import uk.ac.wellcome.bigmessaging.typesafe.BigMessagingBuilder
+import uk.ac.wellcome.storage.Version
+import uk.ac.wellcome.messaging.typesafe.SQSBuilder
+import uk.ac.wellcome.bigmessaging.typesafe.VHSBuilder
 import uk.ac.wellcome.messaging.typesafe.SNSBuilder
 import uk.ac.wellcome.storage.locking.dynamo.{
   DynamoLockDao,
@@ -56,8 +58,9 @@ object Main extends WellcomeTypesafeApp {
     val workMatcher = new WorkMatcher(workGraphStore, new DynamoLockingService)
 
     new MatcherWorkerService(
-      msgStream = BigMessagingBuilder
-        .buildMessageStream[TransformedBaseWork](config),
+      store = VHSBuilder.build[TransformedBaseWork](config),
+      msgStream = SQSBuilder
+        .buildSQSStream[Version[String, Int]](config),
       msgSender = SNSBuilder
         .buildSNSMessageSender(config, subject = "Sent from the matcher"),
       workMatcher = workMatcher

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerService.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerService.scala
@@ -33,7 +33,7 @@ class MatcherWorkerService[MsgDestination](
   def run(): Future[Done] =
     msgStream.foreach(this.getClass.getSimpleName, processMessage)
 
-  def processMessage(key: Version[String, Int]): Future[Unit] = {
+  def processMessage(key: Version[String, Int]): Future[Unit] =
     (for {
       work <- getWork(key)
       identifiersList <- workMatcher.matchWork(work)
@@ -43,7 +43,6 @@ class MatcherWorkerService[MsgDestination](
         debug(
           s"Not matching work due to version conflict exception: ${e.getMessage}")
     }
-  }
 
   def getWork(key: Version[String, Int]): Future[TransformedBaseWork] =
     store.get(key) match {

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerService.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerService.scala
@@ -9,14 +9,22 @@ import uk.ac.wellcome.platform.matcher.models.VersionExpectedConflictException
 import uk.ac.wellcome.platform.matcher.exceptions.MatcherException
 import uk.ac.wellcome.typesafe.Runnable
 import uk.ac.wellcome.models.Implicits._
+import uk.ac.wellcome.json.JsonUtil._
 
-import uk.ac.wellcome.bigmessaging.message.BigMessageStream
+import uk.ac.wellcome.storage.store.{HybridStoreEntry, VersionedStore}
+import uk.ac.wellcome.storage.{Version, Identified}
+import uk.ac.wellcome.messaging.sqs.SQSStream
 import uk.ac.wellcome.messaging.MessageSender
+import uk.ac.wellcome.bigmessaging.EmptyMetadata
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class MatcherWorkerService[MsgDestination](
-  msgStream: BigMessageStream[TransformedBaseWork],
+  store: VersionedStore[
+    String,
+    Int,
+    HybridStoreEntry[TransformedBaseWork, EmptyMetadata]],
+  msgStream: SQSStream[Version[String, Int]],
   msgSender: MessageSender[MsgDestination],
   workMatcher: WorkMatcher)(implicit val actorSystem: ActorSystem,
                             ec: ExecutionContext)
@@ -26,13 +34,22 @@ class MatcherWorkerService[MsgDestination](
   def run(): Future[Done] =
     msgStream.foreach(this.getClass.getSimpleName, processMessage)
 
-  def processMessage(work: TransformedBaseWork): Future[Unit] =
+  def processMessage(key: Version[String, Int]): Future[Unit] =
     (for {
+      work <- getWork(key)
       identifiersList <- workMatcher.matchWork(work)
       _ <- Future.fromTry(msgSender.sendT(identifiersList))
     } yield ()).recover {
       case MatcherException(e: VersionExpectedConflictException) =>
         debug(
           s"Not matching work due to version conflict exception: ${e.getMessage}")
+    }
+
+  def getWork(key: Version[String, Int]): Future[TransformedBaseWork] =
+    store.get(key) match {
+      case Left(err) =>
+        error(s"Error fetching $key from VHS")
+        Future.failed(err.e)
+      case Right(Identified(_, entry)) => Future.successful(entry.t)
     }
 }

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerService.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerService.scala
@@ -12,7 +12,7 @@ import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.json.JsonUtil._
 
 import uk.ac.wellcome.storage.store.{HybridStoreEntry, VersionedStore}
-import uk.ac.wellcome.storage.{Version, Identified}
+import uk.ac.wellcome.storage.{Identified, Version}
 import uk.ac.wellcome.messaging.sqs.SQSStream
 import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.bigmessaging.EmptyMetadata
@@ -20,10 +20,9 @@ import uk.ac.wellcome.bigmessaging.EmptyMetadata
 import scala.concurrent.{ExecutionContext, Future}
 
 class MatcherWorkerService[MsgDestination](
-  store: VersionedStore[
-    String,
-    Int,
-    HybridStoreEntry[TransformedBaseWork, EmptyMetadata]],
+  store: VersionedStore[String,
+                        Int,
+                        HybridStoreEntry[TransformedBaseWork, EmptyMetadata]],
   msgStream: SQSStream[Version[String, Int]],
   msgSender: MessageSender[MsgDestination],
   workMatcher: WorkMatcher)(implicit val actorSystem: ActorSystem,

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerService.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerService.scala
@@ -33,7 +33,7 @@ class MatcherWorkerService[MsgDestination](
   def run(): Future[Done] =
     msgStream.foreach(this.getClass.getSimpleName, processMessage)
 
-  def processMessage(key: Version[String, Int]): Future[Unit] =
+  def processMessage(key: Version[String, Int]): Future[Unit] = {
     (for {
       work <- getWork(key)
       identifiersList <- workMatcher.matchWork(work)
@@ -43,6 +43,7 @@ class MatcherWorkerService[MsgDestination](
         debug(
           s"Not matching work due to version conflict exception: ${e.getMessage}")
     }
+  }
 
   def getWork(key: Version[String, Int]): Future[TransformedBaseWork] =
     store.get(key) match {

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerService.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerService.scala
@@ -34,7 +34,7 @@ class MatcherWorkerService[MsgDestination](
   def run(): Future[Done] =
     msgStream.foreach(this.getClass.getSimpleName, processMessage)
 
-  def processMessage(key: Version[String, Int]): Future[Unit] =
+  def processMessage(key: Version[String, Int]): Future[Unit] = {
     (for {
       work <- getWork(key)
       identifiersList <- workMatcher.matchWork(work)
@@ -44,6 +44,7 @@ class MatcherWorkerService[MsgDestination](
         debug(
           s"Not matching work due to version conflict exception: ${e.getMessage}")
     }
+  }
 
   def getWork(key: Version[String, Int]): Future[TransformedBaseWork] =
     store.get(key) match {

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
@@ -84,7 +84,7 @@ class MatcherFeatureTest
                 listMessagesReceivedFromSNS(topic).size shouldBe 0
               }
             }
-        }
+          }
       }
     }
   }

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
@@ -84,7 +84,7 @@ class MatcherFeatureTest
                 listMessagesReceivedFromSNS(topic).size shouldBe 0
               }
             }
-          }
+        }
       }
     }
   }

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
@@ -10,7 +10,6 @@ import uk.ac.wellcome.models.matcher.{
 }
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
 import uk.ac.wellcome.models.work.generators.WorksGenerators
-import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.json.JsonUtil.fromJson
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
@@ -26,24 +25,26 @@ class MatcherFeatureTest
   it("processes a message with a simple UnidentifiedWork with no linked works") {
     withLocalSnsTopic { topic =>
       withLocalSqsQueue { queue =>
-        withWorkerService(queue, topic) { _ =>
-          val work = createUnidentifiedWork
+        withVHS { vhs =>
+          withWorkerService(vhs, queue, topic) { _ =>
+            val work = createUnidentifiedWork
 
-          sendMessage[TransformedBaseWork](queue = queue, work)
+            sendWork(work, vhs, queue)
 
-          eventually {
-            val snsMessages = listMessagesReceivedFromSNS(topic)
-            snsMessages.size should be >= 1
+            eventually {
+              val snsMessages = listMessagesReceivedFromSNS(topic)
+              snsMessages.size should be >= 1
 
-            snsMessages.map { snsMessage =>
-              val identifiersList =
-                fromJson[MatcherResult](snsMessage.message).get
+              snsMessages.map { snsMessage =>
+                val identifiersList =
+                  fromJson[MatcherResult](snsMessage.message).get
 
-              identifiersList shouldBe
-                MatcherResult(
-                  Set(MatchedIdentifiers(
-                    Set(WorkIdentifier(work))
-                  )))
+                identifiersList shouldBe
+                  MatcherResult(
+                    Set(MatchedIdentifiers(
+                      Set(WorkIdentifier(work))
+                    )))
+              }
             }
           }
         }
@@ -57,31 +58,33 @@ class MatcherFeatureTest
       withLocalSqsQueueAndDlq {
         case QueuePair(queue, dlq) =>
           withWorkGraphTable { graphTable =>
-            withWorkerService(queue, topic, graphTable) { _ =>
-              val existingWorkVersion = 2
-              val updatedWorkVersion = 1
+            withVHS { vhs =>
+              withWorkerService(vhs, queue, topic, graphTable) { _ =>
+                val existingWorkVersion = 2
+                val updatedWorkVersion = 1
 
-              val workAv1 = createUnidentifiedWorkWith(
-                version = updatedWorkVersion
-              )
+                val workAv1 = createUnidentifiedWorkWith(
+                  version = updatedWorkVersion
+                )
 
-              val existingWorkAv2 = WorkNode(
-                id = workAv1.sourceIdentifier.toString,
-                version = Some(existingWorkVersion),
-                linkedIds = Nil,
-                componentId = workAv1.sourceIdentifier.toString
-              )
-              put(dynamoClient, graphTable.name)(existingWorkAv2)
+                val existingWorkAv2 = WorkNode(
+                  id = workAv1.sourceIdentifier.toString,
+                  version = Some(existingWorkVersion),
+                  linkedIds = Nil,
+                  componentId = workAv1.sourceIdentifier.toString
+                )
+                put(dynamoClient, graphTable.name)(existingWorkAv2)
 
-              sendMessage[TransformedBaseWork](queue = queue, workAv1)
+                sendWork(workAv1, vhs, queue)
 
-              eventually {
-                noMessagesAreWaitingIn(queue)
-                noMessagesAreWaitingIn(dlq)
+                eventually {
+                  noMessagesAreWaitingIn(queue)
+                  noMessagesAreWaitingIn(dlq)
+                }
+                listMessagesReceivedFromSNS(topic).size shouldBe 0
               }
-              listMessagesReceivedFromSNS(topic).size shouldBe 0
             }
-          }
+        }
       }
     }
   }

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
@@ -13,22 +13,21 @@ import org.scanamo.query.UniqueKey
 import org.scanamo.semiauto._
 import org.scanamo.time.JavaTimeFormats._
 
+import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.platform.matcher.matcher.WorkMatcher
 import uk.ac.wellcome.models.matcher.{MatchedIdentifiers, WorkNode}
 import uk.ac.wellcome.platform.matcher.services.MatcherWorkerService
 import uk.ac.wellcome.platform.matcher.storage.{WorkGraphStore, WorkNodeDao}
-import uk.ac.wellcome.models.Implicits._
 
 import uk.ac.wellcome.messaging.sns.SNSConfig
 import uk.ac.wellcome.messaging.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.fixtures.SQS
-import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
-import uk.ac.wellcome.bigmessaging.memory.MemoryTypedStoreCompanion
+import uk.ac.wellcome.bigmessaging.fixtures.{BigMessagingFixture, VHSFixture}
+import uk.ac.wellcome.bigmessaging.EmptyMetadata
 
 import uk.ac.wellcome.storage.dynamo._
-import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.fixtures.DynamoFixtures.Table
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.locking.dynamo.{
@@ -36,11 +35,14 @@ import uk.ac.wellcome.storage.locking.dynamo.{
   DynamoLockingService,
   ExpiringLock
 }
+import uk.ac.wellcome.storage.{Version, Identified}
+import uk.ac.wellcome.storage.store.HybridStoreEntry
 
 trait MatcherFixtures
     extends BigMessagingFixture
     with DynamoLockDaoFixtures
     with LocalWorkGraphDynamoDb
+    with VHSFixture[TransformedBaseWork]
     with S3Fixtures {
 
   implicit val workNodeFormat: DynamoFormat[WorkNode] = deriveDynamoFormat
@@ -56,18 +58,16 @@ trait MatcherFixtures
       testWith(table)
     }
 
-  def withWorkerService[R](queue: SQS.Queue, topic: Topic, graphTable: Table)(
+  def withWorkerService[R](vhs: VHS, queue: SQS.Queue, topic: Topic, graphTable: Table)(
     testWith: TestWith[MatcherWorkerService[SNSConfig], R]): R =
     withSnsMessageSender(topic) { msgSender =>
       withActorSystem { implicit actorSystem =>
         withLockTable { lockTable =>
           withWorkGraphStore(graphTable) { workGraphStore =>
             withWorkMatcher(workGraphStore, lockTable) { workMatcher =>
-              implicit val streamStore =
-                MemoryTypedStoreCompanion[ObjectLocation, TransformedBaseWork]()
-              withBigMessageStream[TransformedBaseWork, R](queue) { msgStream =>
+              withSQSStream[Version[String, Int], R](queue) { msgStream =>
                 val workerService =
-                  new MatcherWorkerService(msgStream, msgSender, workMatcher)
+                  new MatcherWorkerService(vhs, msgStream, msgSender, workMatcher)
                 workerService.run()
                 testWith(workerService)
               }
@@ -77,10 +77,10 @@ trait MatcherFixtures
       }
     }
 
-  def withWorkerService[R](queue: SQS.Queue, topic: Topic)(
+  def withWorkerService[R](vhs: VHS, queue: SQS.Queue, topic: Topic)(
     testWith: TestWith[MatcherWorkerService[SNSConfig], R]): R =
     withWorkGraphTable { graphTable =>
-      withWorkerService(queue, topic, graphTable) { service =>
+      withWorkerService(vhs, queue, topic, graphTable) { service =>
         testWith(service)
       }
     }
@@ -118,6 +118,16 @@ trait MatcherFixtures
       DynamoConfig(table.name, table.index)
     )
     testWith(workNodeDao)
+  }
+
+  def sendWork(work: TransformedBaseWork, vhs: VHS, queue: SQS.Queue, version: Int = 1) = {
+    val entry = HybridStoreEntry(work, EmptyMetadata())
+    val id = work.sourceIdentifier.toString
+    val key = vhs.putLatest(id)(entry) match {
+      case Left(err) => throw new Exception(s"Failed storing work in VHS: $err")
+      case Right(Identified(key, _)) => key
+    }
+    sendSqsMessage(queue, key)
   }
 
   def ciHash(str: String): String =

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
@@ -140,9 +140,8 @@ class MatcherWorkerServiceTest
 
             processAndAssertMatchedWorkIs(
               workBv1,
-              MatcherResult(
-                Set(MatchedIdentifiers(
-                  Set(WorkIdentifier("sierra-system-number/B", 1))))),
+              MatcherResult(Set(MatchedIdentifiers(
+                Set(WorkIdentifier("sierra-system-number/B", 1))))),
               vhs,
               queue,
               topic)
@@ -171,9 +170,8 @@ class MatcherWorkerServiceTest
 
             processAndAssertMatchedWorkIs(
               workCv1,
-              MatcherResult(
-                Set(MatchedIdentifiers(
-                  Set(WorkIdentifier("sierra-system-number/C", 1))))),
+              MatcherResult(Set(MatchedIdentifiers(
+                Set(WorkIdentifier("sierra-system-number/C", 1))))),
               vhs,
               queue,
               topic)
@@ -215,9 +213,8 @@ class MatcherWorkerServiceTest
 
             processAndAssertMatchedWorkIs(
               workAv1,
-              MatcherResult(
-                Set(MatchedIdentifiers(
-                  Set(WorkIdentifier("sierra-system-number/A", 1))))),
+              MatcherResult(Set(MatchedIdentifiers(
+                Set(WorkIdentifier("sierra-system-number/A", 1))))),
               vhs,
               queue,
               topic)
@@ -229,9 +226,8 @@ class MatcherWorkerServiceTest
 
             processAndAssertMatchedWorkIs(
               workBv1,
-              MatcherResult(
-                Set(MatchedIdentifiers(
-                  Set(WorkIdentifier("sierra-system-number/B", 1))))),
+              MatcherResult(Set(MatchedIdentifiers(
+                Set(WorkIdentifier("sierra-system-number/B", 1))))),
               vhs,
               queue,
               topic)
@@ -323,37 +319,37 @@ class MatcherWorkerServiceTest
     withLocalSnsTopic { topic =>
       withLocalSqsQueueAndDlq {
         case QueuePair(queue, dlq) =>
-        withVHS { vhs =>
-          withWorkerService(vhs, queue, topic) { _ =>
-            val workAv2 = createUnidentifiedWorkWith(
-              sourceIdentifier = identifierA,
-              version = 2
-            )
+          withVHS { vhs =>
+            withWorkerService(vhs, queue, topic) { _ =>
+              val workAv2 = createUnidentifiedWorkWith(
+                sourceIdentifier = identifierA,
+                version = 2
+              )
 
-            val expectedMatchedWorkAv2 = MatcherResult(
-              Set(MatchedIdentifiers(
-                Set(WorkIdentifier("sierra-system-number/A", 2)))))
+              val expectedMatchedWorkAv2 = MatcherResult(
+                Set(MatchedIdentifiers(
+                  Set(WorkIdentifier("sierra-system-number/A", 2)))))
 
-            processAndAssertMatchedWorkIs(
-              workAv2,
-              expectedMatchedWorkAv2,
-              vhs,
-              queue,
-              topic)
+              processAndAssertMatchedWorkIs(
+                workAv2,
+                expectedMatchedWorkAv2,
+                vhs,
+                queue,
+                topic)
 
-            // Work V1 is sent but not matched
-            val differentWorkAv2 = createUnidentifiedWorkWith(
-              sourceIdentifier = identifierA,
-              mergeCandidates = List(MergeCandidate(identifierB)),
-              version = 2)
+              // Work V1 is sent but not matched
+              val differentWorkAv2 = createUnidentifiedWorkWith(
+                sourceIdentifier = identifierA,
+                mergeCandidates = List(MergeCandidate(identifierB)),
+                version = 2)
 
-            sendWork(differentWorkAv2, vhs, queue)
-            eventually {
-              assertQueueEmpty(queue)
-              assertQueueHasSize(dlq, 1)
+              sendWork(differentWorkAv2, vhs, queue)
+              eventually {
+                assertQueueEmpty(queue)
+                assertQueueHasSize(dlq, 1)
+              }
             }
           }
-        }
       }
     }
   }

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
@@ -31,18 +31,21 @@ class MatcherWorkerServiceTest
   it("creates a work without identifiers") {
     withLocalSnsTopic { topic =>
       withLocalSqsQueue { queue =>
-        withWorkerService(queue, topic) { _ =>
-          // Work Av1 created without any matched works
-          val updatedWork = createUnidentifiedSierraWork
-          val expectedMatchedWorks =
-            MatcherResult(
-              Set(MatchedIdentifiers(Set(WorkIdentifier(updatedWork)))))
+        withVHS { vhs =>
+          withWorkerService(vhs, queue, topic) { _ =>
+            // Work Av1 created without any matched works
+            val updatedWork = createUnidentifiedSierraWork
+            val expectedMatchedWorks =
+              MatcherResult(
+                Set(MatchedIdentifiers(Set(WorkIdentifier(updatedWork)))))
 
-          processAndAssertMatchedWorkIs(
-            updatedWork,
-            expectedMatchedWorks,
-            queue,
-            topic)
+            processAndAssertMatchedWorkIs(
+              updatedWork,
+              expectedMatchedWorks,
+              vhs,
+              queue,
+              topic)
+          }
         }
       }
     }
@@ -52,22 +55,25 @@ class MatcherWorkerServiceTest
     "sends an invisible work as a single matched result with no other matched identifiers") {
     withLocalSnsTopic { topic =>
       withLocalSqsQueue { queue =>
-        withWorkerService(queue, topic) { _ =>
-          val invisibleWork = createUnidentifiedInvisibleWork
-          val expectedMatchedWorks =
-            MatcherResult(
-              Set(
-                MatchedIdentifiers(
-                  Set(WorkIdentifier(invisibleWork))
-                ))
-            )
+        withVHS { vhs =>
+          withWorkerService(vhs, queue, topic) { _ =>
+            val invisibleWork = createUnidentifiedInvisibleWork
+            val expectedMatchedWorks =
+              MatcherResult(
+                Set(
+                  MatchedIdentifiers(
+                    Set(WorkIdentifier(invisibleWork))
+                  ))
+              )
 
-          processAndAssertMatchedWorkIs(
-            workToMatch = invisibleWork,
-            expectedMatchedWorks = expectedMatchedWorks,
-            queue = queue,
-            topic = topic
-          )
+            processAndAssertMatchedWorkIs(
+              workToMatch = invisibleWork,
+              expectedMatchedWorks = expectedMatchedWorks,
+              vhs = vhs,
+              queue = queue,
+              topic = topic
+            )
+          }
         }
       }
     }
@@ -77,26 +83,29 @@ class MatcherWorkerServiceTest
     "work A with one link to B and no existing works returns a single matched work") {
     withLocalSnsTopic { topic =>
       withLocalSqsQueue { queue =>
-        withWorkerService(queue, topic) { _ =>
-          // Work Av1
-          val workAv1 =
-            createUnidentifiedWorkWith(
-              sourceIdentifier = identifierA,
-              mergeCandidates = List(MergeCandidate(identifierB)))
-          // Work Av1 matched to B (before B exists hence version is None)
-          // need to match to works that do not exist to support
-          // bi-directionally matched works without deadlocking (A->B, B->A)
-          val expectedMatchedWorks = MatcherResult(
-            Set(
-              MatchedIdentifiers(Set(
-                WorkIdentifier("sierra-system-number/A", Some(1)),
-                WorkIdentifier("sierra-system-number/B", None)))))
+        withVHS { vhs =>
+          withWorkerService(vhs, queue, topic) { _ =>
+            // Work Av1
+            val workAv1 =
+              createUnidentifiedWorkWith(
+                sourceIdentifier = identifierA,
+                mergeCandidates = List(MergeCandidate(identifierB)))
+            // Work Av1 matched to B (before B exists hence version is None)
+            // need to match to works that do not exist to support
+            // bi-directionally matched works without deadlocking (A->B, B->A)
+            val expectedMatchedWorks = MatcherResult(
+              Set(
+                MatchedIdentifiers(Set(
+                  WorkIdentifier("sierra-system-number/A", Some(1)),
+                  WorkIdentifier("sierra-system-number/B", None)))))
 
-          processAndAssertMatchedWorkIs(
-            workAv1,
-            expectedMatchedWorks,
-            queue,
-            topic)
+            processAndAssertMatchedWorkIs(
+              workAv1,
+              expectedMatchedWorks,
+              vhs,
+              queue,
+              topic)
+          }
         }
       }
     }
@@ -106,82 +115,89 @@ class MatcherWorkerServiceTest
     "matches a work with one link then matches the combined work to a new work") {
     withLocalSnsTopic { topic =>
       withLocalSqsQueue { queue =>
-        withWorkerService(queue, topic) { _ =>
-          // Work Av1
-          val workAv1 =
-            createUnidentifiedWorkWith(sourceIdentifier = identifierA)
+        withVHS { vhs =>
+          withWorkerService(vhs, queue, topic) { _ =>
+            // Work Av1
+            val workAv1 =
+              createUnidentifiedWorkWith(sourceIdentifier = identifierA)
 
-          val expectedMatchedWorks = MatcherResult(
-            Set(
-              MatchedIdentifiers(Set(
-                WorkIdentifier("sierra-system-number/A", 1)
-              ))))
-
-          processAndAssertMatchedWorkIs(
-            workAv1,
-            expectedMatchedWorks,
-            queue,
-            topic)
-
-          // Work Bv1
-          val workBv1 =
-            createUnidentifiedWorkWith(sourceIdentifier = identifierB)
-
-          processAndAssertMatchedWorkIs(
-            workBv1,
-            MatcherResult(
-              Set(MatchedIdentifiers(
-                Set(WorkIdentifier("sierra-system-number/B", 1))))),
-            queue,
-            topic)
-
-          // Work Av1 matched to B
-          val workAv2 = createUnidentifiedWorkWith(
-            sourceIdentifier = identifierA,
-            version = 2,
-            mergeCandidates = List(MergeCandidate(identifierB)))
-
-          processAndAssertMatchedWorkIs(
-            workAv2,
-            MatcherResult(
+            val expectedMatchedWorks = MatcherResult(
               Set(
                 MatchedIdentifiers(Set(
-                  WorkIdentifier("sierra-system-number/A", 2),
-                  WorkIdentifier("sierra-system-number/B", 1))))),
-            queue,
-            topic
-          )
+                  WorkIdentifier("sierra-system-number/A", 1)
+                ))))
 
-          // Work Cv1
-          val workCv1 =
-            createUnidentifiedWorkWith(sourceIdentifier = identifierC)
+            processAndAssertMatchedWorkIs(
+              workAv1,
+              expectedMatchedWorks,
+              vhs,
+              queue,
+              topic)
 
-          processAndAssertMatchedWorkIs(
-            workCv1,
-            MatcherResult(
-              Set(MatchedIdentifiers(
-                Set(WorkIdentifier("sierra-system-number/C", 1))))),
-            queue,
-            topic)
+            // Work Bv1
+            val workBv1 =
+              createUnidentifiedWorkWith(sourceIdentifier = identifierB)
 
-          // Work Bv2 matched to C
-          val workBv2 = createUnidentifiedWorkWith(
-            sourceIdentifier = identifierB,
-            version = 2,
-            mergeCandidates = List(MergeCandidate(identifierC)))
+            processAndAssertMatchedWorkIs(
+              workBv1,
+              MatcherResult(
+                Set(MatchedIdentifiers(
+                  Set(WorkIdentifier("sierra-system-number/B", 1))))),
+              vhs,
+              queue,
+              topic)
 
-          processAndAssertMatchedWorkIs(
-            workBv2,
-            MatcherResult(
-              Set(
-                MatchedIdentifiers(
-                  Set(
+            // Work Av1 matched to B
+            val workAv2 = createUnidentifiedWorkWith(
+              sourceIdentifier = identifierA,
+              version = 2,
+              mergeCandidates = List(MergeCandidate(identifierB)))
+
+            processAndAssertMatchedWorkIs(
+              workAv2,
+              MatcherResult(
+                Set(
+                  MatchedIdentifiers(Set(
                     WorkIdentifier("sierra-system-number/A", 2),
-                    WorkIdentifier("sierra-system-number/B", 2),
-                    WorkIdentifier("sierra-system-number/C", 1))))),
-            queue,
-            topic
-          )
+                    WorkIdentifier("sierra-system-number/B", 1))))),
+              vhs,
+              queue,
+              topic
+            )
+
+            // Work Cv1
+            val workCv1 =
+              createUnidentifiedWorkWith(sourceIdentifier = identifierC)
+
+            processAndAssertMatchedWorkIs(
+              workCv1,
+              MatcherResult(
+                Set(MatchedIdentifiers(
+                  Set(WorkIdentifier("sierra-system-number/C", 1))))),
+              vhs,
+              queue,
+              topic)
+
+            // Work Bv2 matched to C
+            val workBv2 = createUnidentifiedWorkWith(
+              sourceIdentifier = identifierB,
+              version = 2,
+              mergeCandidates = List(MergeCandidate(identifierC)))
+
+            processAndAssertMatchedWorkIs(
+              workBv2,
+              MatcherResult(
+                Set(
+                  MatchedIdentifiers(
+                    Set(
+                      WorkIdentifier("sierra-system-number/A", 2),
+                      WorkIdentifier("sierra-system-number/B", 2),
+                      WorkIdentifier("sierra-system-number/C", 1))))),
+              vhs,
+              queue,
+              topic
+            )
+          }
         }
       }
     }
@@ -190,66 +206,72 @@ class MatcherWorkerServiceTest
   it("breaks matched works into individual works") {
     withLocalSnsTopic { topic =>
       withLocalSqsQueue { queue =>
-        withWorkerService(queue, topic) { _ =>
-          // Work Av1
-          val workAv1 = createUnidentifiedWorkWith(
-            sourceIdentifier = identifierA,
-            version = 1)
+        withVHS { vhs =>
+          withWorkerService(vhs, queue, topic) { _ =>
+            // Work Av1
+            val workAv1 = createUnidentifiedWorkWith(
+              sourceIdentifier = identifierA,
+              version = 1)
 
-          processAndAssertMatchedWorkIs(
-            workAv1,
-            MatcherResult(
-              Set(MatchedIdentifiers(
-                Set(WorkIdentifier("sierra-system-number/A", 1))))),
-            queue,
-            topic)
+            processAndAssertMatchedWorkIs(
+              workAv1,
+              MatcherResult(
+                Set(MatchedIdentifiers(
+                  Set(WorkIdentifier("sierra-system-number/A", 1))))),
+              vhs,
+              queue,
+              topic)
 
-          // Work Bv1
-          val workBv1 = createUnidentifiedWorkWith(
-            sourceIdentifier = identifierB,
-            version = 1)
+            // Work Bv1
+            val workBv1 = createUnidentifiedWorkWith(
+              sourceIdentifier = identifierB,
+              version = 1)
 
-          processAndAssertMatchedWorkIs(
-            workBv1,
-            MatcherResult(
-              Set(MatchedIdentifiers(
-                Set(WorkIdentifier("sierra-system-number/B", 1))))),
-            queue,
-            topic)
-
-          // Match Work A to Work B
-          val workAv2MatchedToB = createUnidentifiedWorkWith(
-            sourceIdentifier = identifierA,
-            version = 2,
-            mergeCandidates = List(MergeCandidate(identifierB)))
-
-          processAndAssertMatchedWorkIs(
-            workAv2MatchedToB,
-            MatcherResult(
-              Set(
-                MatchedIdentifiers(Set(
-                  WorkIdentifier("sierra-system-number/A", 2),
-                  WorkIdentifier("sierra-system-number/B", 1))))),
-            queue,
-            topic
-          )
-
-          // A no longer matches B
-          val workAv3WithNoMatchingWorks = createUnidentifiedWorkWith(
-            sourceIdentifier = identifierA,
-            version = 3)
-
-          processAndAssertMatchedWorkIs(
-            workAv3WithNoMatchingWorks,
-            MatcherResult(
-              Set(
-                MatchedIdentifiers(
-                  Set(WorkIdentifier("sierra-system-number/A", 3))),
-                MatchedIdentifiers(
+            processAndAssertMatchedWorkIs(
+              workBv1,
+              MatcherResult(
+                Set(MatchedIdentifiers(
                   Set(WorkIdentifier("sierra-system-number/B", 1))))),
-            queue,
-            topic
-          )
+              vhs,
+              queue,
+              topic)
+
+            // Match Work A to Work B
+            val workAv2MatchedToB = createUnidentifiedWorkWith(
+              sourceIdentifier = identifierA,
+              version = 2,
+              mergeCandidates = List(MergeCandidate(identifierB)))
+
+            processAndAssertMatchedWorkIs(
+              workAv2MatchedToB,
+              MatcherResult(
+                Set(
+                  MatchedIdentifiers(Set(
+                    WorkIdentifier("sierra-system-number/A", 2),
+                    WorkIdentifier("sierra-system-number/B", 1))))),
+              vhs,
+              queue,
+              topic
+            )
+
+            // A no longer matches B
+            val workAv3WithNoMatchingWorks = createUnidentifiedWorkWith(
+              sourceIdentifier = identifierA,
+              version = 3)
+
+            processAndAssertMatchedWorkIs(
+              workAv3WithNoMatchingWorks,
+              MatcherResult(
+                Set(
+                  MatchedIdentifiers(
+                    Set(WorkIdentifier("sierra-system-number/A", 3))),
+                  MatchedIdentifiers(
+                    Set(WorkIdentifier("sierra-system-number/B", 1))))),
+              vhs,
+              queue,
+              topic
+            )
+          }
         }
       }
     }
@@ -258,47 +280,9 @@ class MatcherWorkerServiceTest
   it("does not match a lower version") {
     withLocalSnsTopic { topic =>
       withLocalSqsQueueAndDlq { queuePair =>
-        withWorkerService(queuePair.queue, topic) { _ =>
-          // process Work V2
-          val workAv2 = createUnidentifiedWorkWith(
-            sourceIdentifier = identifierA,
-            version = 2
-          )
-
-          val expectedMatchedWorkAv2 = MatcherResult(
-            Set(MatchedIdentifiers(
-              Set(WorkIdentifier("sierra-system-number/A", 2)))))
-
-          processAndAssertMatchedWorkIs(
-            workAv2,
-            expectedMatchedWorkAv2,
-            queuePair.queue,
-            topic)
-
-          // Work V1 is sent but not matched
-          val workAv1 = createUnidentifiedWorkWith(
-            sourceIdentifier = identifierA,
-            version = 1)
-
-          sendMessage[TransformedBaseWork](queue = queuePair.queue, workAv1)
-          eventually {
-            noMessagesAreWaitingIn(queuePair.queue)
-            noMessagesAreWaitingIn(queuePair.dlq)
-            assertLastMatchedResultIs(
-              topic = topic,
-              expectedMatcherResult = expectedMatchedWorkAv2
-            )
-          }
-        }
-      }
-    }
-  }
-
-  it("does not match an existing version with different information") {
-    withLocalSnsTopic { topic =>
-      withLocalSqsQueueAndDlq {
-        case QueuePair(queue, dlq) =>
-          withWorkerService(queue, topic) { _ =>
+        withVHS { vhs =>
+          withWorkerService(vhs, queuePair.queue, topic) { _ =>
+            // process Work V2
             val workAv2 = createUnidentifiedWorkWith(
               sourceIdentifier = identifierA,
               version = 2
@@ -311,6 +295,49 @@ class MatcherWorkerServiceTest
             processAndAssertMatchedWorkIs(
               workAv2,
               expectedMatchedWorkAv2,
+              vhs,
+              queuePair.queue,
+              topic)
+
+            // Work V1 is sent but not matched
+            val workAv1 = createUnidentifiedWorkWith(
+              sourceIdentifier = identifierA,
+              version = 1)
+
+            sendWork(workAv1, vhs, queuePair.queue)
+            eventually {
+              noMessagesAreWaitingIn(queuePair.queue)
+              noMessagesAreWaitingIn(queuePair.dlq)
+              assertLastMatchedResultIs(
+                topic = topic,
+                expectedMatcherResult = expectedMatchedWorkAv2
+              )
+            }
+          }
+        }
+      }
+    }
+  }
+
+  it("does not match an existing version with different information") {
+    withLocalSnsTopic { topic =>
+      withLocalSqsQueueAndDlq {
+        case QueuePair(queue, dlq) =>
+        withVHS { vhs =>
+          withWorkerService(vhs, queue, topic) { _ =>
+            val workAv2 = createUnidentifiedWorkWith(
+              sourceIdentifier = identifierA,
+              version = 2
+            )
+
+            val expectedMatchedWorkAv2 = MatcherResult(
+              Set(MatchedIdentifiers(
+                Set(WorkIdentifier("sierra-system-number/A", 2)))))
+
+            processAndAssertMatchedWorkIs(
+              workAv2,
+              expectedMatchedWorkAv2,
+              vhs,
               queue,
               topic)
 
@@ -320,21 +347,23 @@ class MatcherWorkerServiceTest
               mergeCandidates = List(MergeCandidate(identifierB)),
               version = 2)
 
-            sendMessage[TransformedBaseWork](queue = queue, differentWorkAv2)
+            sendWork(differentWorkAv2, vhs, queue)
             eventually {
               assertQueueEmpty(queue)
               assertQueueHasSize(dlq, 1)
             }
           }
+        }
       }
     }
   }
 
   private def processAndAssertMatchedWorkIs(workToMatch: TransformedBaseWork,
                                             expectedMatchedWorks: MatcherResult,
+                                            vhs: VHS,
                                             queue: SQS.Queue,
-                                            topic: Topic): Any = {
-    sendMessage(queue = queue, workToMatch)
+                                            topic: Topic) = {
+    sendWork(workToMatch, vhs, queue)
     eventually {
       assertLastMatchedResultIs(
         topic = topic,

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
@@ -277,78 +277,79 @@ class MatcherWorkerServiceTest
     withLocalSnsTopic { topic =>
       withLocalSqsQueueAndDlq {
         case QueuePair(queue, dlq) =>
-        withVHS { vhs =>
-          withWorkerService(vhs, queue, topic) { _ =>
-            val workAv2 = createUnidentifiedWorkWith(
-              sourceIdentifier = identifierA,
-              version = 2
-            )
-
-            val expectedMatchedWorkAv2 = MatcherResult(
-              Set(MatchedIdentifiers(
-                Set(WorkIdentifier("sierra-system-number/A", 2)))))
-
-            processAndAssertMatchedWorkIs(
-              workAv2,
-              expectedMatchedWorkAv2,
-              vhs,
-              queue,
-              topic)
-
-            // Work V1 is sent but not matched
-            val workAv1 = createUnidentifiedWorkWith(
-              sourceIdentifier = identifierA,
-              version = 1)
-
-            sendWork(workAv1, vhs, queue)
-            eventually {
-              noMessagesAreWaitingIn(queue)
-              noMessagesAreWaitingIn(dlq)
-              assertLastMatchedResultIs(
-                topic = topic,
-                expectedMatcherResult = expectedMatchedWorkAv2
+          withVHS { vhs =>
+            withWorkerService(vhs, queue, topic) { _ =>
+              val workAv2 = createUnidentifiedWorkWith(
+                sourceIdentifier = identifierA,
+                version = 2
               )
+
+              val expectedMatchedWorkAv2 = MatcherResult(
+                Set(MatchedIdentifiers(
+                  Set(WorkIdentifier("sierra-system-number/A", 2)))))
+
+              processAndAssertMatchedWorkIs(
+                workAv2,
+                expectedMatchedWorkAv2,
+                vhs,
+                queue,
+                topic)
+
+              // Work V1 is sent but not matched
+              val workAv1 = createUnidentifiedWorkWith(
+                sourceIdentifier = identifierA,
+                version = 1)
+
+              sendWork(workAv1, vhs, queue)
+              eventually {
+                noMessagesAreWaitingIn(queue)
+                noMessagesAreWaitingIn(dlq)
+                assertLastMatchedResultIs(
+                  topic = topic,
+                  expectedMatcherResult = expectedMatchedWorkAv2
+                )
+              }
             }
           }
-        }
       }
     }
   }
 
   it("does not match an existing version with different information") {
     withLocalSnsTopic { topic =>
-      withLocalSqsQueueAndDlq { case QueuePair(queue, dlq) =>
-        withVHS { vhs =>
-          withWorkerService(vhs, queue, topic) { _ =>
-            val workAv2 = createUnidentifiedWorkWith(
-              sourceIdentifier = identifierA,
-              version = 2
-            )
+      withLocalSqsQueueAndDlq {
+        case QueuePair(queue, dlq) =>
+          withVHS { vhs =>
+            withWorkerService(vhs, queue, topic) { _ =>
+              val workAv2 = createUnidentifiedWorkWith(
+                sourceIdentifier = identifierA,
+                version = 2
+              )
 
-            val expectedMatchedWorkAv2 = MatcherResult(
-              Set(MatchedIdentifiers(
-                Set(WorkIdentifier("sierra-system-number/A", 2)))))
+              val expectedMatchedWorkAv2 = MatcherResult(
+                Set(MatchedIdentifiers(
+                  Set(WorkIdentifier("sierra-system-number/A", 2)))))
 
-            processAndAssertMatchedWorkIs(
-              workAv2,
-              expectedMatchedWorkAv2,
-              vhs,
-              queue,
-              topic)
+              processAndAssertMatchedWorkIs(
+                workAv2,
+                expectedMatchedWorkAv2,
+                vhs,
+                queue,
+                topic)
 
-            // Work V1 is sent but not matched
-            val differentWorkAv2 = createUnidentifiedWorkWith(
-              sourceIdentifier = identifierA,
-              mergeCandidates = List(MergeCandidate(identifierB)),
-              version = 2)
+              // Work V1 is sent but not matched
+              val differentWorkAv2 = createUnidentifiedWorkWith(
+                sourceIdentifier = identifierA,
+                mergeCandidates = List(MergeCandidate(identifierB)),
+                version = 2)
 
-            sendWork(differentWorkAv2, vhs, queue)
-            eventually {
-              assertQueueEmpty(queue)
-              assertQueueHasSize(dlq, 1)
+              sendWork(differentWorkAv2, vhs, queue)
+              eventually {
+                assertQueueEmpty(queue)
+                assertQueueHasSize(dlq, 1)
+              }
             }
           }
-        }
       }
     }
   }

--- a/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerService.scala
+++ b/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerService.scala
@@ -16,10 +16,9 @@ import uk.ac.wellcome.storage.store.{HybridStoreEntry, VersionedStore}
 import uk.ac.wellcome.storage.{Identified, Version}
 
 class RecorderWorkerService[MsgDestination](
-  store: VersionedStore[
-    String,
-    Int,
-    HybridStoreEntry[TransformedBaseWork, EmptyMetadata]],
+  store: VersionedStore[String,
+                        Int,
+                        HybridStoreEntry[TransformedBaseWork, EmptyMetadata]],
   messageStream: BigMessageStream[TransformedBaseWork],
   msgSender: MessageSender[MsgDestination])
     extends Runnable {

--- a/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerService.scala
+++ b/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerService.scala
@@ -8,13 +8,9 @@ import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.typesafe.Runnable
 import uk.ac.wellcome.json.JsonUtil._
 
-import uk.ac.wellcome.bigmessaging.{EmptyMetadata, GetLocation}
+import uk.ac.wellcome.bigmessaging.EmptyMetadata
 import uk.ac.wellcome.messaging.MessageSender
-import uk.ac.wellcome.bigmessaging.message.{
-  BigMessageStream,
-  MessageNotification,
-  RemoteNotification
-}
+import uk.ac.wellcome.bigmessaging.message.BigMessageStream
 
 import uk.ac.wellcome.storage.store.{HybridStoreEntry, VersionedStore}
 import uk.ac.wellcome.storage.{Identified, Version}
@@ -23,7 +19,7 @@ class RecorderWorkerService[MsgDestination](
   store: VersionedStore[
     String,
     Int,
-    HybridStoreEntry[TransformedBaseWork, EmptyMetadata]] with GetLocation,
+    HybridStoreEntry[TransformedBaseWork, EmptyMetadata]],
   messageStream: BigMessageStream[TransformedBaseWork],
   msgSender: MessageSender[MsgDestination])
     extends Runnable {
@@ -35,8 +31,7 @@ class RecorderWorkerService[MsgDestination](
     Future.fromTry {
       for {
         key <- storeWork(work)
-        location <- store.getLocation(key)
-        _ <- msgSender.sendT[MessageNotification](RemoteNotification(location))
+        _ <- msgSender.sendT[Version[String, Int]](key)
       } yield ()
     }
 

--- a/pipeline/terraform/stack/service_matcher.tf
+++ b/pipeline/terraform/stack/service_matcher.tf
@@ -47,9 +47,12 @@ module "matcher" {
     dynamo_index            = "work-sets-index"
     dynamo_lock_table       = "${aws_dynamodb_table.matcher_lock_table.id}"
     dynamo_lock_table_index = "context-ids-index"
+
+    vhs_recorder_dynamo_table_name = "${module.vhs_recorder.table_name}"
+    vhs_recorder_bucket_name       = "${module.vhs_recorder.bucket_name}"
   }
 
-  env_vars_length = 8
+  env_vars_length = 10
 
   secret_env_vars = {}
 


### PR DESCRIPTION
## Issue

https://github.com/wellcometrust/platform/issues/4053

## Description

We are getting Dynamo errors in the `recorder` sometimes when trying to fetch the S3 location to send onwards to the `matcher`.

The error occurs on the second line here:

https://github.com/wellcometrust/catalogue/blob/375bbe33e272a6f958d1ca5d58242c60338009fa/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerService.scala#L37-L38

This is presumably due to Dynamo eventual consistency, where even though we have a response indicating it is stored, the lookup fails and we get a  `DoesNotExist`.

To fix this we just send the VHS (i.e. dynamo) key onward to the `matcher` at this point, rather than trying to send the S3 location itself. The `matcher` can then use the VHS to retrieve the work data (which gets data from S3 internally).

