### PR TITLE
[WIP] Post filtering for useful aggregations

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElastsearchSearchRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElastsearchSearchRequestBuilder.scala
@@ -28,6 +28,7 @@ case class ElastsearchSearchRequestBuilder(
   lazy val request: SearchRequest = search(index)
     .aggs { aggregations }
     .query { filteredQuery }
+    .postFilter { ??? }
     .sortBy { sort ++ sortDefinitions }
     .limit { queryOptions.limit }
     .from { queryOptions.from }


### PR DESCRIPTION
# Who's this for?
Anyone who wants to build useful, performant interfaces with the aggregations returned from the API.

# What is it?
Simplified examples to explain:

User search and aggregation returned for faceted search interface
```JS
// GET /works?query=hula&aggregations=workType
{
  "totalResults": 75,
  "results": [/*..*/]
  "aggregations": {
    "workType": [
      { "label": "a", "count": 10 },
      { "label": "b", "count": 10 },
      { "label": "c", "count": 10 },
      { "label": "d", "count": 15 },
      { "label": "e", "count": 10 },
      { "label": "f", "count": 10 },
      { "label": "g", "count": 10 }
    ]
  }
}
```

Then we filter via `workType` `d`, and we get:
```JS
// GET /works?query=hula&workType=d&aggregations=workType
{
  "totalResults": 15,
  "results": [/*..*/]
  "aggregations": {
    "workType": [
      { "label": "d", "count": 15 }
    ]
  }
}
```

This is logical, but not massively useful for generating interfaces.

The suggestion is that we use [Post filtering](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#request-body-search-post-filter).

## API interface
It feels as though we should leave the current implementation as is as it does what it says on the tin.

We can extend the interface to have a query params of a list of filters to post filter:
```
GET /works?query=hula&workType=d&aggregations=workType&postFilters=workType
```

Another option would be to do this automatically via a boolean param:
```
GET /works?query=hula&workType=d&aggregations=workType&postAggregationFilters=true
```

The problem with the latter is that I can see it creating quite complex logic that might be a little opaque to the client.

Let's extend this for some more clarity:
```
GET /works?query=hula&workType=d&genres.label=medicine&aggregations=workType,genres.label
```

☝️ lands us with the problem of starting tho think about hierarchy, i.e. a person _might_ be filtering by `workType` and then `genre`. In this case then we would want the `workType` filter applied to the results, but not the genres. Using the latter the client could control this via:
```
GET /works?query=hula&workType=d&genres.label=medicine&aggregations=workType,genres.label&postFilters=genres.label
```

This way we would we apply the 

# TBC