### PR TITLE
Merger partitioning refactor

### DIFF
--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/MergerRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/MergerRule.scala
@@ -10,7 +10,8 @@ trait MergerRule { this: Partitioner with WorkPairMerger =>
 
   def mergeAndRedirectWorks(works: Seq[BaseWork]): Seq[BaseWork] =
     partitionWorks(works) match {
-      case Some(Partition(PotentialMergedWork(target, redirectedWork), remaining)) =>
+      case Some(
+          Partition(PotentialMergedWork(target, redirectedWork), remaining)) =>
         mergeAndRedirectWorkPair(target, redirectedWork)
           .map(result => updateVersion(result) ++ remaining)
           .getOrElse(works)
@@ -53,7 +54,9 @@ trait WorkTagPartitioner extends Partitioner {
     val redirectedWorks = taggedWorks.get(Redirected).toList.flatten
     val remaining = taggedWorks.get(PassThrough).toList.flatten
     (targetWorks, redirectedWorks) match {
-      case (List(target: UnidentifiedWork), List(redirected: TransformedBaseWork)) =>
+      case (
+          List(target: UnidentifiedWork),
+          List(redirected: TransformedBaseWork)) =>
         Some(Partition(PotentialMergedWork(target, redirected), remaining))
       case _ => None
     }

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/MergerRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/MergerRule.scala
@@ -37,6 +37,29 @@ trait Partitioner {
   protected def partitionWorks(works: Seq[BaseWork]): Option[Partition]
 }
 
+trait WorkTagPartitioner extends Partitioner {
+
+  sealed trait WorkTag
+
+  case object Target extends WorkTag
+  case object Redirected extends WorkTag
+  case object PassThrough extends WorkTag
+
+  protected def tagWork(work: BaseWork): WorkTag
+
+  def partitionWorks(works: Seq[BaseWork]): Option[Partition] = {
+    val taggedWorks = works.groupBy(tagWork)
+    val targetWorks = taggedWorks.get(Target).toList.flatten
+    val redirectedWorks = taggedWorks.get(Redirected).toList.flatten
+    val remaining = taggedWorks.get(PassThrough).toList.flatten
+    (targetWorks, redirectedWorks) match {
+      case (List(target: UnidentifiedWork), List(redirected: TransformedBaseWork)) =>
+        Some(Partition(PotentialMergedWork(target, redirected), remaining))
+      case _ => None
+    }
+  }
+}
+
 trait WorkPairMerger {
   protected def mergeAndRedirectWorkPair(
     firstWork: UnidentifiedWork,

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/physicaldigital/SierraPhysicalDigitalPartitioner.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/physicaldigital/SierraPhysicalDigitalPartitioner.scala
@@ -5,15 +5,11 @@ import uk.ac.wellcome.models.work.internal.{
   IdentifierType,
   UnidentifiedWork
 }
-import uk.ac.wellcome.platform.merger.rules.{Partition, Partitioner}
+import uk.ac.wellcome.platform.merger.rules.{Partition, Partitioner, PotentialMergedWork}
 
 trait SierraPhysicalDigitalPartitioner extends Partitioner {
 
-  private object workType extends Enumeration {
-    val SierraDigitalWork, SierraPhysicalWork, OtherWork = Value
-  }
-
-  override def partitionWorks(works: Seq[BaseWork]): Option[Partition] = {
+  def partitionWorks(works: Seq[BaseWork]): Option[Partition] = {
     val groupedWorks = works.groupBy {
       case work: UnidentifiedWork if isSierraPhysicalWork(work) =>
         workType.SierraPhysicalWork
@@ -32,9 +28,13 @@ trait SierraPhysicalDigitalPartitioner extends Partitioner {
       case (
           List(physicalWork: UnidentifiedWork),
           List(digitalWork: UnidentifiedWork)) =>
-        Some(Partition(physicalWork, digitalWork, otherWorks))
+        Some(Partition(PotentialMergedWork(physicalWork, digitalWork), otherWorks))
       case _ => None
     }
+  }
+
+  private object workType extends Enumeration {
+    val SierraDigitalWork, SierraPhysicalWork, OtherWork = Value
   }
 
   private def isSierraWork(work: UnidentifiedWork): Boolean =

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/physicaldigital/SierraPhysicalDigitalPartitioner.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/physicaldigital/SierraPhysicalDigitalPartitioner.scala
@@ -12,8 +12,8 @@ trait SierraPhysicalDigitalPartitioner extends WorkTagPartitioner {
   def tagWork(work: BaseWork): WorkTag =
     work match {
       case work: UnidentifiedWork if isSierraPhysicalWork(work) => Target
-      case work: UnidentifiedWork if isSierraDigitalWork(work) => Redirected
-      case _ => PassThrough
+      case work: UnidentifiedWork if isSierraDigitalWork(work)  => Redirected
+      case _                                                    => PassThrough
     }
 
   private def isSierraWork(work: UnidentifiedWork): Boolean =

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/sierramets/SierraMetsPartitioner.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/sierramets/SierraMetsPartitioner.scala
@@ -6,15 +6,11 @@ import uk.ac.wellcome.models.work.internal.{
   UnidentifiedInvisibleWork,
   UnidentifiedWork
 }
-import uk.ac.wellcome.platform.merger.rules.{Partition, Partitioner}
+import uk.ac.wellcome.platform.merger.rules.{Partition, Partitioner, PotentialMergedWork}
 
 class SierraMetsPartitioner extends Partitioner {
 
-  private object workType extends Enumeration {
-    val SierraWork, MetsWork, OtherWork = Value
-  }
-
-  override def partitionWorks(works: Seq[BaseWork]): Option[Partition] = {
+  def partitionWorks(works: Seq[BaseWork]): Option[Partition] = {
     val groupedWorks = works.groupBy {
       case work: UnidentifiedWork if isSierraWork(work) =>
         workType.SierraWork
@@ -33,11 +29,14 @@ class SierraMetsPartitioner extends Partitioner {
       case (
           List(physicalWork: UnidentifiedWork),
           List(metsWork: UnidentifiedInvisibleWork)) =>
-        Some(Partition(physicalWork, metsWork, otherWorks))
+        Some(Partition(PotentialMergedWork(physicalWork, metsWork), otherWorks))
       case _ => None
     }
   }
 
+  private object workType extends Enumeration {
+    val SierraWork, MetsWork, OtherWork = Value
+  }
   private def isSierraWork(work: UnidentifiedWork): Boolean =
     work.sourceIdentifier.identifierType == IdentifierType(
       "sierra-system-number")

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/sierramets/SierraMetsPartitioner.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/sierramets/SierraMetsPartitioner.scala
@@ -12,9 +12,9 @@ class SierraMetsPartitioner extends WorkTagPartitioner {
 
   def tagWork(work: BaseWork): WorkTag =
     work match {
-      case work: UnidentifiedWork if isSierraWork(work) => Target
+      case work: UnidentifiedWork if isSierraWork(work)        => Target
       case work: UnidentifiedInvisibleWork if isMetsWork(work) => Redirected
-      case _ => PassThrough
+      case _                                                   => PassThrough
     }
 
   private def isSierraWork(work: UnidentifiedWork): Boolean =

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/singlepagemiro/SierraMiroPartitioner.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/singlepagemiro/SierraMiroPartitioner.scala
@@ -5,15 +5,11 @@ import uk.ac.wellcome.models.work.internal.{
   IdentifierType,
   UnidentifiedWork
 }
-import uk.ac.wellcome.platform.merger.rules.{Partition, Partitioner}
+import uk.ac.wellcome.platform.merger.rules.{Partition, Partitioner, PotentialMergedWork}
 
 trait SierraMiroPartitioner extends Partitioner {
 
-  private object workType extends Enumeration {
-    val SierraWork, MiroWork, OtherWork = Value
-  }
-
-  override def partitionWorks(works: Seq[BaseWork]): Option[Partition] = {
+  def partitionWorks(works: Seq[BaseWork]): Option[Partition] = {
     val groupedWorks = works.groupBy {
       case work: UnidentifiedWork if isSierraWork(work) => workType.SierraWork
       case work: UnidentifiedWork if isMiroWork(work)   => workType.MiroWork
@@ -30,11 +26,14 @@ trait SierraMiroPartitioner extends Partitioner {
       case (
           List(sierraWork: UnidentifiedWork),
           List(miroWork: UnidentifiedWork)) =>
-        Some(Partition(sierraWork, miroWork, otherWorks))
+        Some(Partition(PotentialMergedWork(sierraWork, miroWork), otherWorks))
       case _ => None
     }
   }
 
+  private object workType extends Enumeration {
+    val SierraWork, MiroWork, OtherWork = Value
+  }
   private def isSierraWork(work: UnidentifiedWork): Boolean =
     work.sourceIdentifier.identifierType ==
       IdentifierType("sierra-system-number")

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/singlepagemiro/SierraMiroPartitioner.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/singlepagemiro/SierraMiroPartitioner.scala
@@ -3,37 +3,19 @@ package uk.ac.wellcome.platform.merger.rules.singlepagemiro
 import uk.ac.wellcome.models.work.internal.{
   BaseWork,
   IdentifierType,
-  UnidentifiedWork
+  UnidentifiedWork,
 }
-import uk.ac.wellcome.platform.merger.rules.{Partition, Partitioner, PotentialMergedWork}
+import uk.ac.wellcome.platform.merger.rules.WorkTagPartitioner
 
-trait SierraMiroPartitioner extends Partitioner {
+trait SierraMiroPartitioner extends WorkTagPartitioner {
 
-  def partitionWorks(works: Seq[BaseWork]): Option[Partition] = {
-    val groupedWorks = works.groupBy {
-      case work: UnidentifiedWork if isSierraWork(work) => workType.SierraWork
-      case work: UnidentifiedWork if isMiroWork(work)   => workType.MiroWork
-      case _                                            => workType.OtherWork
+  protected def tagWork(work: BaseWork): WorkTag =
+    work match {
+      case work: UnidentifiedWork if isSierraWork(work) => Target
+      case work: UnidentifiedWork if isMiroWork(work)   => Redirected
+      case _                                            => PassThrough
     }
 
-    val sierraWorks =
-      groupedWorks.get(workType.SierraWork).toList.flatten
-    val miroWorks =
-      groupedWorks.get(workType.MiroWork).toList.flatten
-    val otherWorks = groupedWorks.get(workType.OtherWork).toList.flatten
-
-    (sierraWorks, miroWorks) match {
-      case (
-          List(sierraWork: UnidentifiedWork),
-          List(miroWork: UnidentifiedWork)) =>
-        Some(Partition(PotentialMergedWork(sierraWork, miroWork), otherWorks))
-      case _ => None
-    }
-  }
-
-  private object workType extends Enumeration {
-    val SierraWork, MiroWork, OtherWork = Value
-  }
   private def isSierraWork(work: UnidentifiedWork): Boolean =
     work.sourceIdentifier.identifierType ==
       IdentifierType("sierra-system-number")

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/MergerRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/MergerRuleTest.scala
@@ -29,15 +29,15 @@ class MergerRuleTest extends FunSpec with WorksGenerators with Matchers {
     val mergerRule = new MergerRule with Partitioner with WorkPairMerger {
       override protected def partitionWorks(
         works: Seq[BaseWork]): Option[Partition] =
-          Some(
-            Partition(
-              PotentialMergedWork(
-                works.head.asInstanceOf[UnidentifiedWork],
-                works.tail.head.asInstanceOf[UnidentifiedWork]
-              ),
-              works.tail.tail
-            )
+        Some(
+          Partition(
+            PotentialMergedWork(
+              works.head.asInstanceOf[UnidentifiedWork],
+              works.tail.head.asInstanceOf[UnidentifiedWork]
+            ),
+            works.tail.tail
           )
+        )
       override protected def mergeAndRedirectWorkPair(
         firstWork: UnidentifiedWork,
         secondWork: TransformedBaseWork): Option[MergedWork] = None
@@ -51,15 +51,15 @@ class MergerRuleTest extends FunSpec with WorksGenerators with Matchers {
     val mergerRule = new MergerRule with Partitioner with WorkPairMerger {
       override protected def partitionWorks(
         works: Seq[BaseWork]): Option[Partition] =
-          Some(
-            Partition(
-              PotentialMergedWork(
-                works.head.asInstanceOf[UnidentifiedWork],
-                works.tail.head.asInstanceOf[UnidentifiedWork]
-              ),
-              works.tail.tail
-            )
+        Some(
+          Partition(
+            PotentialMergedWork(
+              works.head.asInstanceOf[UnidentifiedWork],
+              works.tail.head.asInstanceOf[UnidentifiedWork]
+            ),
+            works.tail.tail
           )
+        )
       override protected def mergeAndRedirectWorkPair(
         firstWork: UnidentifiedWork,
         secondWork: TransformedBaseWork): Option[MergedWork] =

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/MergerRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/MergerRuleTest.scala
@@ -29,11 +29,15 @@ class MergerRuleTest extends FunSpec with WorksGenerators with Matchers {
     val mergerRule = new MergerRule with Partitioner with WorkPairMerger {
       override protected def partitionWorks(
         works: Seq[BaseWork]): Option[Partition] =
-        Some(
-          Partition(
-            works.head.asInstanceOf[UnidentifiedWork],
-            works.tail.head.asInstanceOf[UnidentifiedWork],
-            works.tail.tail))
+          Some(
+            Partition(
+              PotentialMergedWork(
+                works.head.asInstanceOf[UnidentifiedWork],
+                works.tail.head.asInstanceOf[UnidentifiedWork]
+              ),
+              works.tail.tail
+            )
+          )
       override protected def mergeAndRedirectWorkPair(
         firstWork: UnidentifiedWork,
         secondWork: TransformedBaseWork): Option[MergedWork] = None
@@ -47,11 +51,15 @@ class MergerRuleTest extends FunSpec with WorksGenerators with Matchers {
     val mergerRule = new MergerRule with Partitioner with WorkPairMerger {
       override protected def partitionWorks(
         works: Seq[BaseWork]): Option[Partition] =
-        Some(
-          Partition(
-            works.head.asInstanceOf[UnidentifiedWork],
-            works.tail.head.asInstanceOf[UnidentifiedWork],
-            works.tail.tail))
+          Some(
+            Partition(
+              PotentialMergedWork(
+                works.head.asInstanceOf[UnidentifiedWork],
+                works.tail.head.asInstanceOf[UnidentifiedWork]
+              ),
+              works.tail.tail
+            )
+          )
       override protected def mergeAndRedirectWorkPair(
         firstWork: UnidentifiedWork,
         secondWork: TransformedBaseWork): Option[MergedWork] =

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/physicaldigital/SierraPhysicalDigitalPartitionerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/physicaldigital/SierraPhysicalDigitalPartitionerTest.scala
@@ -17,20 +17,23 @@ class SierraPhysicalDigitalPartitionerTest
   it("partitions a physical and digital work") {
     val result = partitioner.partitionWorks(Seq(physicalWork, digitalWork))
 
-    result shouldBe Some(Partition(PotentialMergedWork(physicalWork, digitalWork), Nil))
+    result shouldBe Some(
+      Partition(PotentialMergedWork(physicalWork, digitalWork), Nil))
   }
 
   it("partitions a physical and digital work, order in sequence") {
     val result = partitioner.partitionWorks(Seq(digitalWork, physicalWork))
 
-    result shouldBe Some(Partition(PotentialMergedWork(physicalWork, digitalWork), Nil))
+    result shouldBe Some(
+      Partition(PotentialMergedWork(physicalWork, digitalWork), Nil))
   }
 
   it("partitions a physical, digital and other works") {
     val result =
       partitioner.partitionWorks(Seq(physicalWork, digitalWork) ++ otherWorks)
 
-    result shouldBe Some(Partition(PotentialMergedWork(physicalWork, digitalWork), otherWorks))
+    result shouldBe Some(
+      Partition(PotentialMergedWork(physicalWork, digitalWork), otherWorks))
   }
 
   it("does not partition a single physical work") {

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/physicaldigital/SierraPhysicalDigitalPartitionerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/physicaldigital/SierraPhysicalDigitalPartitionerTest.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.merger.rules.physicaldigital
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
-import uk.ac.wellcome.platform.merger.rules.Partition
+import uk.ac.wellcome.platform.merger.rules.{Partition, PotentialMergedWork}
 
 class SierraPhysicalDigitalPartitionerTest
     extends FunSpec
@@ -17,20 +17,20 @@ class SierraPhysicalDigitalPartitionerTest
   it("partitions a physical and digital work") {
     val result = partitioner.partitionWorks(Seq(physicalWork, digitalWork))
 
-    result shouldBe Some(Partition(physicalWork, digitalWork, Nil))
+    result shouldBe Some(Partition(PotentialMergedWork(physicalWork, digitalWork), Nil))
   }
 
   it("partitions a physical and digital work, order in sequence") {
     val result = partitioner.partitionWorks(Seq(digitalWork, physicalWork))
 
-    result shouldBe Some(Partition(physicalWork, digitalWork, Nil))
+    result shouldBe Some(Partition(PotentialMergedWork(physicalWork, digitalWork), Nil))
   }
 
   it("partitions a physical, digital and other works") {
     val result =
       partitioner.partitionWorks(Seq(physicalWork, digitalWork) ++ otherWorks)
 
-    result shouldBe Some(Partition(physicalWork, digitalWork, otherWorks))
+    result shouldBe Some(Partition(PotentialMergedWork(physicalWork, digitalWork), otherWorks))
   }
 
   it("does not partition a single physical work") {

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/sierramets/SierraMetsPartitionerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/sierramets/SierraMetsPartitionerTest.scala
@@ -16,20 +16,23 @@ class SierraMetsPartitionerTest
   it("partitions a sierra physical and a mets work") {
     val result = partitioner.partitionWorks(Seq(sierraWork, metsWork))
 
-    result shouldBe Some(Partition(PotentialMergedWork(sierraWork, metsWork), Nil))
+    result shouldBe Some(
+      Partition(PotentialMergedWork(sierraWork, metsWork), Nil))
   }
 
   it("partitions a Sierra and mets work, order in sequence") {
     val result = partitioner.partitionWorks(Seq(metsWork, sierraWork))
 
-    result shouldBe Some(Partition(PotentialMergedWork(sierraWork, metsWork), Nil))
+    result shouldBe Some(
+      Partition(PotentialMergedWork(sierraWork, metsWork), Nil))
   }
 
   it("partitions a Sierra, Mets and other works") {
     val result =
       partitioner.partitionWorks(Seq(sierraWork, metsWork) ++ otherWorks)
 
-    result shouldBe Some(Partition(PotentialMergedWork(sierraWork, metsWork), otherWorks))
+    result shouldBe Some(
+      Partition(PotentialMergedWork(sierraWork, metsWork), otherWorks))
   }
 
   it("does not partition a single Sierra work") {

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/sierramets/SierraMetsPartitionerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/sierramets/SierraMetsPartitionerTest.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.merger.rules.sierramets
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
-import uk.ac.wellcome.platform.merger.rules.Partition
+import uk.ac.wellcome.platform.merger.rules.{Partition, PotentialMergedWork}
 
 class SierraMetsPartitionerTest
     extends FunSpec
@@ -16,20 +16,20 @@ class SierraMetsPartitionerTest
   it("partitions a sierra physical and a mets work") {
     val result = partitioner.partitionWorks(Seq(sierraWork, metsWork))
 
-    result shouldBe Some(Partition(sierraWork, metsWork, Nil))
+    result shouldBe Some(Partition(PotentialMergedWork(sierraWork, metsWork), Nil))
   }
 
   it("partitions a Sierra and mets work, order in sequence") {
     val result = partitioner.partitionWorks(Seq(metsWork, sierraWork))
 
-    result shouldBe Some(Partition(sierraWork, metsWork, Nil))
+    result shouldBe Some(Partition(PotentialMergedWork(sierraWork, metsWork), Nil))
   }
 
   it("partitions a Sierra, Mets and other works") {
     val result =
       partitioner.partitionWorks(Seq(sierraWork, metsWork) ++ otherWorks)
 
-    result shouldBe Some(Partition(sierraWork, metsWork, otherWorks))
+    result shouldBe Some(Partition(PotentialMergedWork(sierraWork, metsWork), otherWorks))
   }
 
   it("does not partition a single Sierra work") {

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/singlepagemiro/SierraMiroPartitionerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/singlepagemiro/SierraMiroPartitionerTest.scala
@@ -17,20 +17,23 @@ class SierraMiroPartitionerTest
   it("partitions a sierra and miro work") {
     val result = partitioner.partitionWorks(Seq(sierraWork, miroWork))
 
-    result shouldBe Some(Partition(PotentialMergedWork(sierraWork, miroWork), Nil))
+    result shouldBe Some(
+      Partition(PotentialMergedWork(sierraWork, miroWork), Nil))
   }
 
   it("partitions a Sierra and Miro work, order in sequence") {
     val result = partitioner.partitionWorks(Seq(miroWork, sierraWork))
 
-    result shouldBe Some(Partition(PotentialMergedWork(sierraWork, miroWork), Nil))
+    result shouldBe Some(
+      Partition(PotentialMergedWork(sierraWork, miroWork), Nil))
   }
 
   it("partitions a Sierra, Miro and other works") {
     val result =
       partitioner.partitionWorks(Seq(sierraWork, miroWork) ++ otherWorks)
 
-    result shouldBe Some(Partition(PotentialMergedWork(sierraWork, miroWork), otherWorks))
+    result shouldBe Some(
+      Partition(PotentialMergedWork(sierraWork, miroWork), otherWorks))
   }
 
   it("does not partition a single Sierra work") {

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/singlepagemiro/SierraMiroPartitionerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/singlepagemiro/SierraMiroPartitionerTest.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.merger.rules.singlepagemiro
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
-import uk.ac.wellcome.platform.merger.rules.Partition
+import uk.ac.wellcome.platform.merger.rules.{Partition, PotentialMergedWork}
 
 class SierraMiroPartitionerTest
     extends FunSpec
@@ -17,20 +17,20 @@ class SierraMiroPartitionerTest
   it("partitions a sierra and miro work") {
     val result = partitioner.partitionWorks(Seq(sierraWork, miroWork))
 
-    result shouldBe Some(Partition(sierraWork, miroWork, Nil))
+    result shouldBe Some(Partition(PotentialMergedWork(sierraWork, miroWork), Nil))
   }
 
   it("partitions a Sierra and Miro work, order in sequence") {
     val result = partitioner.partitionWorks(Seq(miroWork, sierraWork))
 
-    result shouldBe Some(Partition(sierraWork, miroWork, Nil))
+    result shouldBe Some(Partition(PotentialMergedWork(sierraWork, miroWork), Nil))
   }
 
   it("partitions a Sierra, Miro and other works") {
     val result =
       partitioner.partitionWorks(Seq(sierraWork, miroWork) ++ otherWorks)
 
-    result shouldBe Some(Partition(sierraWork, miroWork, otherWorks))
+    result shouldBe Some(Partition(PotentialMergedWork(sierraWork, miroWork), otherWorks))
   }
 
   it("does not partition a single Sierra work") {


### PR DESCRIPTION
Updates the `Partition` case class to better describe what it represents, and abstracts away common partitioner functionality into a `WorkTagPartitioner` trait