### PR TITLE
add default to _queryType param

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/QueryParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/QueryParams.scala
@@ -88,7 +88,7 @@ case class MultipleWorksParams(
       license
     ).flatten
 
-  private def dateFilter =
+  private def dateFilter: Option[DateRangeFilter] =
     (`production.dates.from`, `production.dates.to`) match {
       case (None, None)       => None
       case (dateFrom, dateTo) => Some(DateRangeFilter(dateFrom, dateTo))
@@ -173,7 +173,8 @@ object MultipleWorksParams extends QueryParamsUtils {
     )
 
   implicit val _queryTypeDecoder: Decoder[SearchQueryType] =
-    decodeOneOf(
+    decodeOneWithDefaultOf(
+      SearchQueryType.default,
       "scoringTiers" -> SearchQueryType.ScoringTiers
     )
 }
@@ -218,6 +219,9 @@ trait QueryParamsUtils extends Directives with TimeInstances {
         .map(Right(_))
         .getOrElse(Left(invalidValuesMsg(List(str), values.map(_._1).toList)))
     }
+
+  def decodeOneWithDefaultOf[T](default: T, values: (String, T)*): Decoder[T] =
+    Decoder.decodeString.map { values.toMap.getOrElse(_, default) }
 
   def decodeOneOfCommaSeperated[T](values: (String, T)*): Decoder[List[T]] =
     decodeCommaSeperated.emap { strs =>

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2ErrorsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2ErrorsTest.scala
@@ -98,4 +98,24 @@ class ApiV2ErrorsTest extends ApiV2WorksTestBase with ApiErrorsTestBase {
       )
     }
   }
+
+  // This is expected as it's transient parameter that will have valid values changing over time
+  // And if there is a client with a deprecated value, we wouldn't want it to fail
+  describe("returns a 200 for invalid values in the ?_queryType parameter") {
+    it("200s despite being a unknown value") {
+      withApi {
+        case (_, routes) =>
+          assertJsonResponse(
+            routes,
+            s"/$apiPrefix/works?_queryType=athingwewouldneverusebutmightbecausewesaidwewouldnot") {
+            Status.OK -> s"""
+            {
+              ${resultList(apiPrefix, totalResults = 0, totalPages = 0)},
+              "results": []
+            }
+          """
+          }
+      }
+    }
+  }
 }


### PR DESCRIPTION
We need to be able to allow invalid value through as the client might have an older version of the paramters that are valid, and we wouldn't want to error.

This is a transient every changing value that isn't documented so this hopefully is expected behaviour.