### PR TITLE
Allow merging of a mets work with a digital sierra work

### DIFF
--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/sierramets/SierraMetsWorkPairMerger.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/sierramets/SierraMetsWorkPairMerger.scala
@@ -1,6 +1,15 @@
 package uk.ac.wellcome.platform.merger.rules.sierramets
 
-import uk.ac.wellcome.models.work.internal.{DigitalLocation, IdentifiableRedirect, Item, MaybeDisplayable, TransformedBaseWork, Unidentifiable, UnidentifiedRedirectedWork, UnidentifiedWork}
+import uk.ac.wellcome.models.work.internal.{
+  DigitalLocation,
+  IdentifiableRedirect,
+  Item,
+  MaybeDisplayable,
+  TransformedBaseWork,
+  Unidentifiable,
+  UnidentifiedRedirectedWork,
+  UnidentifiedWork
+}
 import uk.ac.wellcome.platform.merger.model.MergedWork
 import uk.ac.wellcome.platform.merger.rules.{MergerRule, WorkPairMerger}
 
@@ -21,9 +30,7 @@ trait SierraMetsWorkPairMerger extends WorkPairMerger {
     sierraWork: UnidentifiedWork,
     metsWork: TransformedBaseWork): Option[MergedWork] = {
     (sierraWork.data.items, metsWork.data.items) match {
-      case (
-          List(sierraItem),
-          List(metsItem: Unidentifiable[Item])) =>
+      case (List(sierraItem), List(metsItem: Unidentifiable[Item])) =>
         metsItem.agent.locations match {
           case List(metsLocation: DigitalLocation) =>
             val targetWork = sierraWork.withData(data =>

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/sierramets/SierraMetsWorkPairMerger.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/sierramets/SierraMetsWorkPairMerger.scala
@@ -1,15 +1,6 @@
 package uk.ac.wellcome.platform.merger.rules.sierramets
 
-import uk.ac.wellcome.models.work.internal.{
-  DigitalLocation,
-  Identifiable,
-  IdentifiableRedirect,
-  Item,
-  TransformedBaseWork,
-  Unidentifiable,
-  UnidentifiedRedirectedWork,
-  UnidentifiedWork
-}
+import uk.ac.wellcome.models.work.internal.{DigitalLocation, IdentifiableRedirect, Item, MaybeDisplayable, TransformedBaseWork, Unidentifiable, UnidentifiedRedirectedWork, UnidentifiedWork}
 import uk.ac.wellcome.platform.merger.model.MergedWork
 import uk.ac.wellcome.platform.merger.rules.{MergerRule, WorkPairMerger}
 
@@ -31,7 +22,7 @@ trait SierraMetsWorkPairMerger extends WorkPairMerger {
     metsWork: TransformedBaseWork): Option[MergedWork] = {
     (sierraWork.data.items, metsWork.data.items) match {
       case (
-          List(sierraItem: Identifiable[Item]),
+          List(sierraItem),
           List(metsItem: Unidentifiable[Item])) =>
         metsItem.agent.locations match {
           case List(metsLocation: DigitalLocation) =>
@@ -48,7 +39,7 @@ trait SierraMetsWorkPairMerger extends WorkPairMerger {
     }
   }
 
-  private def mergeLocations(sierraItem: Identifiable[Item],
+  private def mergeLocations(sierraItem: MaybeDisplayable[Item],
                              metsLocation: DigitalLocation) = {
     sierraItem.withAgent(item => {
       val filteredLocations = item.locations.filter {

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/sierramets/SierraMetsWorkPairMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/sierramets/SierraMetsWorkPairMergerTest.scala
@@ -124,7 +124,8 @@ class SierraMetsWorkPairMergerTest
     val sierraWork = createSierraDigitalWork
     val result = workPairMerger.mergeAndRedirectWorkPair(sierraWork, metsWork)
 
-    val digitalItem = sierraWork.data.items.head.asInstanceOf[Unidentifiable[Item]]
+    val digitalItem =
+      sierraWork.data.items.head.asInstanceOf[Unidentifiable[Item]]
 
     val metsLocation = metsWork.data.items.head.agent.locations.head
     val expectedItems = List(
@@ -133,14 +134,14 @@ class SierraMetsWorkPairMergerTest
 
     inside(result) {
       case Some(
-      MergedWork(
-      UnidentifiedWork(
-      sierraWork.version,
-      sierraWork.sourceIdentifier,
-      data,
-      sierraWork.ontologyType,
-      sierraWork.identifiedType),
-      redirectedWork)) =>
+          MergedWork(
+            UnidentifiedWork(
+              sierraWork.version,
+              sierraWork.sourceIdentifier,
+              data,
+              sierraWork.ontologyType,
+              sierraWork.identifiedType),
+            redirectedWork)) =>
         data shouldBe sierraWork.data.copy(items = expectedItems)
 
         redirectedWork shouldBe UnidentifiedRedirectedWork(

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/sierramets/SierraMetsWorkPairMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/sierramets/SierraMetsWorkPairMergerTest.scala
@@ -16,7 +16,7 @@ class SierraMetsWorkPairMergerTest
 
   val workPairMerger = new SierraMetsWorkPairMerger {}
 
-  it("merges a Sierra and a Mets work") {
+  it("merges a physical Sierra and a Mets work") {
     val result = workPairMerger.mergeAndRedirectWorkPair(sierraWork, metsWork)
 
     val physicalItem: Identifiable[Item] =
@@ -120,6 +120,36 @@ class SierraMetsWorkPairMergerTest
     }
   }
 
+  it("merges a digital Sierra and a Mets work") {
+    val sierraWork = createSierraDigitalWork
+    val result = workPairMerger.mergeAndRedirectWorkPair(sierraWork, metsWork)
+
+    val digitalItem = sierraWork.data.items.head.asInstanceOf[Unidentifiable[Item]]
+
+    val metsLocation = metsWork.data.items.head.agent.locations.head
+    val expectedItems = List(
+      digitalItem.copy(agent = digitalItem.agent.copy(
+        locations = digitalItem.agent.locations :+ metsLocation)))
+
+    inside(result) {
+      case Some(
+      MergedWork(
+      UnidentifiedWork(
+      sierraWork.version,
+      sierraWork.sourceIdentifier,
+      data,
+      sierraWork.ontologyType,
+      sierraWork.identifiedType),
+      redirectedWork)) =>
+        data shouldBe sierraWork.data.copy(items = expectedItems)
+
+        redirectedWork shouldBe UnidentifiedRedirectedWork(
+          sourceIdentifier = metsWork.sourceIdentifier,
+          version = metsWork.version,
+          redirect = IdentifiableRedirect(sierraWork.sourceIdentifier))
+    }
+  }
+
   it("doesn't merge if the sierra work has more than one item") {
     val sierraWorkWithMultipleItems = createUnidentifiedSierraWorkWith(
       items = List(createPhysicalItem, createPhysicalItem)
@@ -127,16 +157,6 @@ class SierraMetsWorkPairMergerTest
 
     workPairMerger.mergeAndRedirectWorkPair(
       sierraWorkWithMultipleItems,
-      metsWork) shouldBe None
-  }
-
-  it("doesn't merge if the sierra work has an unidentifiable item") {
-    val sierraWorkWithUnidentifiableItems = createUnidentifiedSierraWorkWith(
-      items = List(createUnidentifiableItemWith(List(createPhysicalLocation)))
-    )
-
-    workPairMerger.mergeAndRedirectWorkPair(
-      sierraWorkWithUnidentifiableItems,
       metsWork) shouldBe None
   }
 


### PR DESCRIPTION
[`sierra-system-number/b30246039`](https://api.wellcomecollection.org/catalogue/v2/works/w5kf38vx?include=identifiers,items) is a Sierra work with an item with a `DigitalLocation` pointing at the iiif-presentation api. Currently, the merger doesn't merge it with `mets/b30246039` because it's restricting on the type of Item it allows on the target Sierra work.

This PR relaxes this restriction so that we can merge digital works as well as physical works with mets works