### PR TITLE
METS thumbnail

### DIFF
--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/parsers/MetsXmlParser.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/parsers/MetsXmlParser.scala
@@ -17,10 +17,12 @@ object MetsXmlParser {
     for {
       id <- recordIdentifier(root)
       maybeAccessCondition <- accessCondition(root)
+      thumbnailUrl <- thumbnailUrl(root)
     } yield
       Mets(
         recordIdentifier = id,
         accessCondition = maybeAccessCondition,
+        thumbnailUrl = thumbnailUrl,
       )
   }
 
@@ -48,4 +50,7 @@ object MetsXmlParser {
           new Exception("Found multiple accessCondtions in METS XML"))
     }
   }
+
+  private def thumbnailUrl(root: Elem): Either[Exception, Option[String]] =
+    Right(None)
 }

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/parsers/MetsXmlParser.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/parsers/MetsXmlParser.scala
@@ -51,6 +51,10 @@ object MetsXmlParser {
     }
   }
 
+  /** Here we use the first defined item in the physicalStructMap to lookup a
+    *  file ID the fileObjects mapping, and use the files location as the
+    *  thumbnail image.
+    */
   private def thumbnailLocation(root: Elem): Option[String] =
     physicalStructMap(root).headOption
       .flatMap {
@@ -59,6 +63,25 @@ object MetsXmlParser {
       }
       .map(_.stripPrefix("objects/"))
 
+  /** The METS XML contains locations of associated files, contained in a
+    *  mapping with the following format:
+    *
+    *  <mets:fileSec>
+    *    <mets:fileGrp USE="OBJECTS">
+    *      <mets:file ID="FILE_0001_OBJECTS" MIMETYPE="image/jp2">
+    *        <mets:FLocat LOCTYPE="URL" xlink:href="objects/b30246039_0001.jp2" />
+    *      </mets:file>
+    *      <mets:file ID="FILE_0002_OBJECTS" MIMETYPE="image/jp2">
+    *        <mets:FLocat LOCTYPE="URL" xlink:href="objects/b30246039_0002.jp2" />
+    *      </mets:file>
+    *    </mets:fileGrp>
+    *  </mets:fileSec>
+    *
+    *  For this input we would expect the following output:
+    *
+    *  Map("FILE_0001_OBJECTS" -> "objects/b30246039_0001.jp2",
+    *      "FILE_0002_OBJECTS" -> "objects/b30246039_0002.jp2")
+    */
   private def fileObjects(root: Elem): Map[String, String] =
     (root \ "fileSec" \ "fileGrp")
       .filterByAttribute("USE", "OBJECTS")
@@ -69,6 +92,28 @@ object MetsXmlParser {
         valueAttrib = "{http://www.w3.org/1999/xlink}href"
       )
 
+  /** Valid METS documents should contain a physicalStructMap section, with the
+    *  bottom most divs each representing a physical page, and linking to files
+    *  in the corresponding fileSec structures:
+    *
+    *  <mets:structMap TYPE="PHYSICAL">
+    *    <mets:div DMDID="DMDPHYS_0000" ID="PHYS_0000" TYPE="physSequence">
+    *      <mets:div ADMID="AMD_0001" ID="PHYS_0001" ORDER="1" TYPE="page">
+    *        <mets:fptr FILEID="FILE_0001_OBJECTS" />
+    *        <mets:fptr FILEID="FILE_0001_ALTO" />
+    *      </mets:div>
+    *      <mets:div ADMID="AMD_0002" ID="PHYS_0002" ORDER="2" TYPE="page">
+    *        <mets:fptr FILEID="FILE_0002_OBJECTS" />
+    *        <mets:fptr FILEID="FILE_0002_ALTO" />
+    *      </mets:div>
+    *    </mets:div>
+    *  </mets:structMap>
+    *
+    *  For this input we would expect the following output:
+    *
+    *  Map("PHYS_0001" -> "FILE_0001_OBJECTS",
+    *      "PHYS_0002" -> "FILE_0002_OBJECTS")
+    */
   private def physicalStructMap(root: Elem): ListMap[String, String] =
     (root \ "structMap")
       .filterByAttribute("TYPE", "PHYSICAL")

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/parsers/MetsXmlParser.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/parsers/MetsXmlParser.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.transformer.mets.parsers
 
 import scala.collection.immutable.ListMap
 import scala.util.Try
-import scala.xml.{Elem, XML, NodeSeq}
+import scala.xml.{Elem, NodeSeq, XML}
 
 import uk.ac.wellcome.platform.transformer.mets.transformer.Mets
 

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/parsers/MetsXmlParser.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/parsers/MetsXmlParser.scala
@@ -70,7 +70,8 @@ object MetsXmlParser {
         (id, location)
       }
       .collect {
-        case (id, Some(location)) if location.nonEmpty => (id, location)
+        case (id, Some(location)) if id.nonEmpty && location.nonEmpty =>
+          (id, location)
       }
       .toMap
 
@@ -85,7 +86,8 @@ object MetsXmlParser {
           (id, fileId)
         }
         .collect {
-          case (id, Some(fileId)) if fileId.nonEmpty => (id, fileId)
+          case (id, Some(fileId)) if id.nonEmpty && fileId.nonEmpty =>
+            (id, fileId)
         }
     ListMap(physicalMappings: _*)
   }

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/parsers/MetsXmlParser.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/parsers/MetsXmlParser.scala
@@ -52,23 +52,20 @@ object MetsXmlParser {
   }
 
   private def thumbnailLocation(root: Elem): Option[String] =
-    physicalStructMap(root)
-      .headOption
-      .flatMap { case (_, fileId) =>
-        fileObjects(root).get(fileId)
+    physicalStructMap(root).headOption
+      .flatMap {
+        case (_, fileId) =>
+          fileObjects(root).get(fileId)
       }
       .map(_.stripPrefix("objects/"))
 
   private def fileObjects(root: Elem): Map[String, String] =
-    (root \ "fileSec" \ "fileGrp")
-      .toList
+    (root \ "fileSec" \ "fileGrp").toList
       .filter(_ \@ "USE" == "OBJECTS")
       .flatMap(_ \ "file")
       .map { node =>
         val id = node \@ "ID"
-        val location = (node  \ "FLocat")
-          .toList
-          .headOption
+        val location = (node \ "FLocat").toList.headOption
           .map(_ \@ "{http://www.w3.org/1999/xlink}href")
         (id, location)
       }
@@ -79,8 +76,7 @@ object MetsXmlParser {
 
   private def physicalStructMap(root: Elem): ListMap[String, String] = {
     val physicalMappings =
-      (root \ "structMap")
-        .toList
+      (root \ "structMap").toList
         .filter(_ \@ "TYPE" == "PHYSICAL")
         .flatMap(_ \\ "div")
         .map { node =>
@@ -91,6 +87,6 @@ object MetsXmlParser {
         .collect {
           case (id, Some(fileId)) if fileId.nonEmpty => (id, fileId)
         }
-    ListMap(physicalMappings:_*)
+    ListMap(physicalMappings: _*)
   }
 }

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/Mets.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/Mets.scala
@@ -8,9 +8,9 @@ import cats.implicits._
 case class Mets(
   recordIdentifier: String,
   accessCondition: Option[String],
-  thumbnailUrl: Option[String] = None
+  thumbnailLocation: Option[String] = None
 ) {
-
+  
   def toWork(version: Int): Either[Throwable, UnidentifiedInvisibleWork] =
     for {
       maybeDigitalLocation <- digitalLocation
@@ -61,12 +61,14 @@ case class Mets(
       ontologyType = "Work",
       value = recordIdentifier)
   }
-  
+
+  private val thumbnailHeight = "200"
+
   private def thumbnail =
-    thumbnailUrl.map { url =>
+    thumbnailLocation.map { location =>
       DigitalLocation(
-        url = url,
-        locationType = LocationType("thumbnail-image"),
+        s"https://dlcs.io/iiif-img/wellcome/5/$location/full/,$thumbnailHeight/0/default.jpg",
+        LocationType("thumbnail-image"),
       )
     }
 }

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/Mets.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/Mets.scala
@@ -7,7 +7,8 @@ import cats.implicits._
 
 case class Mets(
   recordIdentifier: String,
-  accessCondition: Option[String]
+  accessCondition: Option[String],
+  thumbnailUrl: Option[String] = None
 ) {
 
   def toWork(version: Int): Either[Throwable, UnidentifiedInvisibleWork] =
@@ -25,7 +26,9 @@ case class Mets(
   private def workData(unidentifiableItem: MaybeDisplayable[Item]) =
     WorkData(
       items = List(unidentifiableItem),
-      mergeCandidates = List(mergeCandidate))
+      mergeCandidates = List(mergeCandidate),
+      thumbnail = thumbnail,
+    )
 
   private def mergeCandidate = MergeCandidate(
     identifier = SourceIdentifier(
@@ -40,11 +43,10 @@ case class Mets(
     val url = s"https://wellcomelibrary.org/iiif/$recordIdentifier/manifest"
     for {
       maybeLicense <- parseLicense
-    } yield
-      (DigitalLocation(
+    } yield DigitalLocation(
         url,
         LocationType("iiif-presentation"),
-        license = maybeLicense))
+        license = maybeLicense)
   }
 
   private def parseLicense = {
@@ -59,4 +61,12 @@ case class Mets(
       ontologyType = "Work",
       value = recordIdentifier)
   }
+  
+  private def thumbnail =
+    thumbnailUrl.map { url =>
+      DigitalLocation(
+        url = url,
+        locationType = LocationType("thumbnail-image"),
+      )
+    }
 }

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/Mets.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/Mets.scala
@@ -63,12 +63,12 @@ case class Mets(
       value = recordIdentifier)
   }
 
-  private val thumbnailHeight = "200"
+  private val thumbnailDim = "200"
 
   private def thumbnail =
     thumbnailLocation.map { location =>
       DigitalLocation(
-        s"https://dlcs.io/iiif-img/wellcome/5/$location/full/,$thumbnailHeight/0/default.jpg",
+        s"https://dlcs.io/iiif-img/wellcome/5/$location/full/!$thumbnailDim,$thumbnailDim/0/default.jpg",
         LocationType("thumbnail-image"),
       )
     }

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/Mets.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/Mets.scala
@@ -10,7 +10,7 @@ case class Mets(
   accessCondition: Option[String],
   thumbnailLocation: Option[String] = None
 ) {
-  
+
   def toWork(version: Int): Either[Throwable, UnidentifiedInvisibleWork] =
     for {
       maybeDigitalLocation <- digitalLocation
@@ -43,7 +43,8 @@ case class Mets(
     val url = s"https://wellcomelibrary.org/iiif/$recordIdentifier/manifest"
     for {
       maybeLicense <- parseLicense
-    } yield DigitalLocation(
+    } yield
+      DigitalLocation(
         url,
         LocationType("iiif-presentation"),
         license = maybeLicense)

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/parsers/MetsXmlParserTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/parsers/MetsXmlParserTest.scala
@@ -38,6 +38,10 @@ class MetsXmlParserTest extends FunSpec with Matchers {
       "b30246039_0001.jp2")
   }
 
+  it("cannot parse thumbnail when invalid file ID") {
+    MetsXmlParser(xmlInvalidFileId).right.get.thumbnailLocation shouldBe None
+  }
+
   def xml =
     IOUtils.toString(getClass.getResourceAsStream("/b30246039.xml"), "UTF-8")
 
@@ -92,5 +96,46 @@ class MetsXmlParserTest extends FunSpec with Matchers {
           </mets:xmlData>
         </mets:mdWrap>
       </mets:dmdSec>
+    </mets:mets>
+
+  def xmlInvalidFileId =
+    <mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:mods="http://www.loc.gov/mods/v3">
+      <mets:dmdSec ID="DMDLOG_0000">
+        <mets:mdWrap MDTYPE="MODS">
+          <mets:xmlData>
+            <mods:mods>
+              <mods:recordInfo>
+                <mods:recordIdentifier source="gbv-ppn">b30246039</mods:recordIdentifier>
+              </mods:recordInfo>
+            </mods:mods>
+          </mets:xmlData>
+        </mets:mdWrap>
+      </mets:dmdSec>
+      <mets:fileSec>
+        <mets:fileGrp USE="OBJECTS">
+          <mets:file ID="FILE_0001_OBJECTS" MIMETYPE="image/jp2">
+            <mets:FLocat LOCTYPE="URL" xlink:href="objects/b30246039_0001.jp2" />
+          </mets:file>
+          <mets:file ID="FILE_0002_OBJECTS" MIMETYPE="image/jp2">
+            <mets:FLocat LOCTYPE="URL" xlink:href="objects/b30246039_0002.jp2" />
+          </mets:file>
+        </mets:fileGrp>
+        <mets:fileGrp USE="ALTO">
+          <mets:file ID="FILE_0001_ALTO" MIMETYPE="application/xml">
+            <mets:FLocat LOCTYPE="URL" xlink:href="alto/b30246039_0001.xml" />
+          </mets:file>
+        </mets:fileGrp>
+      </mets:fileSec>
+      <mets:structMap TYPE="PHYSICAL">
+        <mets:div DMDID="DMDPHYS_0000" ID="PHYS_0000" TYPE="physSequence">
+          <mets:div ADMID="AMD_0001" ID="PHYS_0001" ORDER="1" ORDERLABEL=" - " TYPE="page">
+            <mets:fptr FILEID="OOPS" />
+            <mets:fptr FILEID="FILE_0001_ALTO" />
+          </mets:div>
+          <mets:div ADMID="AMD_0002" ID="PHYS_0002" ORDER="2" ORDERLABEL=" - " TYPE="page">
+            <mets:fptr FILEID="FILE_0002_OBJECTS" />
+          </mets:div>
+        </mets:div>
+      </mets:structMap>
     </mets:mets>
 }

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/parsers/MetsXmlParserTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/parsers/MetsXmlParserTest.scala
@@ -34,7 +34,8 @@ class MetsXmlParserTest extends FunSpec with Matchers {
   }
 
   it("parses thumbnail from XML") {
-    MetsXmlParser(xml).right.get.thumbnailLocation shouldBe Some("b30246039_0001.jp2")
+    MetsXmlParser(xml).right.get.thumbnailLocation shouldBe Some(
+      "b30246039_0001.jp2")
   }
 
   def xml =

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/parsers/MetsXmlParserTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/parsers/MetsXmlParserTest.scala
@@ -43,70 +43,54 @@ class MetsXmlParserTest extends FunSpec with Matchers {
 
   def xmlNodmdSec =
     <mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:mods="http://www.loc.gov/mods/v3">
-         <mods:recordIdentifier source="gbv-ppn">b30246039</mods:recordIdentifier>
-       </mets:mets>.toString()
+       <mods:recordIdentifier source="gbv-ppn">b30246039</mods:recordIdentifier>
+     </mets:mets>
 
   def xmlMultipleIds =
     <mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:mods="http://www.loc.gov/mods/v3">
-         <mets:dmdSec ID="DMDLOG_0000">
-           <mets:mdWrap MDTYPE="MODS">
-             <mets:xmlData>
-               <mods:mods>
-                 <mods:recordInfo>
-                   <mods:recordIdentifier source="gbv-ppn">b30246039</mods:recordIdentifier>
-                   <mods:recordIdentifier source="gbv-ppn">b3024346567</mods:recordIdentifier>
-                 </mods:recordInfo>
-               </mods:mods>
-             </mets:xmlData>
-           </mets:mdWrap>
-         </mets:dmdSec>
-       </mets:mets>.toString()
+      <mets:dmdSec ID="DMDLOG_0000">
+        <mets:mdWrap MDTYPE="MODS">
+          <mets:xmlData>
+            <mods:mods>
+              <mods:recordInfo>
+                <mods:recordIdentifier source="gbv-ppn">b30246039</mods:recordIdentifier>
+                <mods:recordIdentifier source="gbv-ppn">b3024346567</mods:recordIdentifier>
+              </mods:recordInfo>
+            </mods:mods>
+          </mets:xmlData>
+        </mets:mdWrap>
+      </mets:dmdSec>
+    </mets:mets>
 
   def xmlNoLicense =
     <mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:mods="http://www.loc.gov/mods/v3">
-       <mets:dmdSec ID="DMDLOG_0000">
-         <mets:mdWrap MDTYPE="MODS">
-           <mets:xmlData>
-             <mods:mods>
-               <mods:recordInfo>
-                 <mods:recordIdentifier source="gbv-ppn">b30246039</mods:recordIdentifier>
-               </mods:recordInfo>
-             </mods:mods>
-           </mets:xmlData>
-         </mets:mdWrap>
-       </mets:dmdSec>
-       </mets:mets>.toString()
+      <mets:dmdSec ID="DMDLOG_0000">
+        <mets:mdWrap MDTYPE="MODS">
+          <mets:xmlData>
+            <mods:mods>
+              <mods:recordInfo>
+                <mods:recordIdentifier source="gbv-ppn">b30246039</mods:recordIdentifier>
+              </mods:recordInfo>
+            </mods:mods>
+          </mets:xmlData>
+        </mets:mdWrap>
+      </mets:dmdSec>
+    </mets:mets>
 
   def xmlMultipleLicense =
     <mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:mods="http://www.loc.gov/mods/v3">
-         <mets:dmdSec ID="DMDLOG_0000">
-           <mets:mdWrap MDTYPE="MODS">
-             <mets:xmlData>
-               <mods:mods>
-                 <mods:recordInfo>
-                   <mods:recordIdentifier source="gbv-ppn">b30246039</mods:recordIdentifier>
-                 </mods:recordInfo>
-                 <mods:accessCondition type="dz">CC-BY-NC</mods:accessCondition>
-                 <mods:accessCondition type="dz">CC-BY</mods:accessCondition>
-               </mods:mods>
-             </mets:xmlData>
-           </mets:mdWrap>
-         </mets:dmdSec>
-       </mets:mets>.toString()
-
-  def xmlThumbnail =
-    <mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:mods="http://www.loc.gov/mods/v3">
-         <mets:dmdSec ID="DMDLOG_0000">
-           <mets:mdWrap MDTYPE="MODS">
-             <mets:xmlData>
-               <mods:mods>
-                 <mods:recordInfo>
-                   <mods:recordIdentifier source="gbv-ppn">b30246039</mods:recordIdentifier>
-                   <mods:recordIdentifier source="gbv-ppn">b3024346567</mods:recordIdentifier>
-                 </mods:recordInfo>
-               </mods:mods>
-             </mets:xmlData>
-           </mets:mdWrap>
-         </mets:dmdSec>
-       </mets:mets>.toString()
+      <mets:dmdSec ID="DMDLOG_0000">
+        <mets:mdWrap MDTYPE="MODS">
+          <mets:xmlData>
+            <mods:mods>
+              <mods:recordInfo>
+                <mods:recordIdentifier source="gbv-ppn">b30246039</mods:recordIdentifier>
+              </mods:recordInfo>
+              <mods:accessCondition type="dz">CC-BY-NC</mods:accessCondition>
+              <mods:accessCondition type="dz">CC-BY</mods:accessCondition>
+            </mods:mods>
+          </mets:xmlData>
+        </mets:mdWrap>
+      </mets:dmdSec>
+    </mets:mets>
 }

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/parsers/MetsXmlParserTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/parsers/MetsXmlParserTest.scala
@@ -33,6 +33,10 @@ class MetsXmlParserTest extends FunSpec with Matchers {
     MetsXmlParser("hagdf") shouldBe a[Left[_, _]]
   }
 
+  it("parses thumbnail from XML") {
+    MetsXmlParser(xml).right.get.thumbnailLocation shouldBe Some("b30246039_0001.jp2")
+  }
+
   def xml =
     IOUtils.toString(getClass.getResourceAsStream("/b30246039.xml"), "UTF-8")
 
@@ -89,4 +93,19 @@ class MetsXmlParserTest extends FunSpec with Matchers {
          </mets:dmdSec>
        </mets:mets>.toString()
 
+  def xmlThumbnail =
+    <mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:mods="http://www.loc.gov/mods/v3">
+         <mets:dmdSec ID="DMDLOG_0000">
+           <mets:mdWrap MDTYPE="MODS">
+             <mets:xmlData>
+               <mods:mods>
+                 <mods:recordInfo>
+                   <mods:recordIdentifier source="gbv-ppn">b30246039</mods:recordIdentifier>
+                   <mods:recordIdentifier source="gbv-ppn">b3024346567</mods:recordIdentifier>
+                 </mods:recordInfo>
+               </mods:mods>
+             </mets:xmlData>
+           </mets:mdWrap>
+         </mets:dmdSec>
+       </mets:mets>.toString()
 }

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsTest.scala
@@ -97,7 +97,7 @@ class MetsTest extends FunSpec with RandomStrings with Matchers {
     result shouldBe a[Right[_, _]]
     result.right.get.data.thumbnail shouldBe Some(
       DigitalLocation(
-        s"https://dlcs.io/iiif-img/wellcome/5/location.png/full/,200/0/default.jpg",
+        s"https://dlcs.io/iiif-img/wellcome/5/location.png/full/!200,200/0/default.jpg",
         LocationType("thumbnail-image")
       )
     )

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsTest.scala
@@ -88,17 +88,18 @@ class MetsTest extends FunSpec with RandomStrings with Matchers {
   }
 
   it("creates a invisible work with a thumbnail location") {
-    val bNumber = randomAlphanumeric(10)
-    val url = "https://path.to/thumbnail.png"
     val metsData = Mets(
-        recordIdentifier = bNumber,
+        recordIdentifier = randomAlphanumeric(10),
         accessCondition = Some("CC-BY-NC"),
-        thumbnailUrl = Some(url)
+        thumbnailLocation = Some("location.png")
     )
     val result = metsData.toWork(1)
     result shouldBe a[Right[_, _]]
     result.right.get.data.thumbnail shouldBe Some(
-      DigitalLocation(url, LocationType("thumbnail-image"))
+      DigitalLocation(
+        s"https://dlcs.io/iiif-img/wellcome/5/location.png/full/,200/0/default.jpg",
+        LocationType("thumbnail-image")
+      )
     )
   }
 }

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsTest.scala
@@ -87,4 +87,18 @@ class MetsTest extends FunSpec with RandomStrings with Matchers {
 
   }
 
+  it("creates a invisible work with a thumbnail location") {
+    val bNumber = randomAlphanumeric(10)
+    val url = "https://path.to/thumbnail.png"
+    val metsData = Mets(
+        recordIdentifier = bNumber,
+        accessCondition = Some("CC-BY-NC"),
+        thumbnailUrl = Some(url)
+    )
+    val result = metsData.toWork(1)
+    result shouldBe a[Right[_, _]]
+    result.right.get.data.thumbnail shouldBe Some(
+      DigitalLocation(url, LocationType("thumbnail-image"))
+    )
+  }
 }

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsTest.scala
@@ -89,9 +89,9 @@ class MetsTest extends FunSpec with RandomStrings with Matchers {
 
   it("creates a invisible work with a thumbnail location") {
     val metsData = Mets(
-        recordIdentifier = randomAlphanumeric(10),
-        accessCondition = Some("CC-BY-NC"),
-        thumbnailLocation = Some("location.png")
+      recordIdentifier = randomAlphanumeric(10),
+      accessCondition = Some("CC-BY-NC"),
+      thumbnailLocation = Some("location.png")
     )
     val result = metsData.toWork(1)
     result shouldBe a[Right[_, _]]


### PR DESCRIPTION
## Issue

https://github.com/wellcometrust/platform/issues/3945

## Description

Parse the thumbnail location from the METS XML.

NOTE: We are using the first item in the physical struct map to extract a thumbnail location. I am not sure that this is the correct thing to do, and it may be more correct to additionally make use of the logical struct map. However it is not clear to me from looking the the METS structure [here](https://github.com/wellcometrust/catalogue/blob/master/pipeline/transformer/transformer_mets/src/test/resources/b30246039.xml) how exactly that would work..