### PR TITLE
Use `ORDER` attribute for retrieving first physical thumbnail

### DIFF
--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/parsers/MetsXmlParser.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/parsers/MetsXmlParser.scala
@@ -153,6 +153,7 @@ object MetsXmlParser {
     (root \ "structMap")
       .filterByAttribute("TYPE", "PHYSICAL")
       .descendentsWithTag("div")
+      .sortByAttribute("ORDER")
       .toMapping(
         keyAttrib = "ID",
         valueNode = "fptr",
@@ -169,6 +170,9 @@ object MetsXmlParser {
 
     def descendentsWithTag(tag: String) =
       nodes.flatMap(_ \\ tag)
+
+    def sortByAttribute(attrib: String) =
+      nodes.sortBy(_ \@ attrib)
 
     def toMapping(keyAttrib: String, valueNode: String, valueAttrib: String) = {
       val mappings = nodes

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/parsers/MetsXmlParser.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/parsers/MetsXmlParser.scala
@@ -38,7 +38,7 @@ object MetsXmlParser {
     *          </mods:recordInfo>
     *        </mod:mods>
     *      </mets:xmlData>
-    *    </mets:mdWrap> 
+    *    </mets:mdWrap>
     *  </mets:dmdSec>
     *
     *  The expected output would be: "b30246039"

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/parsers/MetsXmlParser.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/parsers/MetsXmlParser.scala
@@ -185,6 +185,7 @@ object MetsXmlParser {
           case (key, Some(value)) if key.nonEmpty && value.nonEmpty =>
             (key, value)
         }
+      // Return a ListMap here over standard Map to preserve ordering
       ListMap(mappings: _*)
     }
   }

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/parsers/MetsXmlParser.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/parsers/MetsXmlParser.scala
@@ -26,6 +26,23 @@ object MetsXmlParser {
       )
   }
 
+  /** The record identifier (generally the B number) is encoded in the METS. For
+    *  example:
+    *
+    *  <mets:dmdSec ID="DMDLOG_0000">
+    *    <mets:mdWrap MDTYPE="MODS">
+    *      <mets:xmlData>
+    *        <mods:mods>
+    *          <mods:recordInfo>
+    *            <mods:recordIdentifier source="gbv-ppn">b30246039</mods:recordIdentifier>
+    *          </mods:recordInfo>
+    *        </mod:mods>
+    *      </mets:xmlData>
+    *    </mets:mdWrap> 
+    *  </mets:dmdSec>
+    *
+    *  The expected output would be: "b30246039"
+    */
   private def recordIdentifier(root: Elem): Either[Exception, String] = {
     val identifierNodes =
       (root \\ "dmdSec" \ "mdWrap" \\ "recordInfo" \ "recordIdentifier").toList
@@ -37,6 +54,24 @@ object MetsXmlParser {
     }
   }
 
+  /** We are interested with the access condition with type `dz`. For example:
+    *
+    *  <mets:dmdSec ID="DMDLOG_0000">
+    *    <mets:mdWrap MDTYPE="MODS">
+    *      <mets:xmlData>
+    *        <mods:mods>
+    *          ...
+    *          <mods:accessCondition type="dz">CC-BY-NC</mods:accessCondition>
+    *          <mods:accessCondition type="player">63</mods:accessCondition>
+    *          <mods:accessCondition type="status">Open</mods:accessCondition>
+    *          ...
+    *        </mods:mods>
+    *      </mets:xmlData>
+    *    </mets:mdWrap>
+    *  </mets:dmdSec>
+    *
+    *  The expected output would be: "CC-BY-NC"
+    */
   private def accessCondition(root: Elem): Either[Exception, Option[String]] = {
     val licenseNodes = (root \\ "dmdSec" \ "mdWrap" \\ "accessCondition")
       .filterByAttribute("type", "dz")

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/parsers/MetsXmlParserTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/parsers/MetsXmlParserTest.scala
@@ -2,6 +2,7 @@ package uk.ac.wellcome.platform.transformer.mets.parsers
 
 import org.apache.commons.io.IOUtils
 import org.scalatest.{FunSpec, Matchers}
+import scala.xml.Elem
 
 class MetsXmlParserTest extends FunSpec with Matchers {
 
@@ -35,6 +36,16 @@ class MetsXmlParserTest extends FunSpec with Matchers {
 
   it("parses thumbnail from XML") {
     MetsXmlParser(xml).right.get.thumbnailLocation shouldBe Some(
+      "b30246039_0001.jp2")
+  }
+
+  it("parses first thumbnail when no ORDER attribute") {
+    MetsXmlParser(xmlNoOrderAttrib).right.get.thumbnailLocation shouldBe Some(
+      "b30246039_0001.jp2")
+  }
+
+  it("parses thumbnail using ORDER attrib when non-sequential order") {
+    MetsXmlParser(xmlNonSequentialOrder).right.get.thumbnailLocation shouldBe Some(
       "b30246039_0001.jp2")
   }
 
@@ -98,8 +109,8 @@ class MetsXmlParserTest extends FunSpec with Matchers {
       </mets:dmdSec>
     </mets:mets>
 
-  def xmlInvalidFileId =
-    <mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:mods="http://www.loc.gov/mods/v3">
+  def xmlWithThumbnailImages(structMap: Elem) =
+    <mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:mods="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink">
       <mets:dmdSec ID="DMDLOG_0000">
         <mets:mdWrap MDTYPE="MODS">
           <mets:xmlData>
@@ -126,16 +137,51 @@ class MetsXmlParserTest extends FunSpec with Matchers {
           </mets:file>
         </mets:fileGrp>
       </mets:fileSec>
+      {structMap}
+    </mets:mets>
+
+  def xmlNoOrderAttrib =
+    xmlWithThumbnailImages {
       <mets:structMap TYPE="PHYSICAL">
         <mets:div DMDID="DMDPHYS_0000" ID="PHYS_0000" TYPE="physSequence">
-          <mets:div ADMID="AMD_0001" ID="PHYS_0001" ORDER="1" ORDERLABEL=" - " TYPE="page">
-            <mets:fptr FILEID="OOPS" />
+          <mets:div ADMID="AMD_0001" ID="PHYS_0001" TYPE="page">
+            <mets:fptr FILEID="FILE_0001_OBJECTS" />
             <mets:fptr FILEID="FILE_0001_ALTO" />
           </mets:div>
-          <mets:div ADMID="AMD_0002" ID="PHYS_0002" ORDER="2" ORDERLABEL=" - " TYPE="page">
+          <mets:div ADMID="AMD_0002" ID="PHYS_0002" TYPE="page">
             <mets:fptr FILEID="FILE_0002_OBJECTS" />
           </mets:div>
         </mets:div>
       </mets:structMap>
-    </mets:mets>
+    }
+
+  def xmlNonSequentialOrder =
+    xmlWithThumbnailImages {
+      <mets:structMap TYPE="PHYSICAL">
+        <mets:div DMDID="DMDPHYS_0000" ID="PHYS_0000" TYPE="physSequence">
+          <mets:div ADMID="AMD_0002" ID="PHYS_0002" ORDER="2" TYPE="page">
+            <mets:fptr FILEID="FILE_0002_OBJECTS" />
+          </mets:div>
+          <mets:div ADMID="AMD_0001" ID="PHYS_0001" ORDER="1" TYPE="page">
+            <mets:fptr FILEID="FILE_0001_OBJECTS" />
+            <mets:fptr FILEID="FILE_0001_ALTO" />
+          </mets:div>
+        </mets:div>
+      </mets:structMap>
+    }
+
+  def xmlInvalidFileId =
+    xmlWithThumbnailImages {
+      <mets:structMap TYPE="PHYSICAL">
+        <mets:div DMDID="DMDPHYS_0000" ID="PHYS_0000" TYPE="physSequence">
+          <mets:div ADMID="AMD_0001" ID="PHYS_0001" ORDER="1" TYPE="page">
+            <mets:fptr FILEID="OOPS" />
+            <mets:fptr FILEID="FILE_0001_ALTO" />
+          </mets:div>
+          <mets:div ADMID="AMD_0002" ID="PHYS_0002" ORDER="2" TYPE="page">
+            <mets:fptr FILEID="FILE_0002_OBJECTS" />
+          </mets:div>
+        </mets:div>
+      </mets:structMap>
+    }
 }


### PR DESCRIPTION
## Issue

https://github.com/wellcometrust/platform/issues/3945

## Description

If present we should  use the `ORDER` attribute in the physical `structMap` to retrieve the first thumbnail.