### PR TITLE
Merge METS thumbnail onto Sierra work

### DIFF
--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/sierramets/SierraMetsWorkPairMerger.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/sierramets/SierraMetsWorkPairMerger.scala
@@ -33,8 +33,12 @@ trait SierraMetsWorkPairMerger extends WorkPairMerger {
       case (List(sierraItem), List(metsItem: Unidentifiable[Item])) =>
         metsItem.agent.locations match {
           case List(metsLocation: DigitalLocation) =>
-            val targetWork = sierraWork.withData(data =>
-              data.copy(items = List(mergeLocations(sierraItem, metsLocation))))
+            val targetWork = sierraWork.withData { data =>
+              data.copy(
+                items = List(mergeLocations(sierraItem, metsLocation)),
+                thumbnail = metsWork.data.thumbnail.map(Some(_)).getOrElse(data.thumbnail)
+              )
+            }
             val redirectedWork = UnidentifiedRedirectedWork(
               metsWork.sourceIdentifier,
               metsWork.version,

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/sierramets/SierraMetsWorkPairMerger.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/sierramets/SierraMetsWorkPairMerger.scala
@@ -1,15 +1,6 @@
 package uk.ac.wellcome.platform.merger.rules.sierramets
 
-import uk.ac.wellcome.models.work.internal.{
-  DigitalLocation,
-  IdentifiableRedirect,
-  Item,
-  MaybeDisplayable,
-  TransformedBaseWork,
-  Unidentifiable,
-  UnidentifiedRedirectedWork,
-  UnidentifiedWork
-}
+import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.merger.model.MergedWork
 import uk.ac.wellcome.platform.merger.rules.{MergerRule, WorkPairMerger}
 
@@ -28,7 +19,7 @@ import uk.ac.wellcome.platform.merger.rules.{MergerRule, WorkPairMerger}
 trait SierraMetsWorkPairMerger extends WorkPairMerger {
   override def mergeAndRedirectWorkPair(
     sierraWork: UnidentifiedWork,
-    metsWork: TransformedBaseWork): Option[MergedWork] = {
+    metsWork: TransformedBaseWork): Option[MergedWork] =
     (sierraWork.data.items, metsWork.data.items) match {
       case (List(sierraItem), List(metsItem: Unidentifiable[Item])) =>
         metsItem.agent.locations match {
@@ -48,18 +39,24 @@ trait SierraMetsWorkPairMerger extends WorkPairMerger {
         }
       case _ => None
     }
-  }
 
   private def mergeLocations(sierraItem: MaybeDisplayable[Item],
-                             metsLocation: DigitalLocation) = {
-    sierraItem.withAgent(item => {
-      val filteredLocations = item.locations.filter {
-        case l: DigitalLocation if l.url.equals(metsLocation.url) => false
-        case _                                                    => true
-      }
-      item.copy(locations = filteredLocations :+ metsLocation)
-    })
-  }
+                             metsLocation: DigitalLocation) =
+    sierraItem.withAgent { item =>
+      item.copy(
+        locations =
+          item.locations.filterNot(shouldIgnoreLocation(_, metsLocation.url))
+          :+ metsLocation
+      )
+    }
+
+  private def shouldIgnoreLocation(location: Location, metsUrl: String) =
+    location match {
+      case DigitalLocation(url, LocationType("iiif-image", _, _), _, _, _) =>
+        true
+      case DigitalLocation(url, _, _, _, _) if url.equals(metsUrl) => true
+      case _ => false
+    }
 }
 
 object SierraMetsMergerRule

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/sierramets/SierraMetsWorkPairMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/sierramets/SierraMetsWorkPairMergerTest.scala
@@ -151,6 +151,30 @@ class SierraMetsWorkPairMergerTest
     }
   }
 
+  it("merges a digital Sierra and a Mets work using the Mets thumbnail") {
+    val thumbnail =  DigitalLocation(
+      url = "https://path.to/thumbnail.jpg",
+      locationType = LocationType("thumbnail-image"),
+      license = Some(License_CCBY)
+    )
+    val sierraWork = createSierraDigitalWork
+    val metsWork = createUnidentifiedInvisibleMetsWork withData { data =>
+      data.copy(thumbnail = Some(thumbnail))
+    }
+    inside(workPairMerger.mergeAndRedirectWorkPair(sierraWork, metsWork)) {
+      case Some(
+          MergedWork(
+            UnidentifiedWork(
+              sierraWork.version,
+              sierraWork.sourceIdentifier,
+              data,
+              sierraWork.ontologyType,
+              sierraWork.identifiedType),
+            redirectedWork)) =>
+        data.thumbnail shouldBe Some(thumbnail)
+    }
+  }
+
   it("doesn't merge if the sierra work has more than one item") {
     val sierraWorkWithMultipleItems = createUnidentifiedSierraWorkWith(
       items = List(createPhysicalItem, createPhysicalItem)

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
@@ -17,16 +17,16 @@ class MergerTest extends FunSpec with WorksGenerators with Matchers {
     createUnidentifiedInvisibleMetsWorkWith(
       items = List(createDigitalItemWith(List(digitalLocationCCBYNC)))
     ).withData { data =>
-        data.copy(
-          thumbnail = Some(
-            DigitalLocation(
-              url = "https://path.to/thumbnail.jpg",
-              locationType = LocationType("thumbnail-image"),
-              license = Some(License_CCBY)
-            )
+      data.copy(
+        thumbnail = Some(
+          DigitalLocation(
+            url = "https://path.to/thumbnail.jpg",
+            locationType = LocationType("thumbnail-image"),
+            license = Some(License_CCBY)
           )
         )
-      }
+      )
+    }
 
   private val merger = PlatformMerger
 

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
@@ -16,18 +16,17 @@ class MergerTest extends FunSpec with WorksGenerators with Matchers {
   private val metsWork =
     createUnidentifiedInvisibleMetsWorkWith(
       items = List(createDigitalItemWith(List(digitalLocationCCBYNC)))
-    )
-    .withData { data =>
-      data.copy(
-        thumbnail = Some(
-          DigitalLocation(
-            url = "https://path.to/thumbnail.jpg",
-            locationType = LocationType("thumbnail-image"),
-            license = Some(License_CCBY)
+    ).withData { data =>
+        data.copy(
+          thumbnail = Some(
+            DigitalLocation(
+              url = "https://path.to/thumbnail.jpg",
+              locationType = LocationType("thumbnail-image"),
+              license = Some(License_CCBY)
+            )
           )
         )
-      )
-    }
+      }
 
   private val merger = PlatformMerger
 

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
@@ -13,8 +13,21 @@ class MergerTest extends FunSpec with WorksGenerators with Matchers {
   private val sierraDigitalWork = createSierraDigitalWorkWith(
     items = List(createDigitalItemWith(List(digitalLocationNoLicense))))
   private val miroWork = createMiroWork
-  private val metsWork = createUnidentifiedInvisibleMetsWorkWith(
-    items = List(createDigitalItemWith(List(digitalLocationCCBYNC))))
+  private val metsWork =
+    createUnidentifiedInvisibleMetsWorkWith(
+      items = List(createDigitalItemWith(List(digitalLocationCCBYNC)))
+    )
+    .withData { data =>
+      data.copy(
+        thumbnail = Some(
+          DigitalLocation(
+            url = "https://path.to/thumbnail.jpg",
+            locationType = LocationType("thumbnail-image"),
+            license = Some(License_CCBY)
+          )
+        )
+      )
+    }
 
   private val merger = PlatformMerger
 
@@ -196,7 +209,8 @@ class MergerTest extends FunSpec with WorksGenerators with Matchers {
               locations = physicalItem.agent.locations ++ digitalItem.agent.locations
             )
           )
-        )
+        ),
+        thumbnail = metsWork.data.thumbnail,
       )
     }
 
@@ -222,17 +236,16 @@ class MergerTest extends FunSpec with WorksGenerators with Matchers {
 
     val sierraItem =
       sierraPhysicalWork.data.items.head.asInstanceOf[Identifiable[Item]]
-    val miroItem = miroWork.data.items.head
     val metsItem = metsWork.data.items.head
 
     val expectedMergedWork = sierraPhysicalWork.withData { data =>
       data.copy(
         otherIdentifiers = sierraPhysicalWork.data.otherIdentifiers ++ sierraDigitalWork.identifiers ++ miroWork.identifiers,
-        thumbnail = miroWork.data.thumbnail,
+        thumbnail = metsWork.data.thumbnail,
         items = List(
           sierraItem.copy(
             agent = sierraItem.agent.copy(
-              locations = sierraItem.agent.locations ++ miroItem.agent.locations ++ metsItem.agent.locations
+              locations = sierraItem.agent.locations ++ metsItem.agent.locations
             )
           )
         ),


### PR DESCRIPTION
### Issue

https://github.com/wellcometrust/platform/issues/4097

### Description

Update the merger rules so that it the METS thumbnail is used if present. Also we remove any miro locations if present when a METS merge is applied.