### PR TITLE
use MUST for basequery in scoring tiers

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchQueryBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchQueryBuilder.scala
@@ -122,11 +122,13 @@ final case class ScoringTiersQuery(q: String) extends ElasticsearchQuery {
     `type` = Some(MultiMatchQueryBuilderType.CROSS_FIELDS)
   )
 
-  lazy val elasticQuery = BoolQuery(
-    should = Seq(
+  lazy val elasticQuery = bool(
+    shouldQueries = Seq(
       ConstantScore(query = TitleQuery(q).elasticQuery, boost = Some(2000)),
       ConstantScore(query = GenreQuery(q).elasticQuery, boost = Some(1000)),
-      ConstantScore(query = SubjectQuery(q).elasticQuery, boost = Some(1000)),
-      baseQuery
-    ))
+      ConstantScore(query = SubjectQuery(q).elasticQuery, boost = Some(1000))
+    ),
+    mustQueries = Seq(baseQuery),
+    notQueries = Seq()
+  )
 }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchSearchQueryTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchSearchQueryTest.scala
@@ -64,8 +64,8 @@ class ElasticsearchQueryTest
               title = Some(s"subjected $subject"),
               subjects = List(createSubjectWithConcept(subject)))
         }
-
-        insertIntoElasticsearch(index, titledWorks ++ subjectedWorks: _*)
+        val insertedWorks = titledWorks ++ subjectedWorks
+        insertIntoElasticsearch(index, insertedWorks: _*)
 
         val results =
           searchResults(
@@ -73,6 +73,11 @@ class ElasticsearchQueryTest
             queryOptions = createElasticsearchQueryOptionsWith(
               searchQuery = Some(
                 SearchQuery("Gray's anatomy", SearchQueryType.ScoringTiers))))
+
+        withClue(
+          "a MUST query is used on the base query so as not to match everything") {
+          (results.size < insertedWorks.size) should be(true)
+        }
 
         withClue("the exact title should be first") {
           results.head should be(getWorkWithId("Gray's anatomy.", results))


### PR DESCRIPTION
We shouldn't SHOULD match the base query, else we have no MUST matches, and match everything.