### PR TITLE
Send multiple XML file locations from mets_adapter

### DIFF
--- a/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/Main.scala
+++ b/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/Main.scala
@@ -19,9 +19,8 @@ import uk.ac.wellcome.mets_adapter.services.{
   MetsStore,
   TokenService,
 }
-import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.store.dynamo.DynamoSingleVersionStore
-import uk.ac.wellcome.storage.typesafe.{S3Builder, DynamoBuilder}
+import uk.ac.wellcome.storage.typesafe.DynamoBuilder
 
 object Main extends WellcomeTypesafeApp {
   runWithConfig { config: Config =>
@@ -31,8 +30,6 @@ object Main extends WellcomeTypesafeApp {
       AkkaBuilder.buildActorSystem()
     implicit val materializer: ActorMaterializer =
       AkkaBuilder.buildActorMaterializer()
-    implicit val s3Client =
-      S3Builder.buildS3Client(config)
     implicit val dynamoClilent: AmazonDynamoDB =
       DynamoBuilder.buildDynamoClient(config)
 
@@ -40,7 +37,6 @@ object Main extends WellcomeTypesafeApp {
       SQSBuilder.buildSQSStream(config),
       SNSBuilder.buildSNSMessageSender(config, subject = "METS adapter"),
       buildBagRetriever(config),
-      S3TypedStore[String],
       buildMetsStore(config),
     )
   }

--- a/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/models/Bag.scala
+++ b/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/models/Bag.scala
@@ -1,11 +1,7 @@
 package uk.ac.wellcome.mets_adapter.models
 
-case class IngestUpdate(context: IngestUpdateContext)
-
-case class IngestUpdateContext(storageSpace: String, externalIdentifier: String)
-
-case class MetsData(bucket: String, path: String, version: Int)
-
+/** The response receiveved from the storage-service bag API.
+  */
 case class Bag(info: BagInfo,
                manifest: BagManifest,
                location: BagLocation,

--- a/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/models/Bag.scala
+++ b/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/models/Bag.scala
@@ -24,6 +24,8 @@ case class Bag(info: BagInfo,
   // XML file in data directory named with some b-number.
   private val metsFileRegex = "^data/b[0-9]{7}[0-9x].xml$".r
 
+  // A bag can contain number of manifestations, generally named the same as the
+  // main METS file followed by an underscore and it's (zero-padded) index.
   private val manifestationRegex = "^data/b[0-9]{7}[0-9x]_\\w+.xml$".r
 
   private val versionRegex = "^v([0-9]+)".r

--- a/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/models/Bag.scala
+++ b/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/models/Bag.scala
@@ -28,7 +28,7 @@ case class Bag(info: BagInfo,
 
   private val versionRegex = "^v([0-9]+)".r
 
-  private def file: Either[Exception, String] =
+  def file: Either[Exception, String] =
     manifest.files
       .collectFirst {
         case file if metsFileRegex.findFirstIn(file.name).nonEmpty =>
@@ -36,14 +36,14 @@ case class Bag(info: BagInfo,
       }
       .getOrElse(Left(new Exception("Couldn't find METS file")))
 
-  private def manifestations: List[String] =
+  def manifestations: List[String] =
     manifest.files
       .collect {
         case file if manifestationRegex.findFirstIn(file.name).nonEmpty =>
           file.path
       }
 
-  private def parsedVersion: Either[Exception, Int] =
+  def parsedVersion: Either[Exception, Int] =
     version match {
       case versionRegex(num) => Right(num.toInt)
       case _                 => Left(new Exception("Couldn't parse version"))

--- a/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/models/IngestUpdate.scala
+++ b/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/models/IngestUpdate.scala
@@ -1,0 +1,8 @@
+package uk.ac.wellcome.mets_adapter.models
+
+/** Represents an update received over SQS from the storage-service upon ingest
+  *  of some data.
+  */
+case class IngestUpdate(context: IngestUpdateContext)
+
+case class IngestUpdateContext(storageSpace: String, externalIdentifier: String)

--- a/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/models/MetsData.scala
+++ b/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/models/MetsData.scala
@@ -1,0 +1,5 @@
+package uk.ac.wellcome.mets_adapter.models
+
+/** METS data to send onwards to the transformer.
+  */
+case class MetsData(bucket: String, path: String, version: Int)

--- a/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/models/MetsData.scala
+++ b/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/models/MetsData.scala
@@ -2,4 +2,8 @@ package uk.ac.wellcome.mets_adapter.models
 
 /** METS data to send onwards to the transformer.
   */
-case class MetsData(bucket: String, path: String, version: Int)
+case class MetsData(bucket: String,
+                    path: String,
+                    version: Int,
+                    file: String,
+                    manifestations: List[String])

--- a/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/models/MetsData.scala
+++ b/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/models/MetsData.scala
@@ -6,4 +6,4 @@ case class MetsData(bucket: String,
                     path: String,
                     version: Int,
                     file: String,
-                    manifestations: List[String])
+                    manifestations: List[String] = Nil)

--- a/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/services/MetsAdapterWorkerService.scala
+++ b/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/services/MetsAdapterWorkerService.scala
@@ -11,8 +11,7 @@ import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSMessageSender}
 import uk.ac.wellcome.typesafe.Runnable
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.mets_adapter.models._
-import uk.ac.wellcome.storage.{ObjectLocation, Version}
-import uk.ac.wellcome.storage.store.TypedStore
+import uk.ac.wellcome.storage.Version
 
 import scala.concurrent.Future
 
@@ -30,7 +29,6 @@ class MetsAdapterWorkerService(
   msgStream: SQSStream[NotificationMessage],
   msgSender: SNSMessageSender,
   bagRetriever: BagRetriever,
-  xmlStore: TypedStore[ObjectLocation, String],
   metsStore: MetsStore,
   concurrentHttpConnections: Int = 6,
   concurrentDynamoConnections: Int = 4)(implicit ec: ExecutionContext)
@@ -94,7 +92,7 @@ class MetsAdapterWorkerService(
       .mapWithContextAsync(concurrentDynamoConnections) {
         case (ctx, data) =>
           Future {
-            metsStore.storeMetsData(Version(ctx.bagId, data.version), data)
+            metsStore.storeData(Version(ctx.bagId, data.version), data)
           }
       }
 

--- a/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/services/MetsStore.scala
+++ b/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/services/MetsStore.scala
@@ -2,34 +2,22 @@ package uk.ac.wellcome.mets_adapter.services
 
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.storage.VersionAlreadyExistsError
-import uk.ac.wellcome.storage.store.{HybridStoreEntry, VersionedStore}
+import uk.ac.wellcome.storage.store.VersionedStore
 import uk.ac.wellcome.storage.{Identified, Version}
-import uk.ac.wellcome.bigmessaging.EmptyMetadata
+import uk.ac.wellcome.mets_adapter.models.MetsData
 
-class MetsStore(
-  store: VersionedStore[String, Int, HybridStoreEntry[String, EmptyMetadata]])
+class MetsStore(store: VersionedStore[String, Int, MetsData])
     extends Logging {
 
-  def storeXml(key: Version[String, Int],
-               xml: String): Either[Throwable, Version[String, Int]] =
+  def storeMetsData(key: Version[String, Int],
+                    data: MetsData): Either[Throwable, Version[String, Int]] =
     store
-      .put(key)(HybridStoreEntry(xml, EmptyMetadata()))
-      .right
+      .put(key)(data)
       .map { case Identified(key, _) => key }
-      .left
-      .flatMap {
+      .left.flatMap {
         case VersionAlreadyExistsError(_) =>
-          warn(s"$key already exists in VHS so re-publishing")
+          warn(s"$key already exists in store so re-publishing")
           Right(key)
         case err => Left(err.e)
       }
-}
-
-object MetsStore {
-
-  def apply(
-    store: VersionedStore[String,
-                          Int,
-                          HybridStoreEntry[String, EmptyMetadata]]) =
-    new MetsStore(store)
 }

--- a/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/services/MetsStore.scala
+++ b/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/services/MetsStore.scala
@@ -9,8 +9,8 @@ import uk.ac.wellcome.mets_adapter.models.MetsData
 class MetsStore(store: VersionedStore[String, Int, MetsData])
     extends Logging {
 
-  def storeMetsData(key: Version[String, Int],
-                    data: MetsData): Either[Throwable, Version[String, Int]] =
+  def storeData(key: Version[String, Int],
+                data: MetsData): Either[Throwable, Version[String, Int]] =
     store
       .put(key)(data)
       .map { case Identified(key, _) => key }

--- a/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/services/MetsStore.scala
+++ b/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/services/MetsStore.scala
@@ -6,15 +6,15 @@ import uk.ac.wellcome.storage.store.VersionedStore
 import uk.ac.wellcome.storage.{Identified, Version}
 import uk.ac.wellcome.mets_adapter.models.MetsData
 
-class MetsStore(store: VersionedStore[String, Int, MetsData])
-    extends Logging {
+class MetsStore(store: VersionedStore[String, Int, MetsData]) extends Logging {
 
   def storeData(key: Version[String, Int],
                 data: MetsData): Either[Throwable, Version[String, Int]] =
     store
       .put(key)(data)
       .map { case Identified(key, _) => key }
-      .left.flatMap {
+      .left
+      .flatMap {
         case VersionAlreadyExistsError(_) =>
           warn(s"$key already exists in store so re-publishing")
           Right(key)

--- a/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/models/BagTest.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/models/BagTest.scala
@@ -80,8 +80,9 @@ class BagTest extends FunSpec with Matchers {
           "data/b30246039_0002.xml" -> "v1/data/b30246039_0002.xml",
         )
       )
-      bag.manifestations shouldBe List("v1/data/b30246039_0001.xml",
-                                       "v1/data/b30246039_0002.xml")
+      bag.manifestations shouldBe List(
+        "v1/data/b30246039_0001.xml",
+        "v1/data/b30246039_0002.xml")
     }
   }
 

--- a/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/models/BagTest.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/models/BagTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.{FunSpec, Matchers}
 class BagTest extends FunSpec with Matchers {
 
   describe("METS path") {
-    it("parses METS path from Bag") {
+    it("parses METS file from Bag") {
       val bag = createBag(
         s3Path = "digitised/b30246039",
         files = List(
@@ -14,10 +14,10 @@ class BagTest extends FunSpec with Matchers {
           "data/alto/b30246039_0002.xml" -> "v1/data/alto/b30246039_0002.xml",
         )
       )
-      bag.metsPath shouldBe Some("digitised/b30246039/v1/data/b30246039.xml")
+      bag.file shouldBe Some("digitised/b30246039/v1/data/b30246039.xml")
     }
 
-    it("parses METS path from Bag when not first file") {
+    it("parses METS file from Bag when not first file") {
       val bag = createBag(
         s3Path = "digitised/b30246039",
         files = List(
@@ -26,31 +26,31 @@ class BagTest extends FunSpec with Matchers {
           "data/alto/b30246039_0002.xml" -> "v1/data/alto/b30246039_0002.xml",
         )
       )
-      bag.metsPath shouldBe Some("digitised/b30246039/v1/data/b30246039.xml")
+      bag.file shouldBe Some("digitised/b30246039/v1/data/b30246039.xml")
     }
 
-    it("parses METS path from Bag when b-number ending with x") {
+    it("parses METS file from Bag when b-number ending with x") {
       val bag = createBag(
         s3Path = "digitised/b3024603x",
         files = List("data/b3024603x.xml" -> "v1/data/b3024603x.xml")
       )
-      bag.metsPath shouldBe Some("digitised/b3024603x/v1/data/b3024603x.xml")
+      bag.file shouldBe Some("digitised/b3024603x/v1/data/b3024603x.xml")
     }
 
-    it("doesn't parse METS path from Bag when name not prefixed with 'data/'") {
+    it("doesn't parse METS file from Bag when name not prefixed with 'data/'") {
       val bag = createBag(
         s3Path = "digitised/b30246039",
         files = List("b30246039.xml" -> "v1/data/b30246039.xml")
       )
-      bag.metsPath shouldBe None
+      bag.file shouldBe None
     }
 
-    it("doesn't parse METS path from Bag when name isn't XML'") {
+    it("doesn't parse METS file from Bag when name isn't XML'") {
       val bag = createBag(
         s3Path = "digitised/b30246039",
         files = List("data/b30246039.txt" -> "v1/data/b30246039.xml")
       )
-      bag.metsPath shouldBe None
+      bag.file shouldBe None
     }
   }
 
@@ -76,7 +76,7 @@ class BagTest extends FunSpec with Matchers {
         files = List("data/b30246039.xml" -> "v1/data/b30246039.xml"),
       )
       bag.metsData shouldBe Right(
-        MetsData("bucket", "digitised/b30246039/v1/data/b30246039.xml", 2))
+        MetsData("bucket", "digitised/b30246039", 2, "/v1/data/b30246039.xml"))
     }
 
     it("fails extracting METS data if invalid version string") {

--- a/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/MetsAdapterWorkerServiceTest.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/MetsAdapterWorkerServiceTest.scala
@@ -187,8 +187,8 @@ class MetsAdapterWorkerServiceTest
   def createStore(data: Map[Version[String, Int], String] = Map.empty) =
     MemoryVersionedStore(data.mapValues(metsData(_)))
 
-  def metsData(file: String = "new.file", version: Int = 1) =
-    MetsData("bucket", "path", version, file, Nil)
+  def metsData(file: String = "mets.xml", version: Int = 1) =
+    MetsData("bucket", "root", version, file, Nil)
 
   def getMessages(topic: SNS.Topic) =
     listMessagesReceivedFromSNS(topic)

--- a/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/MetsAdapterWorkerServiceTest.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/MetsAdapterWorkerServiceTest.scala
@@ -144,10 +144,10 @@ class MetsAdapterWorkerServiceTest
     }
   }
 
-  def withWorkerService[R](
-    bagRetriever: BagRetriever,
-    store: VersionedStore[String, Int, MetsData],
-    createMsgSender: SNS.Topic => SNSMessageSender = createMsgSender(_))(
+  def withWorkerService[R](bagRetriever: BagRetriever,
+                           store: VersionedStore[String, Int, MetsData],
+                           createMsgSender: SNS.Topic => SNSMessageSender =
+                             createMsgSender(_))(
     testWith: TestWith[(MetsAdapterWorkerService, QueuePair, SNS.Topic), R]) =
     withActorSystem { implicit actorSystem =>
       withLocalSnsTopic { topic =>

--- a/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/MetsStoreTest.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/MetsStoreTest.scala
@@ -4,54 +4,53 @@ import org.scalatest.{FunSpec, Matchers}
 
 import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
 import uk.ac.wellcome.storage.{Identified, Version}
-import uk.ac.wellcome.bigmessaging.EmptyMetadata
-import uk.ac.wellcome.storage.store.HybridStoreEntry
+import uk.ac.wellcome.mets_adapter.models.MetsData
 
 class MetsStoreTest extends FunSpec with Matchers {
 
   it("should store new METS data") {
     val internalStore = createInternalStore()
     val store = new MetsStore(internalStore)
-    store.storeXml(Version("001", 1), "NEW") shouldBe Right(Version("001", 1))
+    store.storeData(Version("001", 1), metsData("NEW")) shouldBe Right(Version("001", 1))
     internalStore.getLatest("001") shouldBe Right(
-      Identified(Version("001", 1), vhsEntry("NEW"))
+      Identified(Version("001", 1), metsData("NEW"))
     )
   }
 
   it("should update METS data when newer version") {
     val internalStore = createInternalStore(Version("001", 1) -> "OLD")
     val store = new MetsStore(internalStore)
-    store.storeXml(Version("001", 2), "NEW") shouldBe Right(Version("001", 2))
+    store.storeData(Version("001", 2), metsData("NEW")) shouldBe Right(Version("001", 2))
     internalStore.getLatest("001") shouldBe Right(
-      Identified(Version("001", 2), vhsEntry("NEW"))
+      Identified(Version("001", 2), metsData("NEW"))
     )
   }
 
   it("should not update METS data when current version") {
     val internalStore = createInternalStore(Version("001", 1) -> "OLD")
     val store = new MetsStore(internalStore)
-    store.storeXml(Version("001", 1), "NEW") shouldBe Right(Version("001", 1))
+    store.storeData(Version("001", 1), metsData("NEW")) shouldBe Right(Version("001", 1))
     internalStore.getLatest("001") shouldBe Right(
-      Identified(Version("001", 1), vhsEntry("OLD"))
+      Identified(Version("001", 1), metsData("OLD"))
     )
   }
 
   it("should error when inserting older version") {
     val internalStore = createInternalStore(Version("001", 2) -> "NEW")
     val store = new MetsStore(internalStore)
-    store.storeXml(Version("001", 1), "NEW") shouldBe a[Left[_, _]]
+    store.storeData(Version("001", 1), metsData("NEW")) shouldBe a[Left[_, _]]
     internalStore.getLatest("001") shouldBe Right(
-      Identified(Version("001", 2), vhsEntry("NEW"))
+      Identified(Version("001", 2), metsData("NEW"))
     )
   }
 
   def createInternalStore(data: (Version[String, Int], String)*) =
-    MemoryVersionedStore[String, HybridStoreEntry[String, EmptyMetadata]](
+    MemoryVersionedStore[String, MetsData](
       Map(
-        data.map { case (version, xml) => (version, vhsEntry(xml)) }: _*
+        data.map { case (version, file) => (version, metsData(file)) }: _*
       )
     )
 
-  def vhsEntry(xml: String) =
-    HybridStoreEntry(xml, EmptyMetadata())
+  def metsData(file: String = "NEW", version: Int = 1) =
+    MetsData("bucket", "path", version, file, Nil)
 }

--- a/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/MetsStoreTest.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/MetsStoreTest.scala
@@ -11,7 +11,8 @@ class MetsStoreTest extends FunSpec with Matchers {
   it("should store new METS data") {
     val internalStore = createInternalStore()
     val store = new MetsStore(internalStore)
-    store.storeData(Version("001", 1), metsData("NEW")) shouldBe Right(Version("001", 1))
+    store.storeData(Version("001", 1), metsData("NEW")) shouldBe Right(
+      Version("001", 1))
     internalStore.getLatest("001") shouldBe Right(
       Identified(Version("001", 1), metsData("NEW"))
     )
@@ -20,7 +21,8 @@ class MetsStoreTest extends FunSpec with Matchers {
   it("should update METS data when newer version") {
     val internalStore = createInternalStore(Version("001", 1) -> "OLD")
     val store = new MetsStore(internalStore)
-    store.storeData(Version("001", 2), metsData("NEW")) shouldBe Right(Version("001", 2))
+    store.storeData(Version("001", 2), metsData("NEW")) shouldBe Right(
+      Version("001", 2))
     internalStore.getLatest("001") shouldBe Right(
       Identified(Version("001", 2), metsData("NEW"))
     )
@@ -29,7 +31,8 @@ class MetsStoreTest extends FunSpec with Matchers {
   it("should not update METS data when current version") {
     val internalStore = createInternalStore(Version("001", 1) -> "OLD")
     val store = new MetsStore(internalStore)
-    store.storeData(Version("001", 1), metsData("NEW")) shouldBe Right(Version("001", 1))
+    store.storeData(Version("001", 1), metsData("NEW")) shouldBe Right(
+      Version("001", 1))
     internalStore.getLatest("001") shouldBe Right(
       Identified(Version("001", 1), metsData("OLD"))
     )


### PR DESCRIPTION
## Issue

https://github.com/wellcometrust/platform/issues/4082

## Description

We need to be able to send not just a single XML file from the adapter, but multiple in the case where there are additional manifestations.

Here we update the architecture so that we just store and send the locations of all relevant XML files, rather than storing an XML file in VHS.