### PR TITLE
Update METS adapter terraform for new architecture

### DIFF
--- a/infrastructure/critical/mets_store.tf
+++ b/infrastructure/critical/mets_store.tf
@@ -1,0 +1,49 @@
+
+resource "aws_dynamodb_table" "mets_adapter_table" {
+  name     = "mets-adapter-store"
+  hash_key = "id"
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+
+  billing_mode = "PAY_PER_REQUEST"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+data "aws_iam_policy_document" "mets_dynamo_full_access_policy" {
+  statement {
+    actions = [
+      "dynamodb:*",
+    ]
+
+    resources = [
+      "${aws_dynamodb_table.mets_adapter_table.arn}",
+
+      # Allow access to the GSIs on the table
+      "${aws_dynamodb_table.mets_adapter_table.arn}/*",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "mets_dynamo_read_policy" {
+  # This is based on the AmazonDynamoDBReadOnlyAccess
+  statement {
+    actions = [
+      "dynamodb:BatchGetItem",
+      "dynamodb:DescribeTable",
+      "dynamodb:GetItem",
+      "dynamodb:ListTables",
+      "dynamodb:Query",
+      "dynamodb:Scan",
+    ]
+
+    resources = [
+      "${aws_dynamodb_table.mets_adapter_table.arn}",
+    ]
+  }
+}

--- a/infrastructure/critical/outputs.tf
+++ b/infrastructure/critical/outputs.tf
@@ -53,26 +53,18 @@ output "vhs_sierra_assumable_read_role" {
   value = "${module.vhs_sierra.assumable_read_role}"
 }
 
-# Mets Hybrid Store
+# Mets Store
 
-output "vhs_mets_full_access_policy" {
-  value = "${module.vhs_mets.full_access_policy}"
+output "mets_dynamo_full_access_policy" {
+  value = "${data.aws_iam_policy_document.mets_dynamo_full_access_policy.json}"
 }
 
-output "vhs_mets_read_policy" {
-  value = "${module.vhs_mets.read_policy}"
+output "mets_dynamo_read_policy" {
+  value = "${data.aws_iam_policy_document.mets_dynamo_read_policy.json}"
 }
 
-output "vhs_mets_table_name" {
-  value = "${module.vhs_mets.table_name}"
-}
-
-output "vhs_mets_bucket_name" {
-  value = "${module.vhs_mets.bucket_name}"
-}
-
-output "vhs_mets_assumable_read_role" {
-  value = "${module.vhs_mets.assumable_read_role}"
+output "mets_dynamo_table_name" {
+  value = "${aws_dynamodb_table.mets_adapter_table.id}"
 }
 
 # Sierra Items Hybrid Store

--- a/infrastructure/critical/vhs_mets.tf
+++ b/infrastructure/critical/vhs_mets.tf
@@ -1,6 +1,0 @@
-module "vhs_mets" {
-  source = "./vhs"
-  name   = "mets"
-
-  read_principals = ["${local.read_principles}"]
-}

--- a/mets_adapter/mets_adapter/src/main/resources/application.conf
+++ b/mets_adapter/mets_adapter/src/main/resources/application.conf
@@ -1,9 +1,7 @@
 aws.sqs.queue.url=${?queue_id}
 aws.metrics.namespace=${?metrics_namespace}
 aws.sns.topic.arn=${?sns_arn}
-aws.vhs.dynamo.tableName=${?vhs_mets_adapter_dynamo_table_name}
-aws.vhs.s3.bucketName=${?vhs_mets_adapter_bucket_name}
-aws.vhs.s3.globalPrefix=mets_adapter
+aws.mets.dynamo.tableName=${?mets_adapter_dynamo_table}
 bags.api.url=${?bag_api_url}
 bags.oauth.url=${?oauth_url}
 bags.oauth.client_id=${?oauth_client_id}

--- a/mets_adapter/terraform/iam.tf
+++ b/mets_adapter/terraform/iam.tf
@@ -5,12 +5,12 @@ resource "aws_iam_role_policy" "read_from_q" {
 
 resource "aws_iam_role_policy" "publish_to_topic" {
   role = "${module.service.task_role_name}"
-  policy = "${module.mets_vhs_keys_topic.publish_policy}"
+  policy = "${module.mets_adapter_topic.publish_policy}"
 }
 
-resource "aws_iam_role_policy" "mets_adapter_vhs_readwrite" {
+resource "aws_iam_role_policy" "mets_adapter_dynamo_readwrite" {
   role   = "${module.service.task_role_name}"
-  policy = "${local.vhs_mets_full_access_policy}"
+  policy = "${local.mets_full_access_policy }"
 }
 
 resource "aws_iam_role_policy" "cloudwatch_push_metrics" {
@@ -27,20 +27,5 @@ data "aws_iam_policy_document" "allow_cloudwatch_push_metrics" {
     resources = [
       "*",
     ]
-  }
-}
-resource "aws_iam_role_policy" "storage_s3_read" {
-  role   = "${module.service.task_role_name}"
-  policy = "${data.aws_iam_policy_document.allow_storage_access.json}"
-}
-
-data "aws_iam_policy_document" "allow_storage_access" {
-  statement {
-    actions = [
-      "s3:GetObject*",
-      "s3:ListBucket",
-    ]
-
-    resources = ["arn:aws:s3:::${local.storage_bucket}", "arn:aws:s3:::${local.storage_bucket}/*"]
   }
 }

--- a/mets_adapter/terraform/locals.tf
+++ b/mets_adapter/terraform/locals.tf
@@ -7,12 +7,9 @@ locals {
  bag_api_url = "https://api.wellcomecollection.org/storage/v1/bags"
  oauth_url = "https://auth.wellcomecollection.org/oauth2/token"
 
- storage_bucket = "wellcomecollection-storage"
-
- # VHS
- vhs_mets_full_access_policy = "${data.terraform_remote_state.catalogue_infra_critical.vhs_mets_full_access_policy}"
- vhs_mets_adapter_table_name = "${data.terraform_remote_state.catalogue_infra_critical.vhs_mets_table_name}"
- vhs_mets_adapter_bucket_name = "${data.terraform_remote_state.catalogue_infra_critical.vhs_mets_bucket_name}"
+ # Store
+ mets_full_access_policy = "${data.terraform_remote_state.catalogue_infra_critical.mets_dynamo_full_access_policy}"
+ mets_adapter_table_name = "${data.terraform_remote_state.catalogue_infra_critical.mets_dynamo_table_name}"
 
  # Infra stuff
  infra_bucket = "${data.terraform_remote_state.shared_infra.infra_bucket}"

--- a/mets_adapter/terraform/outputs.tf
+++ b/mets_adapter/terraform/outputs.tf
@@ -1,3 +1,3 @@
-output "mets_vhs_keys_topic_name" {
-  value = "${module.mets_vhs_keys_topic.name}"
+output "mets_adapter_topic_name" {
+  value = "${module.mets_adapter_topic.name}"
 }

--- a/mets_adapter/terraform/service.tf
+++ b/mets_adapter/terraform/service.tf
@@ -24,17 +24,16 @@ module "service" {
   env_vars = {
     logstash_host = "${local.logstash_host}"
 
-    sns_arn              = "${module.mets_vhs_keys_topic.arn}"
+    sns_arn              = "${module.mets_adapter_topic.arn}"
     queue_id = "${module.queue.id}"
     metrics_namespace    = "${local.namespace}"
-    vhs_mets_adapter_dynamo_table_name = "${local.vhs_mets_adapter_table_name}"
-    vhs_mets_adapter_bucket_name       = "${local.vhs_mets_adapter_bucket_name}"
+    mets_adapter_dynamo_table = "${local.mets_adapter_table_name}"
 
     bag_api_url = "${local.bag_api_url}"
     oauth_url = "${local.oauth_url}"
   }
 
-  env_vars_length = 8
+  env_vars_length = 7
 
   secret_env_vars = {
     oauth_client_id     = "mets_adapter/mets_adapter/client_id"

--- a/mets_adapter/terraform/topics.tf
+++ b/mets_adapter/terraform/topics.tf
@@ -1,6 +1,6 @@
-module "mets_vhs_keys_topic" {
+module "mets_adapter_topic" {
   source                         = "git::https://github.com/wellcometrust/terraform.git//sns?ref=v19.13.2"
-  name                           = "mets_vhs_keys_topic"
+  name                           = "mets_adapter_topic"
 }
 
 // TODO: delete this when we get a topic from the storage service

--- a/pipeline/terraform/locals.tf
+++ b/pipeline/terraform/locals.tf
@@ -17,7 +17,7 @@ locals {
   vhs_mets_adapter_table_name  = "${data.terraform_remote_state.catalogue_infra_critical.vhs_mets_table_name}"
 
   # Mets adapter topics
-  mets_vhs_keys_topic_name = "${data.terraform_remote_state.mets_adapter.mets_vhs_keys_topic_name}"
+  mets_adapter_topic_name = "${data.terraform_remote_state.mets_adapter.mets_adapter_topic_name}"
 
   # Reindexer topics
   miro_reindexer_topic_name   = "${data.terraform_remote_state.shared_infra.catalogue_miro_reindex_topic_name}"

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -32,7 +32,7 @@ module "catalogue_pipeline_20191115" {
   miro_adapter_topic_count = "2"
 
   mets_adapter_topic_count = 1
-  mets_adapter_topic_names = ["${local.mets_vhs_keys_topic_name}"]
+  mets_adapter_topic_names = ["${local.mets_adapter_topic_name}"]
 
   # Elasticsearch
   es_works_index = "v2-20191115"


### PR DESCRIPTION
We are no longer using a VHS in the METS adapter, so here we update the terraform for use of the Dynamo store instead.

The METS transformer terraform will have to be updated to use this in future too.