### PR TITLE
Title field on item model

### DIFF
--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksIncludesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksIncludesTest.scala
@@ -91,7 +91,10 @@ class ApiV2WorksIncludesTest
     withApi {
       case (indexV2, routes) =>
         val work = createIdentifiedWorkWith(
-          items = createIdentifiedItems(count = 1) :+ createUnidentifiableItemWith()
+          items = List(
+            createIdentifiedItemWith(title = Some("item title")),
+            createUnidentifiableItemWith()
+          )
         )
 
         insertIntoElasticsearch(indexV2, work)

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayItemV2.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayItemV2.scala
@@ -20,14 +20,19 @@ case class DisplayItemV2(
       "Relates the item to a unique system-generated identifier that governs interaction between systems and is regarded as canonical within the Wellcome data ecosystem."
   ) identifiers: Option[List[DisplayIdentifierV2]] = None,
   @Schema(
+    readOnly = true,
+    description = "A human readable title."
+  ) title: Option[String] = None,
+  @Schema(
     description = "List of locations that provide access to the item"
   ) locations: List[DisplayLocationV2] = List(),
   @JsonKey("type") @Schema(name = "type") ontologyType: String = "Item"
 )
 
 object DisplayItemV2 {
+
   def apply(item: Displayable[Item],
-            includesIdentifiers: Boolean): DisplayItemV2 = {
+            includesIdentifiers: Boolean): DisplayItemV2 =
     item match {
       case identifiedItem: Identified[Item] =>
         DisplayItemV2(
@@ -36,19 +41,18 @@ object DisplayItemV2 {
             if (includesIdentifiers)
               Some(identifiedItem.identifiers.map { DisplayIdentifierV2(_) })
             else None,
-          locations = identifiedItem.agent.locations.map {
-            DisplayLocationV2(_)
-          }
+          title = identifiedItem.agent.title,
+          locations = displayLocations(identifiedItem.agent)
         )
       case unidentifiableItem: Unidentifiable[Item] =>
         DisplayItemV2(
           id = None,
           identifiers = None,
-          locations = unidentifiableItem.agent.locations.map {
-            DisplayLocationV2(_)
-          }
+          title = unidentifiableItem.agent.title,
+          locations = displayLocations(unidentifiableItem.agent)
         )
     }
 
-  }
+  private def displayLocations(item: Item) =
+    item.locations.map(DisplayLocationV2(_))
 }

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
@@ -42,24 +42,30 @@ trait DisplaySerialisationTestBase { this: Suite =>
       }
       .mkString(",")
 
-  def unidentifiableItem(it: Unidentifiable[Item]) = {
-    s"""{
-          "type": "${it.agent.ontologyType}",
-          "locations": [
-            ${locations(it.agent.locations)}
-          ]
-        }"""
-  }
+  def unidentifiableItem(it: Unidentifiable[Item]) =
+    s"""
+      {
+        "type": "${it.agent.ontologyType}",
+        ${itemTitle(it.agent)}
+        "locations": [${locations(it.agent.locations)}]
+      }
+    """
 
-  def identifiedItem(it: Identified[Item]) = {
-    s"""{
-          "id": "${it.canonicalId}",
-          "type": "${it.agent.ontologyType}",
-          "locations": [
-            ${locations(it.agent.locations)}
-          ]
-        }"""
-  }
+  def identifiedItem(it: Identified[Item]) =
+    s"""
+      {
+        "id": "${it.canonicalId}",
+        "type": "${it.agent.ontologyType}",
+        ${itemTitle(it.agent)}
+        "locations": [${locations(it.agent.locations)}]
+      }
+    """
+
+  def itemTitle(item: Item) =
+    item.title match {
+      case Some(title) => s""""title": "$title","""
+      case None        => ""
+    }
 
   def locations(locations: List[Location]) =
     locations

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayItemV2Test.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayItemV2Test.scala
@@ -69,4 +69,16 @@ class DisplayItemV2Test extends FunSpec with Matchers with ItemsGenerators {
 
     displayItemV2.locations shouldBe List()
   }
+
+  it("parses an identified Item with title") {
+    val title = Some("Nice item")
+    val item = createIdentifiedItemWith(title = title)
+
+    val displayItemV2 = DisplayItemV2(
+      item = item,
+      includesIdentifiers = true
+    )
+
+    displayItemV2.title shouldBe title
+  }
 }

--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndex.scala
@@ -117,7 +117,11 @@ object WorksIndex {
     sourceIdentifier,
     otherIdentifiers,
     keywordField("type"),
-    objectField("agent").fields(location(), keywordField("ontologyType"))
+    objectField("agent").fields(
+      location(),
+      englishTextField("title"),
+      keywordField("ontologyType")
+    )
   )
 
   def englishTextField(name: String) =

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Item.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Item.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.models.work.internal
 
 case class Item(
-  locations: List[Location],
+  title: Option[String] = None,
+  locations: List[Location] = Nil,
   ontologyType: String = "Item"
 )

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ItemsGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ItemsGenerators.scala
@@ -7,13 +7,14 @@ trait ItemsGenerators extends IdentifiersGenerators {
     canonicalId: String = createCanonicalId,
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
     otherIdentifiers: List[SourceIdentifier] = Nil,
-    locations: List[Location] = List(defaultLocation)
+    locations: List[Location] = List(defaultLocation),
+    title: Option[String] = None,
   ): Identified[Item] =
     Identified(
       canonicalId = canonicalId,
       sourceIdentifier = sourceIdentifier,
       otherIdentifiers = otherIdentifiers,
-      agent = Item(locations = locations)
+      agent = Item(locations = locations, title = title)
     )
 
   def createIdentifiedItem: Identified[Item] = createIdentifiedItemWith()

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroRecordTransformerTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroRecordTransformerTest.scala
@@ -279,7 +279,9 @@ class MiroRecordTransformerTest
       LocationType("iiif-image"),
       Some(License_CCBY),
       None)
-    work.data.items shouldBe List(Unidentifiable(Item(List(expectedLocation))))
+    work.data.items shouldBe List(
+      Unidentifiable(Item(locations = List(expectedLocation)))
+    )
   }
 
   it("sets the WorkType as 'Digital Images'") {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraQueryOps.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraQueryOps.scala
@@ -31,7 +31,7 @@ trait SierraQueryOps {
           tags.indexOf(varfield.marcTag.get)
         }
 
-    def withTags(tag: String): List[VarField] = withTags(tag)
+    def withTag(tag: String): List[VarField] = withTags(tag)
 
     def withIndicator1(ind: String): List[VarField] =
       varfields.filter(_.indicator1 == Some(ind))

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsTest.scala
@@ -8,7 +8,8 @@ import uk.ac.wellcome.models.transformable.sierra.{
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.sierra.source.{
   SierraBibData,
-  SierraItemData
+  SierraItemData,
+  VarField
 }
 import uk.ac.wellcome.platform.transformer.sierra.source.sierra.SierraSourceLocation
 import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
@@ -57,6 +58,25 @@ class SierraItemsTest extends FunSpec with Matchers with SierraDataGenerators {
     transformedItem
       .asInstanceOf[Identifiable[Item]]
       .sourceIdentifier shouldBe sourceIdentifier
+  }
+
+  it("extracts the title from item varfield $v") {
+    val itemId = createSierraItemNumber
+    val itemData = createSierraItemData.copy(
+      varFields = List(
+        VarField(marcTag = Some("b"), content = Some("S11.1L")),
+        VarField(marcTag = Some("v"), content = Some("Envelope")),
+      )
+    )
+
+    val transformedItem: MaybeDisplayable[Item] = getTransformedItems(
+      itemDataMap = Map(itemId -> itemData)
+    ).head
+
+    transformedItem
+      .asInstanceOf[Identifiable[Item]]
+      .agent
+      .title shouldBe Some("Envelope")
   }
 
   it("removes items with deleted=true") {


### PR DESCRIPTION
## Issue

https://github.com/wellcometrust/platform/issues/4101

## Description

As part of the METS work we are bringing across more data for individual items that make up a work. Here we include a new `title` field on `Item`, which is populated from the Sierra data. This will be needed to properly display the individual items on the frontend (similarly to how items are displayed on the [library site](http://search.wellcomelibrary.org/iii/encore/record/C__Rb2975324?lang=eng))