### PR TITLE
add search parameters to API response

### DIFF
--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -65,14 +65,22 @@ trait ApiWorksTestBase
   def resultList(apiPrefix: String,
                  pageSize: Int = 10,
                  totalPages: Int = 1,
-                 totalResults: Int = 1) =
+                 totalResults: Int = 1,
+                 page: Int = 1,
+                 sort: List[String] = Nil,
+                 sortOrder: String = "asc") = {
+
     s"""
       "@context": "${contextUrl(apiPrefix)}",
       "type": "ResultList",
       "pageSize": $pageSize,
       "totalPages": $totalPages,
-      "totalResults": $totalResults
+      "totalResults": $totalResults,
+      "sort": ${toJson(sort).get},
+      "sortOrder": "$sortOrder",
+      "page": $page
     """
+  }
 
   def singleWorkResult(apiPrefix: String): String =
     s"""

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -99,7 +99,8 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
             apiPrefix,
             pageSize = 1,
             totalPages = 3,
-            totalResults = 3)},
+            totalResults = 3,
+            page = 2)},
               "prevPage": "$apiScheme://$apiHost/$apiPrefix/works?page=1&pageSize=1",
               "nextPage": "$apiScheme://$apiHost/$apiPrefix/works?page=3&pageSize=1",
               "results": [
@@ -121,7 +122,8 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
             apiPrefix,
             pageSize = 1,
             totalPages = 3,
-            totalResults = 3)},
+            totalResults = 3,
+            page = 1)},
               "nextPage": "$apiScheme://$apiHost/$apiPrefix/works?page=2&pageSize=1",
               "results": [
                 {
@@ -142,7 +144,8 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
             apiPrefix,
             pageSize = 1,
             totalPages = 3,
-            totalResults = 3)},
+            totalResults = 3,
+            page = 3)},
               "prevPage": "$apiScheme://$apiHost/$apiPrefix/works?page=2&pageSize=1",
               "results": [
                 {
@@ -345,10 +348,11 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
         )
         insertIntoElasticsearch(indexV2, work1, work2, work3, work4, work5)
 
+        val sort = List("production.dates")
         assertJsonResponse(routes, s"/$apiPrefix/works?sort=production.dates") {
           Status.OK -> s"""
             {
-              ${resultList(apiPrefix, totalResults = 5)},
+              ${resultList(apiPrefix, totalResults = 5, sort = sort)},
               "results": [{
 	            	 "id": "5",
 	            	 "title": "${work5.data.title.get}",
@@ -398,12 +402,18 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
         )
         insertIntoElasticsearch(indexV2, work1, work2, work3)
 
+        val sortOrder = "desc"
+        val sort = List("production.dates")
         assertJsonResponse(
           routes,
-          s"/$apiPrefix/works?sort=production.dates&sortOrder=desc") {
+          s"/$apiPrefix/works?sort=${sort.mkString(",")}&sortOrder=$sortOrder") {
           Status.OK -> s"""
             {
-              ${resultList(apiPrefix, totalResults = 3)},
+              ${resultList(
+            apiPrefix,
+            totalResults = 3,
+            sort = sort,
+            sortOrder = sortOrder)},
               "results": [{
 	            	 "id": "2",
 	            	 "title": "${work2.data.title.get}",

--- a/common/display/src/main/scala/uk/ac/wellcome/display/json/DisplayJsonSerializers.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/json/DisplayJsonSerializers.scala
@@ -1,0 +1,22 @@
+package uk.ac.wellcome.display.json
+
+import io.circe.Encoder
+import uk.ac.wellcome.display.models.SortingOrder.{Ascending, Descending}
+import uk.ac.wellcome.display.models.{
+  ProductionDateSortRequest,
+  SortRequest,
+  SortingOrder
+}
+
+trait DisplayJsonSerializers {
+  implicit val encodeSortingOrder: Encoder[SortingOrder] =
+    Encoder[String].contramap {
+      case Ascending  => "asc"
+      case Descending => "desc"
+    }
+
+  implicit val encodeSortRequest: Encoder[SortRequest] =
+    Encoder[String].contramap {
+      case ProductionDateSortRequest => "production.dates"
+    }
+}


### PR DESCRIPTION
# Why

## Reason 1 - default settings not requested by client 

There is some information that might not be set by the client that is relevant to the request. 

A simple example of this would be page parameters, where we are actually searching page `1` with `pageSize` of `25`, but the client isn't aware of that state - so we send it down the pipes (we don't actually send current page in the current implementation).

This saves a tiny amount of code on the client i.e. `page = query.page ? query.page : 1`.

Another default, which we can't infer, and what this was setting up for was to get the `queryType` `name`. i.e. `ScoringTiers`, `MSMBoostUsingAndOperator`. We currently have a `default` and `n` amount of tests. The client needs to report on what query is being used, but can't as if it hasn't set the `_queryType` explicitly, it has no way of knowing which is being used. Going forward we might want to take this even more out of the client's code, which would be impossible in this state.

__example__
```JS
// GET /works
{ "queryType": "ScoringTiers" }

// on client
track({ queryType: response.queryType })
```

## Reason  2 - Rendering the UI to reflect current filters that are complex objects, but requested via querystring.

We currently render part of the interface that reflects what filters have been applied:
![filters](https://user-images.githubusercontent.com/31692/70614601-b9be7300-1c02-11ea-95a8-24d15cce1670.png)

Currently we:
- Render aggregation
- Take `query.workType` and do a lookup on the ID to render the filter

```JSX
aggregations = [{ id: 'a', label: 'Books' }]

// Current implementation when this is clicked
// Change URL: workType=a
filters = { workType: ['a'] }
// Render 
filters.workType.map(id => <div>{lookup(id).label}</div>)
```

We could store the aggregation in a client side state, but when working with rendering from the URL (which we have to 💯 support) we would still need to maintain the lookup.

The only solution I can think of is to do something like this in the URL `workType=(label:Books,id:a)` <= but, well, no.

So if we returned from the API:
```JS
{ "filters": { "workType": [{ "id": "a", "label": Books }] } }
```

We'd get to remove the hardcoded lookup.

---  

Adds the parameters to the response - similar to the [HATEOAS](https://restfulapi.net/hateoas/) paradigm.

This was some preliminary work I wanted to do as a <abbr title="proof of concept">POC</abbr> and to move onto adding returning of the `workType` filters to help the UI respond to the request and the `queryType` for reporting.

I am still not 100% sure about the shape of this.

## calculated fields, properties, filters

I was thinking you could split the data up into these pieces:
```JS
{
  "@context": "https://api.wellcomecollection.org/catalogue/v2/context.json",
  "type": "ResultList",
  "pageSize": 10,
  "totalPages": 132784,
  "totalResults": 1327838,
  "results": [
  ],
  "parameters": {
    "sort": [
      "production.dates"
    ],
    "sortOrder": "asc",
    "page": 2,
    "searchQuery": {
      "query": "dogs bogs and hogs",
      "queryType": "ScoringTiers"
    }
  },
  "filters": {
    "workType": [
      {
        "type": "WorkType",
        "label": "Books",
        "id": "a"
      },
      {
        "type": "WorkType",
        "label": "Video",
        "id": "v"
      }
    ]
  }
}
```

Problem is we use `pageSize` already at the root level, which is actually a property.

Because of this, we could flatten the properties, and leave the `"filters"` property there too?