### PR TITLE
Add InEnglishWithContributors query

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/QueryParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/QueryParams.scala
@@ -175,7 +175,7 @@ object MultipleWorksParams extends QueryParamsUtils {
   implicit val _queryTypeDecoder: Decoder[SearchQueryType] =
     decodeOneWithDefaultOf(
       SearchQueryType.default,
-      "ScoringTiers" -> SearchQueryType.ScoringTiers
+      "InEnglishWithContributors" -> SearchQueryType.InEnglishWithContributors
     )
 }
 

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/SearchQueryType.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/SearchQueryType.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.api.models
 sealed trait SearchQueryType
 
 object SearchQueryType {
-  val default = MSMBoostUsingAndOperator
-  final case object MSMBoostUsingAndOperator extends SearchQueryType
+  val default = ScoringTiers
   final case object ScoringTiers extends SearchQueryType
+  final case object InEnglishWithContributors extends SearchQueryType
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchQueryBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchQueryBuilder.scala
@@ -11,25 +11,19 @@ import com.sksamuel.elastic4s.requests.searches.queries.matches.{
 import com.sksamuel.elastic4s.requests.searches.queries.{
   BoolQuery,
   ConstantScore,
-  Query,
-  SimpleQueryStringFlag,
-  SimpleStringQuery
+  Query
 }
+import uk.ac.wellcome.platform.api.models.SearchQuery
 import uk.ac.wellcome.platform.api.models.SearchQueryType.{
-  MSMBoostUsingAndOperator,
+  InEnglishWithContributors,
   ScoringTiers
-}
-import uk.ac.wellcome.platform.api.models.{SearchQuery}
-import uk.ac.wellcome.platform.api.services.QueryDefaults.{
-  defaultBoostedFields,
-  defaultMSM
 }
 
 case class ElasticsearchQueryBuilder(searchQuery: SearchQuery) {
   lazy val query: BoolQuery = searchQuery.queryType match {
-    case MSMBoostUsingAndOperator =>
-      MSMBoostUsingAndOperatorQuery(searchQuery.query).elasticQuery
     case ScoringTiers => ScoringTiersQuery(searchQuery.query).elasticQuery
+    case InEnglishWithContributors =>
+      InEnglishWithContributorsQuery(searchQuery.query).elasticQuery
   }
 }
 
@@ -48,7 +42,31 @@ object QueryDefaults {
     ("data.contributors.*", Some(2.0)),
     ("data.alternativeTitles", None),
     ("data.physicalDescription", None),
-    ("data.lettering", None),
+    ("data.production.*.label", None),
+    ("data.language.label", None),
+    ("data.edition", None),
+    // Identifiers
+    ("canonicalId", None),
+    ("sourceIdentifier.value", None),
+    ("data.otherIdentifiers.value", None),
+    ("data.items.canonicalId", None),
+    ("data.items.sourceIdentifier.value", None),
+    ("data.items.otherIdentifiers.value", None),
+  )
+
+  val englishBoostedFields: Seq[(String, Option[Double])] = Seq(
+    ("data.title.english", Some(9.0)),
+    // Because subjects and genres have been indexed differently
+    // We need to query them slightly differently
+    // TODO: (jamesgorrie) think of a more sustainable way of doing this
+    // maybe having a just a list of terms that we use terms queries to query against,
+    // and then have more structured data underlying
+    ("data.subjects.agent.concepts.agent.label", Some(8.0)),
+    ("data.genres.concepts.agent.label", Some(8.0)),
+    ("data.description.english", Some(3.0)),
+    ("data.contributors.*", Some(2.0)),
+    ("data.alternativeTitles.english", None),
+    ("data.physicalDescription.english", None),
     ("data.production.*.label", None),
     ("data.language.label", None),
     ("data.edition", None),
@@ -65,22 +83,6 @@ object QueryDefaults {
 sealed trait ElasticsearchQuery {
   val q: String
   val elasticQuery: Query
-}
-
-final case class MSMBoostUsingAndOperatorQuery(q: String)
-    extends ElasticsearchQuery {
-  lazy val elasticQuery = must(
-    SimpleStringQuery(
-      q,
-      fields = defaultBoostedFields,
-      lenient = Some(true),
-      minimumShouldMatch = Some(defaultMSM),
-      operator = Some("AND"),
-      // PHRASE is the only syntax that researchers know and understand, so we use this exclusively
-      // so as not to have unexpected results returned when using simple query string syntax.
-      // See: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html#simple-query-string-syntax
-      flags = Seq(SimpleQueryStringFlag.PHRASE)
-    ))
 }
 
 final case class TitleQuery(q: String) extends ElasticsearchQuery {
@@ -107,6 +109,14 @@ final case class SubjectQuery(q: String) extends ElasticsearchQuery {
       operator = Some(Operator.And))
 }
 
+final case class ContributorQuery(q: String) extends ElasticsearchQuery {
+  lazy val elasticQuery =
+    MatchQuery(
+      field = "data.contributors.agent.agent.label",
+      value = q,
+      operator = Some(Operator.And))
+}
+
 final case class ScoringTiersQuery(q: String) extends ElasticsearchQuery {
   import QueryDefaults._
 
@@ -127,6 +137,36 @@ final case class ScoringTiersQuery(q: String) extends ElasticsearchQuery {
       ConstantScore(query = TitleQuery(q).elasticQuery, boost = Some(2000)),
       ConstantScore(query = GenreQuery(q).elasticQuery, boost = Some(1000)),
       ConstantScore(query = SubjectQuery(q).elasticQuery, boost = Some(1000))
+    ),
+    mustQueries = Seq(baseQuery),
+    notQueries = Seq()
+  )
+}
+
+final case class InEnglishWithContributorsQuery(q: String)
+    extends ElasticsearchQuery {
+  import QueryDefaults._
+
+  val fields = englishBoostedFields map {
+    case (field, boost) =>
+      FieldWithOptionalBoost(field = field, boost = boost)
+  }
+
+  val baseQuery = MultiMatchQuery(
+    text = q,
+    fields = fields,
+    minimumShouldMatch = Some(defaultMSM),
+    `type` = Some(MultiMatchQueryBuilderType.CROSS_FIELDS)
+  )
+
+  lazy val elasticQuery = bool(
+    shouldQueries = Seq(
+      ConstantScore(query = GenreQuery(q).elasticQuery, boost = Some(2000)),
+      ConstantScore(query = SubjectQuery(q).elasticQuery, boost = Some(2000)),
+      ConstantScore(
+        query = ContributorQuery(q).elasticQuery,
+        boost = Some(2000)),
+      ConstantScore(query = TitleQuery(q).elasticQuery, boost = Some(1000))
     ),
     mustQueries = Seq(baseQuery),
     notQueries = Seq()

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchSearchQueryTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchSearchQueryTest.scala
@@ -10,7 +10,7 @@ import uk.ac.wellcome.models.work.generators.{
   SubjectGenerators,
   WorksGenerators
 }
-import uk.ac.wellcome.models.work.internal.{IdentifiedBaseWork}
+import uk.ac.wellcome.models.work.internal.IdentifiedBaseWork
 import uk.ac.wellcome.platform.api.generators.SearchOptionsGenerators
 import uk.ac.wellcome.platform.api.models.{SearchQuery, SearchQueryType}
 import uk.ac.wellcome.platform.api.services.{
@@ -36,8 +36,8 @@ class ElasticsearchQueryTest
     elasticClient = elasticClient
   )
 
-  describe("SearchQueryTypes and relevancy") {
-    it("Returns all results in a tiered order") {
+  describe("ScoringTiers") {
+    it("returns all results in a tiered order") {
       withLocalWorksIndex { index =>
         // Longer text used to ensure signal in TF/IDF
         val titledWorks = List(
@@ -90,27 +90,124 @@ class ElasticsearchQueryTest
       }
     }
 
-    it("includes all query tokens from MSMBoostQueryUsingAndOperator") {
-      withLocalWorksIndex { index =>
-        // Longer text used to ensure signal in TF/IDF
-        val works = List(
-          "Lyrical Lychee",
-          "Loose Lychee",
-          "Lyrical Lime",
-          "Loose Lime"
-        ).map { t =>
-          createIdentifiedWorkWith(title = Some(t))
+    describe("InEnglishWithContributors") {
+      it("returns all results in a tiered order") {
+        withLocalWorksIndex { index =>
+          // Longer text used to ensure signal in TF/IDF
+          val titledWorks = List(
+            "Gray's Inn.",
+            "Loose Lychee",
+            "Gray, John",
+            "Gray's Inn Hall.",
+            "Poems by Mr. Gray.",
+            "A brief history of 'Gray's anatomy'",
+            "H. Gray, Anatomy descriptive and surgical",
+            "Gray's anatomy, descriptive and applied.",
+            "Gray's anatomy.",
+          ).map { t =>
+            createIdentifiedWorkWith(canonicalId = t, title = Some(t))
+          }
+
+          val subjectedWorks = List(
+            ("exact match subject", "Gray's Anatomy"),
+            ("partial match subject", "Anatomy"),
+          ).map {
+            case (id, subject) =>
+              createIdentifiedWorkWith(
+                canonicalId = id,
+                title = Some(s"subjected $subject"),
+                subjects = List(createSubjectWithConcept(subject)))
+          }
+          val insertedWorks = titledWorks ++ subjectedWorks
+          insertIntoElasticsearch(index, insertedWorks: _*)
+
+          val results =
+            searchResults(
+              index = index,
+              queryOptions = createElasticsearchQueryOptionsWith(
+                searchQuery = Some(
+                  SearchQuery("Gray's anatomy", SearchQueryType.ScoringTiers))))
+
+          withClue(
+            "a MUST query is used on the base query so as not to match everything") {
+            (results.size < insertedWorks.size) should be(true)
+          }
+
+          withClue("the exact title should be first") {
+            results.head should be(getWorkWithId("Gray's anatomy.", results))
+          }
+
+          withClue(
+            "should find only subjects matching on AND operator and order it highly") {
+            results(1) should be(getWorkWithId("exact match subject", results))
+          }
         }
+      }
 
-        insertIntoElasticsearch(index, works: _*)
+      it("should use the english analyser in the base query") {
+        withLocalWorksIndex { index =>
+          val works = List(
+            "Vlad the impaler",
+            "Dad the impala",
+          ).map { t =>
+            createIdentifiedWorkWith(title = Some(t))
+          }
 
-        val results =
-          searchResults(
-            index = index,
-            queryOptions = createElasticsearchQueryOptionsWith(
-              searchQuery = Some(SearchQuery("Lyrical Lychee"))))
+          insertIntoElasticsearch(index, works: _*)
 
-        results should have length 1
+          // If we search the non-english analysed fields with the base query
+          // `the` would in the search as we're using the `OR` operator
+          // and would be matched in both examples above as the root field
+          // (not `field` rather than `field.english`, see `WorksIndex.scala`)
+          // does not use the english analyser.
+
+          // We wouldn't want to use the english analyser at query time though
+          // as we would lose detail used in other where we use exact matching
+          val results =
+            searchResults(
+              index = index,
+              queryOptions = createElasticsearchQueryOptionsWith(
+                searchQuery = Some(
+                  SearchQuery(
+                    "vlad the impaler",
+                    SearchQueryType.InEnglishWithContributors)))
+            )
+
+          results should contain theSameElementsAs List(works.head)
+        }
+      }
+
+      it("AND scores heavily on the contributors field") {
+        withLocalWorksIndex { index =>
+          val workWithExactMatchingContributors =
+            createIdentifiedWorkWith(
+              contributors = List(
+                createPersonContributorWith("Alice Stewart"),
+                createPersonContributorWith("Honor Fell"),
+              ))
+
+          val workWithPartialMatchingContributors = createIdentifiedWorkWith(
+            contributors = List(
+              createPersonContributorWith("Alice Fell"),
+            ))
+
+          insertIntoElasticsearch(
+            index,
+            workWithPartialMatchingContributors,
+            workWithExactMatchingContributors)
+          val results =
+            searchResults(
+              index = index,
+              queryOptions = createElasticsearchQueryOptionsWith(
+                searchQuery = Some(
+                  SearchQuery(
+                    "Alice Stewart",
+                    SearchQueryType.InEnglishWithContributors)))
+            )
+
+          results.head should be(workWithExactMatchingContributors)
+          results.last should be(workWithPartialMatchingContributors)
+        }
       }
     }
   }


### PR DESCRIPTION
✨ new query - 3 additions 

## Boost concepts before title
Working with @taceybadgerbrook and @harrisonpim it felt these should be boosted higher as it fits how people use our service more closely

## With contributors
Matches contributors and boosts highly.

## In english
I noticed when search for "Vlad the impaler" using the ScoringTiers base query, were returning loads of stuff, nothing to do with Vlads or impaling.

As we're using the OR operator on the base query, the `the` becomes part of the query - albeit with super low score due to TF x IDF - but it still matches.

It shouldn't and this solves that.

## Next up
Looking at matching concepts more accurately using ngrams and a few other tools at our disposal.