### PR TITLE
make identifier values case insensitive

### DIFF
--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -384,6 +384,58 @@ class ElasticsearchServiceTest
         }
       }
     }
+
+    it("searches the identifiers case insensitively") {
+      withLocalWorksIndex { index =>
+        val workWithMatchingCanonicalId = createIdentifiedWorkWith(
+          canonicalId = "A1234567"
+        )
+
+        val workWithMatchingSourceIdentifier = createIdentifiedWorkWith(
+          canonicalId = "workWithMatchingSourceIdentifier",
+          sourceIdentifier = createSourceIdentifierWith(value = "B1234567")
+        )
+
+        val workWithMatchingOtherIdentifiers = createIdentifiedWorkWith(
+          canonicalId = "workWithMatchingOtherIdentifiers",
+          otherIdentifiers =
+            List(createSourceIdentifierWith(value = "C1234567"))
+        )
+
+        insertIntoElasticsearch(
+          index,
+          workWithMatchingCanonicalId,
+          workWithMatchingSourceIdentifier,
+          workWithMatchingOtherIdentifiers)
+
+        assertSearchResultsAreCorrect(
+          index = index,
+          queryOptions = createElasticsearchQueryOptionsWith(
+            searchQuery = Some(SearchQuery("a1234567"))),
+          expectedWorks = List(
+            workWithMatchingCanonicalId
+          )
+        )
+
+        assertSearchResultsAreCorrect(
+          index = index,
+          queryOptions = createElasticsearchQueryOptionsWith(
+            searchQuery = Some(SearchQuery("b1234567"))),
+          expectedWorks = List(
+            workWithMatchingSourceIdentifier
+          )
+        )
+
+        assertSearchResultsAreCorrect(
+          index = index,
+          queryOptions = createElasticsearchQueryOptionsWith(
+            searchQuery = Some(SearchQuery("c1234567"))),
+          expectedWorks = List(
+            workWithMatchingOtherIdentifiers
+          )
+        )
+      }
+    }
   }
 
   describe("findResultById") {

--- a/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/ElasticsearchIndexCreatorTest.scala
+++ b/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/ElasticsearchIndexCreatorTest.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.elasticsearch
 
 import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.requests.analysis.Analysis
 import com.sksamuel.elastic4s.{RequestFailure, Response}
 import com.sksamuel.elastic4s.requests.indexes.IndexResponse
 import com.sksamuel.elastic4s.requests.searches.SearchResponse
@@ -46,8 +47,10 @@ class ElasticsearchIndexCreatorTest
     booleanField("visible")
   )
 
+  val analysis = Analysis(List())
+
   it("creates an index into which doc of the expected type can be put") {
-    withLocalElasticsearchIndex(indexFields) { index =>
+    withLocalElasticsearchIndex(indexFields, analysis) { index =>
       val testObject = TestObject("id", "description", true)
       val testObjectJson = toJson(testObject).get
 
@@ -72,7 +75,7 @@ class ElasticsearchIndexCreatorTest
   }
 
   it("create an index where inserting a doc of an unexpected type fails") {
-    withLocalElasticsearchIndex(indexFields) { index =>
+    withLocalElasticsearchIndex(indexFields, analysis) { index =>
       val badTestObject = BadTestObject("id", 5)
       val badTestObjectJson = toJson(badTestObject).get
 
@@ -91,10 +94,13 @@ class ElasticsearchIndexCreatorTest
   }
 
   it("updates an already existing index with a compatible mapping") {
-    withLocalElasticsearchIndex(indexFields) { index =>
+    withLocalElasticsearchIndex(indexFields, analysis) { index =>
       val compatibleIndexFields = indexFields :+ intField("count")
 
-      withLocalElasticsearchIndex(compatibleIndexFields, index = index) { _ =>
+      withLocalElasticsearchIndex(
+        compatibleIndexFields,
+        index = index,
+        analysis = analysis) { _ =>
         val compatibleTestObject = CompatibleTestObject(
           id = "id",
           description = "description",

--- a/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -2,6 +2,7 @@ package uk.ac.wellcome.elasticsearch.test.fixtures
 
 import com.sksamuel.elastic4s.Index
 import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.requests.analysis.Analysis
 import com.sksamuel.elastic4s.requests.cluster.ClusterHealthResponse
 import com.sksamuel.elastic4s.requests.common.VersionType.ExternalGte
 import com.sksamuel.elastic4s.requests.get.GetResponse
@@ -56,9 +57,10 @@ trait ElasticsearchFixtures
     implicitly[Position])
 
   def withLocalWorksIndex[R](testWith: TestWith[Index, R]): R =
-    withLocalElasticsearchIndex[R](fields = WorksIndex.rootIndexFields) {
-      index =>
-        testWith(index)
+    withLocalElasticsearchIndex[R](
+      fields = WorksIndex.rootIndexFields,
+      WorksIndex.analysis) { index =>
+      testWith(index)
     }
 
   private val elasticsearchIndexCreator = new ElasticsearchIndexCreator(
@@ -67,10 +69,11 @@ trait ElasticsearchFixtures
 
   def withLocalElasticsearchIndex[R](
     fields: Seq[FieldDefinition],
+    analysis: Analysis,
     index: Index = createIndex): Fixture[Index, R] = fixture[Index, R](
     create = {
       elasticsearchIndexCreator
-        .create(index = index, fields = fields)
+        .create(index = index, fields = fields, analysis = analysis)
         .await
 
       // Elasticsearch is eventually consistent, so the future

--- a/pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
+++ b/pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
@@ -30,7 +30,8 @@ class IngestorWorkerService(
 
   private val indexCreated = indexCreator.create(
     index = ingestorConfig.index,
-    fields = WorksIndex.rootIndexFields
+    fields = WorksIndex.rootIndexFields,
+    analysis = WorksIndex.analysis
   )
 
   private def processMessages(bundles: List[Bundle]): FutureBundles =


### PR DESCRIPTION
Searching for `v1234567` or `V1234567` should work.

This lowercases the ID value fields and stores a keyword version, the same as other fields. It'll work as the default query normalizer also lowercases the query.

This should probably have been done with a slightly larger audit of the index, but I would like to get it in for William for Friday's catchat as a point that we can iterate quickly.