### PR TITLE
use the actual elastic field for scoring tiers

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/QueryParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/QueryParams.scala
@@ -175,7 +175,7 @@ object MultipleWorksParams extends QueryParamsUtils {
   implicit val _queryTypeDecoder: Decoder[SearchQueryType] =
     decodeOneWithDefaultOf(
       SearchQueryType.default,
-      "InEnglishWithContributors" -> SearchQueryType.InEnglishWithContributors
+      "FixedFields" -> SearchQueryType.FixedFields
     )
 }
 

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/SearchQueryType.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/SearchQueryType.scala
@@ -5,5 +5,5 @@ sealed trait SearchQueryType
 object SearchQueryType {
   val default = ScoringTiers
   final case object ScoringTiers extends SearchQueryType
-  final case object InEnglishWithContributors extends SearchQueryType
+  final case object FixedFields extends SearchQueryType
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchQueryBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchQueryBuilder.scala
@@ -88,7 +88,7 @@ sealed trait ElasticsearchQuery {
 final case class TitleQuery(q: String) extends ElasticsearchQuery {
   lazy val elasticQuery =
     MatchQuery(
-      field = "title.english",
+      field = "data.title.english",
       value = q,
       operator = Some(Operator.And))
 }
@@ -96,7 +96,7 @@ final case class TitleQuery(q: String) extends ElasticsearchQuery {
 final case class GenreQuery(q: String) extends ElasticsearchQuery {
   lazy val elasticQuery =
     MatchQuery(
-      field = "genres.concepts.agent.label",
+      field = "data.genres.concepts.agent.label",
       value = q,
       operator = Some(Operator.And))
 }
@@ -104,7 +104,7 @@ final case class GenreQuery(q: String) extends ElasticsearchQuery {
 final case class SubjectQuery(q: String) extends ElasticsearchQuery {
   lazy val elasticQuery =
     MatchQuery(
-      field = "subjects.agent.concepts.agent.label",
+      field = "data.subjects.agent.concepts.agent.label",
       value = q,
       operator = Some(Operator.And))
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchQueryBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchQueryBuilder.scala
@@ -104,7 +104,7 @@ final case class GenreQuery(q: String) extends ElasticsearchQuery {
 final case class SubjectQuery(q: String) extends ElasticsearchQuery {
   lazy val elasticQuery =
     MatchQuery(
-      field = "data.subjects.agent.concepts.agent.label",
+      field = "subjects.agent.concepts.agent.label",
       value = q,
       operator = Some(Operator.And))
 }
@@ -128,7 +128,7 @@ final case class FixedGenreQuery(q: String) extends ElasticsearchQuery {
 final case class FixedSubjectQuery(q: String) extends ElasticsearchQuery {
   lazy val elasticQuery =
     MatchQuery(
-      field = "subjects.agent.concepts.agent.label",
+      field = "data.subjects.agent.concepts.agent.label",
       value = q,
       operator = Some(Operator.And))
 }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchSearchQueryTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchSearchQueryTest.scala
@@ -90,7 +90,7 @@ class ElasticsearchQueryTest
       }
     }
 
-    describe("InEnglishWithContributors") {
+    describe("FixedFields") {
       it("returns all results in a tiered order") {
         withLocalWorksIndex { index =>
           // Longer text used to ensure signal in TF/IDF
@@ -168,9 +168,7 @@ class ElasticsearchQueryTest
               index = index,
               queryOptions = createElasticsearchQueryOptionsWith(
                 searchQuery = Some(
-                  SearchQuery(
-                    "vlad the impaler",
-                    SearchQueryType.InEnglishWithContributors)))
+                  SearchQuery("vlad the impaler", SearchQueryType.FixedFields)))
             )
 
           results should contain theSameElementsAs List(works.head)
@@ -198,11 +196,8 @@ class ElasticsearchQueryTest
           val results =
             searchResults(
               index = index,
-              queryOptions = createElasticsearchQueryOptionsWith(
-                searchQuery = Some(
-                  SearchQuery(
-                    "Alice Stewart",
-                    SearchQueryType.InEnglishWithContributors)))
+              queryOptions = createElasticsearchQueryOptionsWith(searchQuery =
+                Some(SearchQuery("Alice Stewart", SearchQueryType.FixedFields)))
             )
 
           results.head should be(workWithExactMatchingContributors)


### PR DESCRIPTION
Annoyingly this has been running for a while, which is why we might not have seen many changes in the tests that are running.

I will be trying to get rid of these strings - but want to fix it first for the tests.