### PR TITLE
add parameters to search response with queryType

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/QueryParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/QueryParams.scala
@@ -199,6 +199,7 @@ trait QueryParamsUtils extends Directives with TimeInstances {
       "contributors" -> WorkInclude.Contributors,
       "production" -> WorkInclude.Production,
       "notes" -> WorkInclude.Notes,
+      "parameters" -> WorkInclude.Parameters,
     ).emap(values => Right(V2WorksIncludes(values)))
 
   implicit val decodeLocalDate: Decoder[LocalDate] =

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/Responses.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/Responses.scala
@@ -49,7 +49,8 @@ case class MultipleWorksResponse(
   results: List[DisplayWorkV2],
   prevPage: Option[String] = None,
   nextPage: Option[String] = None,
-  aggregations: Option[DisplayAggregations] = None
+  aggregations: Option[DisplayAggregations] = None,
+  parameters: Option[DisplaySearchParameters] = None
 )
 
 object MultipleWorksResponse {
@@ -71,13 +72,16 @@ object MultipleWorksResponse {
       ),
       currentPage = searchOptions.pageNumber,
       requestUri = requestUri,
-      contextUri = contextUri
+      contextUri = contextUri,
+      searchParameters = Some(DisplaySearchParameters(searchOptions))
     )
 
-  def apply(resultList: DisplayResultList[DisplayWorkV2],
-            currentPage: Int,
-            requestUri: Uri,
-            contextUri: String): MultipleWorksResponse =
+  def apply(
+    resultList: DisplayResultList[DisplayWorkV2],
+    currentPage: Int,
+    requestUri: Uri,
+    contextUri: String,
+    searchParameters: Option[DisplaySearchParameters]): MultipleWorksResponse =
     MultipleWorksResponse(
       context = contextUri,
       ontologyType = resultList.ontologyType,
@@ -88,6 +92,7 @@ object MultipleWorksResponse {
       prevPage = pageLink(currentPage - 1, resultList.totalPages, requestUri),
       nextPage = pageLink(currentPage + 1, resultList.totalPages, requestUri),
       aggregations = resultList.aggregations,
+      parameters = searchParameters
     )
 
   private def pageLink(page: Int,

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplaySearchParameters.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplaySearchParameters.scala
@@ -1,0 +1,22 @@
+package uk.ac.wellcome.platform.api.models
+
+import io.circe.generic.extras.JsonKey
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.ac.wellcome.platform.api.services.WorksSearchOptions
+@Schema(
+  name = "SearchParameters",
+  description = "The parameters used to fetch a set of results.")
+case class DisplaySearchParameters(
+  queryType: Option[String],
+  @JsonKey("type") @Schema(name = "type") ontologyType: String =
+    "SearchParameters")
+
+object DisplaySearchParameters {
+  def apply(searchOptions: WorksSearchOptions): DisplaySearchParameters = {
+
+    val queryType =
+      searchOptions.searchQuery.map(_.queryType.name)
+
+    DisplaySearchParameters(queryType = queryType)
+  }
+}

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/SearchQueryType.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/SearchQueryType.scala
@@ -1,6 +1,11 @@
 package uk.ac.wellcome.platform.api.models
 
-sealed trait SearchQueryType
+sealed trait SearchQueryType {
+  // This is because the `this` is the actual simpleton so gets `$`
+  // appended to the `simpleName`. Not great, but contained, so meh.
+  // As this changes quite often it felt worth doing
+  def name = this.getClass.getSimpleName
+}
 
 object SearchQueryType {
   val default = ScoringTiers

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/WorksIncludes.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/WorksIncludes.scala
@@ -10,6 +10,7 @@ object WorkInclude {
   case object Contributors extends WorkInclude
   case object Production extends WorkInclude
   case object Notes extends WorkInclude
+  case object Parameters extends WorkInclude
 }
 
 trait WorksIncludes
@@ -22,6 +23,7 @@ case class V2WorksIncludes(includes: List[WorkInclude]) extends WorksIncludes {
   def contributors = includes.contains(WorkInclude.Contributors)
   def production = includes.contains(WorkInclude.Production)
   def notes = includes.contains(WorkInclude.Notes)
+  def parameters = includes.contains(WorkInclude.Parameters)
 }
 
 object V2WorksIncludes {
@@ -36,6 +38,7 @@ object V2WorksIncludes {
     contributors: Boolean = false,
     production: Boolean = false,
     notes: Boolean = false,
+    parameters: Boolean = false,
   ): V2WorksIncludes = V2WorksIncludes(
     List(
       if (identifiers) Some(Identifiers) else None,
@@ -45,10 +48,11 @@ object V2WorksIncludes {
       if (contributors) Some(Contributors) else None,
       if (production) Some(Production) else None,
       if (notes) Some(Notes) else None,
+      if (parameters) Some(Parameters) else None,
     ).flatten
   )
 
   def includeAll(): V2WorksIncludes = V2WorksIncludes(
-    true, true, true, true, true, true, true
+    true, true, true, true, true, true, true, true
   )
 }


### PR DESCRIPTION
Sends `queryType` back to the client.

This will help with accurate reporting as to what is going on from the client perspective. e.g.
```js
track("searched", { query: "harbinger", queryType: apiResponse.parameters.queryType })
```

We might move other things onto this to be able to rely on it completely for things like that ☝️ (see [HATEOAS](https://en.wikipedia.org/wiki/HATEOAS)).

I've kept it at the edge as it is basically just a representation of `searchOptions` and isn't needed anywhere in the application.

`"options"` wouldn't read right I don't think as that is what you might send on the display model as things the client can chose from.