### PR TITLE
Cut down the size of APM traces

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/Tracing.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/Tracing.scala
@@ -42,7 +42,8 @@ object Tracing {
         "service_name" -> config.getOrElse("apm.service.name")("catalogue-api"),
         "server_urls" -> config.getOrElse("apm.server.url")(
           "http://localhost:9200"),
-        "secret_token" -> config.getOrElse[String]("apm.secret")("")
+        "secret_token" -> config.getOrElse[String]("apm.secret")(""),
+        "span_frames_min_duration" -> "250ms"
       ).asJava)
     actorSystem.dispatchers.registerConfigurator(
       "tracing-dispatcher",


### PR DESCRIPTION
The APM errors we're getting are likely related to the free-tier APM server having insufficient throughput for the amount of data that we're sending it - this should drastically decrease that.

See https://www.elastic.co/guide/en/apm/server/current/processing-performance.html
and https://www.elastic.co/guide/en/apm/agent/java/current/config-stacktrace.html#config-span-frames-min-duration