### PR TITLE
Extract AccessCondition for physical items in Sierra

### DIFF
--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayAccessCondition.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayAccessCondition.scala
@@ -1,7 +1,5 @@
 package uk.ac.wellcome.display.models
 
-import java.time.{LocalDateTime, ZoneOffset}
-import java.time.format.DateTimeFormatter.ISO_LOCAL_DATE
 import io.circe.generic.extras.JsonKey
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.ac.wellcome.models.work.internal.{AccessCondition, AccessStatus}
@@ -23,9 +21,7 @@ object DisplayAccessCondition {
     DisplayAccessCondition(
       status = DisplayAccessStatus(accessCondition.status),
       terms = accessCondition.terms,
-      to = accessCondition.to.map { instant =>
-        LocalDateTime.ofInstant(instant, ZoneOffset.UTC).format(ISO_LOCAL_DATE)
-      }
+      to = accessCondition.to
     )
 }
 

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
@@ -5,8 +5,6 @@ import io.circe.parser._
 import org.scalatest.Suite
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.models.work.internal._
-import java.time.{LocalDateTime, ZoneOffset}
-import java.time.format.DateTimeFormatter.ISO_LOCAL_DATE
 
 trait DisplaySerialisationTestBase { this: Suite =>
 
@@ -114,21 +112,15 @@ trait DisplaySerialisationTestBase { this: Suite =>
   def accessConditions(conds: List[AccessCondition]) =
     s"[${conds.map(accessCondition).mkString(",")}]"
 
-  def accessCondition(cond: AccessCondition) = {
-    val expectedTo = cond.to.map { instant =>
-      LocalDateTime
-        .ofInstant(instant, ZoneOffset.UTC)
-        .format(ISO_LOCAL_DATE)
-    }
+  def accessCondition(cond: AccessCondition) =
     s"""
       {
         "type": "AccessCondition",
         ${optionalString("terms", cond.terms)}
-        ${optionalString("to", expectedTo)}
+        ${optionalString("to", cond.to)}
         ${accessStatus(cond.status)}
       }
     """
-  }
 
   def accessStatus(status: AccessStatus) = {
     s"""

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayLocationsV2SerialisationTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/v2/DisplayLocationsV2SerialisationTest.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.display.models.v2
 
 import org.scalatest.{Assertion, FunSpec}
-import java.time.{LocalDate, ZoneOffset}
 
 import uk.ac.wellcome.display.json.DisplayJsonUtil._
 import uk.ac.wellcome.display.models.V2WorksIncludes
@@ -94,9 +93,7 @@ class DisplayLocationsV2SerialisationTest
           AccessCondition(
             status = AccessStatus.Restricted,
             terms = Some("Ask politely"),
-            to = Some(
-              LocalDate.of(2024, 2, 24).atStartOfDay.toInstant(ZoneOffset.UTC)
-            )
+            to = Some("2024-02-24")
           )
         )
       )

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AccessCondition.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AccessCondition.scala
@@ -1,11 +1,9 @@
 package uk.ac.wellcome.models.work.internal
 
-import java.time.Instant
-
 case class AccessCondition(
   status: AccessStatus,
   terms: Option[String] = None,
-  to: Option[Instant] = None
+  to: Option[String] = None
 )
 
 sealed trait AccessStatus

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
@@ -21,7 +21,7 @@ case class SierraItems(itemDataMap: Map[SierraItemNumber, SierraItemData])
   type Output = List[MaybeDisplayable[Item]]
 
   def apply(bibId: SierraBibNumber, bibData: SierraBibData) = {
-    val physicalItems = getPhysicalItems(itemDataMap)
+    val physicalItems = getPhysicalItems(itemDataMap, bibData)
     val maybeDigitalItem = getDigitalItem(bibId = bibId, bibData = bibData)
 
     // If we have a digital Item and a *single* physical Item, we know
@@ -46,7 +46,8 @@ case class SierraItems(itemDataMap: Map[SierraItemNumber, SierraItemData])
   }
 
   private def getPhysicalItems(
-    sierraItemDataMap: Map[SierraItemNumber, SierraItemData])
+    sierraItemDataMap: Map[SierraItemNumber, SierraItemData],
+    bibData: SierraBibData)
     : List[Identifiable[Item]] =
     sierraItemDataMap
       .filterNot {
@@ -54,10 +55,7 @@ case class SierraItems(itemDataMap: Map[SierraItemNumber, SierraItemData])
       }
       .map {
         case (itemId: SierraItemNumber, itemData: SierraItemData) =>
-          transformItemData(
-            itemId = itemId,
-            itemData = itemData
-          )
+          transformItemData(itemId, itemData, bibData)
       }
       .toList
 
@@ -96,7 +94,8 @@ case class SierraItems(itemDataMap: Map[SierraItemNumber, SierraItemData])
 
   private def transformItemData(
     itemId: SierraItemNumber,
-    itemData: SierraItemData): Identifiable[Item] = {
+    itemData: SierraItemData,
+    bibData: SierraBibData): Identifiable[Item] = {
     debug(s"Attempting to transform $itemId")
     Identifiable(
       sourceIdentifier = SourceIdentifier(
@@ -113,7 +112,7 @@ case class SierraItems(itemDataMap: Map[SierraItemNumber, SierraItemData])
       ),
       agent = Item(
         title = getItemTitle(itemData),
-        locations = getPhysicalLocation(itemData).toList
+        locations = getPhysicalLocation(itemData, bibData).toList
       )
     )
   }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
@@ -47,8 +47,7 @@ case class SierraItems(itemDataMap: Map[SierraItemNumber, SierraItemData])
 
   private def getPhysicalItems(
     sierraItemDataMap: Map[SierraItemNumber, SierraItemData],
-    bibData: SierraBibData)
-    : List[Identifiable[Item]] =
+    bibData: SierraBibData): List[Identifiable[Item]] =
     sierraItemDataMap
       .filterNot {
         case (_: SierraItemNumber, itemData: SierraItemData) => itemData.deleted
@@ -92,10 +91,9 @@ case class SierraItems(itemDataMap: Map[SierraItemNumber, SierraItemData])
     }
   }
 
-  private def transformItemData(
-    itemId: SierraItemNumber,
-    itemData: SierraItemData,
-    bibData: SierraBibData): Identifiable[Item] = {
+  private def transformItemData(itemId: SierraItemNumber,
+                                itemData: SierraItemData,
+                                bibData: SierraBibData): Identifiable[Item] = {
     debug(s"Attempting to transform $itemId")
     Identifiable(
       sourceIdentifier = SourceIdentifier(

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
@@ -2,12 +2,18 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.sierra.exceptions.SierraTransformerException
-import uk.ac.wellcome.platform.transformer.sierra.source.{SierraBibData, SierraItemData, SierraQueryOps, VarField}
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  SierraBibData,
+  SierraItemData,
+  SierraQueryOps,
+  VarField
+}
 import uk.ac.wellcome.platform.transformer.sierra.source.sierra.SierraSourceLocation
 
 trait SierraLocation extends SierraQueryOps {
 
-  def getPhysicalLocation(itemData: SierraItemData, bibData: SierraBibData): Option[PhysicalLocation] =
+  def getPhysicalLocation(itemData: SierraItemData,
+                          bibData: SierraBibData): Option[PhysicalLocation] =
     itemData.location.flatMap {
       // We've seen records where the "location" field is populated in
       // the JSON, but the code and name are both empty strings or "none".
@@ -18,7 +24,8 @@ trait SierraLocation extends SierraQueryOps {
         Some(
           PhysicalLocation(
             locationType = LocationType(code),
-            accessConditions = Option(getAccessConditions(bibData)).filter(_.nonEmpty),
+            accessConditions =
+              Option(getAccessConditions(bibData)).filter(_.nonEmpty),
             label = name
           )
         )
@@ -38,7 +45,8 @@ trait SierraLocation extends SierraQueryOps {
     }
   }
 
-  private def getAccessConditions(bibData: SierraBibData): List[AccessCondition] =
+  private def getAccessConditions(
+    bibData: SierraBibData): List[AccessCondition] =
     bibData.varfieldsWithTag("506").map { varfield =>
       AccessCondition(
         status = getAccessStatus(varfield),
@@ -64,6 +72,7 @@ trait SierraLocation extends SierraQueryOps {
             throw new Exception(s"Unrecognised AccessStatus: $status")
         }
         .getOrElse {
-          throw new Exception("Could not parse AccessCondition: 506$f not found")
+          throw new Exception(
+            "Could not parse AccessCondition: 506$f not found")
         }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
@@ -2,27 +2,26 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.sierra.exceptions.SierraTransformerException
-import uk.ac.wellcome.platform.transformer.sierra.source.SierraItemData
+import uk.ac.wellcome.platform.transformer.sierra.source.{SierraBibData, SierraItemData, SierraQueryOps, VarField}
 import uk.ac.wellcome.platform.transformer.sierra.source.sierra.SierraSourceLocation
 
-trait SierraLocation {
-  def getPhysicalLocation(itemData: SierraItemData): Option[PhysicalLocation] =
-    itemData.location match {
+trait SierraLocation extends SierraQueryOps {
+
+  def getPhysicalLocation(itemData: SierraItemData, bibData: SierraBibData): Option[PhysicalLocation] =
+    itemData.location.flatMap {
       // We've seen records where the "location" field is populated in
       // the JSON, but the code and name are both empty strings or "none".
       // We can't do anything useful with this, so don't return a location.
-      // TODO: Find out if we can populate location from other fields.
-      case Some(SierraSourceLocation("", ""))         => None
-      case Some(SierraSourceLocation("none", "none")) => None
-
-      case Some(loc: SierraSourceLocation) =>
+      case SierraSourceLocation("", "")         => None
+      case SierraSourceLocation("none", "none") => None
+      case SierraSourceLocation(code, name) =>
         Some(
           PhysicalLocation(
-            locationType = LocationType(loc.code),
-            label = loc.name
+            locationType = LocationType(code),
+            accessConditions = Option(getAccessConditions(bibData)).filter(_.nonEmpty),
+            label = name
           )
         )
-      case None => None
     }
 
   def getDigitalLocation(identifier: String): DigitalLocation = {
@@ -38,4 +37,33 @@ trait SierraLocation {
         "id required by DigitalLocation has not been provided")
     }
   }
+
+  private def getAccessConditions(bibData: SierraBibData): List[AccessCondition] =
+    bibData.varfieldsWithTag("506").map { varfield =>
+      AccessCondition(
+        status = getAccessStatus(varfield),
+        terms = varfield.subfieldsWithTag("a").contentString,
+        to = varfield.subfieldsWithTag("g").contents.headOption
+      )
+    }
+
+  private def getAccessStatus(varfield: VarField): AccessStatus =
+    if (varfield.indicator1 == Some("0"))
+      AccessStatus.Open
+    else
+      varfield
+        .subfieldsWithTag("f")
+        .contents
+        .headOption
+        .map {
+          case "Open"               => AccessStatus.Open
+          case "Open with advisory" => AccessStatus.OpenWithAdvisory
+          case "Restricted"         => AccessStatus.Restricted
+          case "Closed"             => AccessStatus.Closed
+          case status =>
+            throw new Exception(s"Unrecognised AccessStatus: $status")
+        }
+        .getOrElse {
+          throw new Exception("Could not parse AccessCondition: 506$f not found")
+        }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationTest.scala
@@ -18,6 +18,9 @@ class SierraLocationTest
   private val transformer = new SierraLocation {}
 
   describe("Physical locations") {
+
+    val bibData = createSierraBibData
+
     it("extracts location from item data") {
       val locationTypeCode = "sgmed"
       val locationType = LocationType("sgmed")
@@ -27,7 +30,7 @@ class SierraLocationTest
       )
       val expectedLocation = PhysicalLocation(locationType, label)
 
-      transformer.getPhysicalLocation(itemData = itemData) shouldBe Some(
+      transformer.getPhysicalLocation(itemData, bibData) shouldBe Some(
         expectedLocation)
     }
 
@@ -36,14 +39,14 @@ class SierraLocationTest
         location = Some(SierraSourceLocation("", ""))
       )
 
-      transformer.getPhysicalLocation(itemData = itemData) shouldBe None
+      transformer.getPhysicalLocation(itemData, bibData) shouldBe None
     }
 
     it("returns None if the location field only contains the string 'none'") {
       val itemData = createSierraItemDataWith(
         location = Some(SierraSourceLocation("none", "none"))
       )
-      transformer.getPhysicalLocation(itemData = itemData) shouldBe None
+      transformer.getPhysicalLocation(itemData, bibData) shouldBe None
     }
 
     it("returns None if there is no location in the item data") {
@@ -51,7 +54,7 @@ class SierraLocationTest
         location = None
       )
 
-      transformer.getPhysicalLocation(itemData = itemData) shouldBe None
+      transformer.getPhysicalLocation(itemData, bibData) shouldBe None
     }
   }
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationTest.scala
@@ -10,7 +10,10 @@ import uk.ac.wellcome.models.work.internal.{
 }
 import uk.ac.wellcome.platform.transformer.sierra.exceptions.SierraTransformerException
 import uk.ac.wellcome.platform.transformer.sierra.source.sierra.SierraSourceLocation
-import uk.ac.wellcome.platform.transformer.sierra.source.{VarField, MarcSubfield}
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  MarcSubfield,
+  VarField
+}
 import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
 
 class SierraLocationTest


### PR DESCRIPTION
## Issue

https://github.com/wellcometrust/platform/issues/4125

## Description

Attempts to extract `AccessCondition` from the MARC data.

This modifies the `accessConfition.to` field to be `String`, rather than `Instant`: this is because we do not need to filter / aggregate on this field, and for display we should just show whatever is within the field rather than attempting to parse it.
