### PR TITLE
add ID search to API

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/SearchQueryType.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/SearchQueryType.scala
@@ -7,11 +7,11 @@ sealed trait SearchQueryType {
   final val name = this.getClass.getSimpleName.split("\\$").last
 }
 object SearchQueryType {
-  val default = ScoringTiers
+  val default = FixedFields
   // These are the queries that we are surfacing to the frontend to be able to select which one they want to run.
   // You'll need to change the `allowableValues` in `uk.ac.wellcome.platform.api.swagger.SwaggerDocs`
   // when changing these as they can't be read there as they need to be constant.
-  val allowed = List(ScoringTiers, FixedFields)
-  final case object ScoringTiers extends SearchQueryType
+  val allowed = List(IdSearch, FixedFields)
+  final case object IdSearch extends SearchQueryType
   final case object FixedFields extends SearchQueryType
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticSearchRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticSearchRequestBuilder.scala
@@ -50,7 +50,9 @@ case class ElasticSearchRequestBuilder(
         .size(100)
         .sources(
           List(
-            TermsValueSource("label", field = Some("data.workType.label.raw")),
+            TermsValueSource(
+              "label",
+              field = Some("data.workType.label.keyword")),
             TermsValueSource("id", field = Some("data.workType.id")),
             TermsValueSource("type", field = Some("data.workType.ontologyType"))
           )
@@ -71,7 +73,7 @@ case class ElasticSearchRequestBuilder(
           List(
             TermsValueSource(
               "label",
-              field = Some("data.genres.concepts.agent.label.raw"))
+              field = Some("data.genres.concepts.agent.label.keyword"))
           )
         )
         .subAggregations(sortedByCount)
@@ -83,7 +85,7 @@ case class ElasticSearchRequestBuilder(
           List(
             TermsValueSource(
               "label",
-              field = Some("data.subjects.agent.label.raw")
+              field = Some("data.subjects.agent.label.keyword")
             )
           )
         )
@@ -95,7 +97,9 @@ case class ElasticSearchRequestBuilder(
         .sources(
           List(
             TermsValueSource("id", field = Some("data.language.id")),
-            TermsValueSource("label", field = Some("data.language.label.raw"))
+            TermsValueSource(
+              "label",
+              field = Some("data.language.label.keyword"))
           )
         )
 

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
@@ -265,7 +265,7 @@ trait MultipleWorksSwagger {
           "Which query should we use search the works? Used predominantly for internal testing of relevancy. Considered Unstable.",
         schema = new Schema(
           `type` = "enum",
-          allowableValues = Array("ScoringTiers", "FixedFields"),
+          allowableValues = Array("IdSearch", "FixedFields"),
         ),
         required = false
       )

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchSearchQueryTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchSearchQueryTest.scala
@@ -71,8 +71,7 @@ class ElasticsearchQueryTest
           searchResults(
             index = index,
             queryOptions = createElasticsearchQueryOptionsWith(
-              searchQuery = Some(
-                SearchQuery("Gray's anatomy", SearchQueryType.ScoringTiers))))
+              searchQuery = Some(SearchQuery("Gray's anatomy"))))
 
         withClue(
           "a MUST query is used on the base query so as not to match everything") {
@@ -125,8 +124,7 @@ class ElasticsearchQueryTest
             searchResults(
               index = index,
               queryOptions = createElasticsearchQueryOptionsWith(
-                searchQuery = Some(
-                  SearchQuery("Gray's anatomy", SearchQueryType.ScoringTiers))))
+                searchQuery = Some(SearchQuery("Gray's anatomy"))))
 
           withClue(
             "a MUST query is used on the base query so as not to match everything") {

--- a/docs/search_relevance/query_design.md
+++ b/docs/search_relevance/query_design.md
@@ -74,9 +74,11 @@ Searching for a work based on local and external identifiers e.g. Catalogue API 
 
 #### Expectations
 
-* Searching for _an_ identifier, I get the result back
+* Searching for _an_ identifier, I get _the_ result back
 * Searching for a list of identifiers, I get all the results back
 * Searches should be case insensitive
+* If the search query contains and ID and other input, we should match
+  the ID and terms with the the ID match at the top of the list.
 
 #### Examples
 

--- a/scriptFile.scala
+++ b/scriptFile.scala
@@ -1,0 +1,8 @@
+val value = keywordField("value")
+    .normalizer(lowercaseNormalizer.name)
+    .fields(keywordField("raw"))
+
+  val canonicalId =
+    keywordField("canonicalId")
+      .normalizer(lowercaseNormalizer.name)
+      .fields(keywordField("raw"))


### PR DESCRIPTION
Extends on the ability to search IDs fields more affectively.

Previously
- searched exact, case sensitive single IDs

Now
- Multiple ID search
- Case insensitive
- ID search can be combined with other search e.g. "Standing on the wrong side of a horse 123abc" will return 2 results, the ID and the [standing on the wrong side of a horse](https://wellcomecollection.org/works/pczdvhdg)

Ping @jennpb 

**Requires reindex**