### PR TITLE
Clean up expected JSON in API works tests

### DIFF
--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -112,13 +112,12 @@ trait ApiWorksTestBase
       | }
     """.stripMargin
 
-  def worksListResponse(apiPrefix: String,
-                        works: Seq[IdentifiedWork]): String =
+  def worksListResponse(apiPrefix: String, works: Seq[IdentifiedWork]): String =
     s"""
        |{
        |  ${resultList(apiPrefix, totalResults = works.size)},
        |  "results": [
-       |    ${works.map { workResponse }.mkString(",") }
+       |    ${works.map { workResponse }.mkString(",")}
        |  ]
        |}
       """.stripMargin

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -112,6 +112,17 @@ trait ApiWorksTestBase
       | }
     """.stripMargin
 
+  def worksListResponse(apiPrefix: String,
+                        works: Seq[IdentifiedWork]): String =
+    s"""
+       |{
+       |  ${resultList(apiPrefix, totalResults = works.size)},
+       |  "results": [
+       |    ${works.map { workResponse }.mkString(",") }
+       |  ]
+       |}
+      """.stripMargin
+
   def workTypeResponse(workType: WorkType): String =
     s"""
       | "workType": {

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2ErrorsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2ErrorsTest.scala
@@ -108,12 +108,7 @@ class ApiV2ErrorsTest extends ApiV2WorksTestBase with ApiErrorsTestBase {
           assertJsonResponse(
             routes,
             s"/$apiPrefix/works?_queryType=athingwewouldneverusebutmightbecausewesaidwewouldnot") {
-            Status.OK -> s"""
-            {
-              ${resultList(apiPrefix, totalResults = 0, totalPages = 0)},
-              "results": []
-            }
-          """
+            Status.OK -> emptyJsonResult(apiPrefix)
           }
       }
     }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2FiltersTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2FiltersTest.scala
@@ -32,14 +32,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
         assertJsonResponse(
           routes,
           s"/$apiPrefix/works?genres.label=horror&subjects.label=england") {
-          Status.OK -> s"""
-          {
-            ${resultList(apiPrefix, totalResults = 1)},
-            "results": [
-              ${workResponse(work2)}
-            ]
-          }
-          """
+          Status.OK -> worksListResponse(apiPrefix, works = Seq(work2))
         }
     }
   }
@@ -178,20 +171,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
           assertJsonResponse(
             routes,
             s"/$apiPrefix/works?workType=${ManuscriptsAsian.id}") {
-            Status.OK -> s"""
-            {
-              ${resultList(apiPrefix, totalResults = 1)},
-                "results": [
-                  {
-                    "type": "Work",
-                    "id": "${manuscriptWork.canonicalId}",
-                    "title": "${manuscriptWork.data.title.get}",
-                    "alternativeTitles": [],
-                    "workType": ${workType(manuscriptWork.data.workType.get)}
-                  }
-                ]
-              }
-            """
+            Status.OK -> worksListResponse(apiPrefix, works = Seq(manuscriptWork))
           }
       }
     }
@@ -204,27 +184,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
           assertJsonResponse(
             routes,
             s"/$apiPrefix/works?workType=${ManuscriptsAsian.id},${CDRoms.id}") {
-            Status.OK -> s"""
-            {
-              ${resultList(apiPrefix, totalResults = 2)},
-              "results": [
-                {
-                  "type": "Work",
-                  "id": "${cdRomWork.canonicalId}",
-                  "title": "${cdRomWork.data.title.get}",
-                  "alternativeTitles": [],
-                  "workType": ${workType(cdRomWork.data.workType.get)}
-                },
-                {
-                  "type": "Work",
-                  "id": "${manuscriptWork.canonicalId}",
-                  "title": "${manuscriptWork.data.title.get}",
-                  "alternativeTitles": [],
-                  "workType": ${workType(manuscriptWork.data.workType.get)}
-                }
-              ]
-            }
-          """
+            Status.OK -> worksListResponse(apiPrefix, works = Seq(cdRomWork, manuscriptWork))
           }
       }
     }
@@ -237,27 +197,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
           assertJsonResponse(
             routes,
             s"/$apiPrefix/works?query=apple&workType=${ManuscriptsAsian.id},${CDRoms.id}") {
-            Status.OK -> s"""
-            {
-              ${resultList(apiPrefix, totalResults = 2)},
-                "results": [
-                  {
-                    "type": "Work",
-                    "id": "${cdRomWork.canonicalId}",
-                    "title": "${cdRomWork.data.title.get}",
-                    "alternativeTitles": [],
-                    "workType": ${workType(cdRomWork.data.workType.get)}
-                  },
-                  {
-                    "type": "Work",
-                    "id": "${manuscriptWork.canonicalId}",
-                    "title": "${manuscriptWork.data.title.get}",
-                    "alternativeTitles": [],
-                    "workType": ${workType(manuscriptWork.data.workType.get)}
-                  }
-                ]
-              }
-            """
+            Status.OK -> worksListResponse(apiPrefix, works = Seq(cdRomWork, manuscriptWork))
           }
       }
     }
@@ -277,19 +217,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
           assertJsonResponse(
             routes,
             s"/$apiPrefix/works?production.dates.from=1900-01-01&production.dates.to=1960-01-01") {
-            Status.OK -> s"""
-              {
-                ${resultList(apiPrefix, totalResults = 1)},
-                "results": [
-                  {
-                    "type": "Work",
-                    "id": "${work2.canonicalId}",
-                    "title": "${work2.data.title.get}",
-                    "alternativeTitles": []
-                  }
-                ]
-              }
-            """
+            Status.OK -> worksListResponse(apiPrefix, works = Seq(work2))
           }
       }
     }
@@ -301,25 +229,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
           assertJsonResponse(
             routes,
             s"/$apiPrefix/works?production.dates.from=1900-01-01") {
-            Status.OK -> s"""
-              {
-                ${resultList(apiPrefix, totalResults = 2)},
-                "results": [
-                  {
-                    "type": "Work",
-                    "id": "${work2.canonicalId}",
-                    "title": "${work2.data.title.get}",
-                    "alternativeTitles": []
-                  },
-                  {
-                    "type": "Work",
-                    "id": "${work3.canonicalId}",
-                    "title": "${work3.data.title.get}",
-                    "alternativeTitles": []
-                  }
-                ]
-              }
-            """
+            Status.OK -> worksListResponse(apiPrefix, works = Seq(work2, work3))
           }
       }
     }
@@ -331,25 +241,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
           assertJsonResponse(
             routes,
             s"/$apiPrefix/works?production.dates.to=1960-01-01") {
-            Status.OK -> s"""
-              {
-                ${resultList(apiPrefix, totalResults = 2)},
-                "results": [
-                  {
-                    "type": "Work",
-                    "id": "${work1.canonicalId}",
-                    "title": "${work1.data.title.get}",
-                    "alternativeTitles": []
-                  },
-                  {
-                    "type": "Work",
-                    "id": "${work2.canonicalId}",
-                    "title": "${work2.data.title.get}",
-                    "alternativeTitles": []
-                  }
-                ]
-              }
-            """
+            Status.OK -> worksListResponse(apiPrefix, works = Seq(work1, work2))
           }
       }
     }
@@ -390,24 +282,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
         case (indexV2, routes) =>
           insertIntoElasticsearch(indexV2, works: _*)
           assertJsonResponse(routes, s"/$apiPrefix/works?language=eng") {
-            Status.OK -> s"""
-              {
-                ${resultList(apiPrefix, totalResults = 1)},
-                "results": [
-                  {
-                    "type": "Work",
-                    "id": "${englishWork.canonicalId}",
-                    "title": "${englishWork.data.title.get}",
-                    "alternativeTitles": [],
-                    "language": {
-                      "id": "eng",
-                      "label": "English",
-                      "type": "Language"
-                    }
-                  }
-                ]
-              }
-            """
+            Status.OK -> worksListResponse(apiPrefix, works = Seq(englishWork))
           }
       }
     }
@@ -417,35 +292,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
         case (indexV2, routes) =>
           insertIntoElasticsearch(indexV2, works: _*)
           assertJsonResponse(routes, s"/$apiPrefix/works?language=eng,ger") {
-            Status.OK -> s"""
-              {
-                ${resultList(apiPrefix, totalResults = 2)},
-                "results": [
-                  {
-                    "type": "Work",
-                    "id": "${englishWork.canonicalId}",
-                    "title": "${englishWork.data.title.get}",
-                    "alternativeTitles": [],
-                    "language": {
-                      "id": "eng",
-                      "label": "English",
-                      "type": "Language"
-                    }
-                  },
-                  {
-                    "type": "Work",
-                    "id": "${germanWork.canonicalId}",
-                    "title": "${germanWork.data.title.get}",
-                    "alternativeTitles": [],
-                    "language": {
-                      "id": "ger",
-                      "label": "German",
-                      "type": "Language"
-                    }
-                  }
-                ]
-              }
-            """
+            Status.OK -> worksListResponse(apiPrefix, works = Seq(englishWork, germanWork))
           }
       }
     }
@@ -482,15 +329,7 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
         case (indexV2, routes) =>
           insertIntoElasticsearch(indexV2, works: _*)
           assertJsonResponse(routes, s"/$apiPrefix/works?genres.label=horrible") {
-            Status.OK -> s"""
-              {
-                ${resultList(apiPrefix, totalResults = 2)},
-                "results": [
-                  ${workResponse(horrorWork)},
-                  ${workResponse(romcomHorrorWork)}
-                ]
-              }
-            """
+            Status.OK -> worksListResponse(apiPrefix, works = Seq(horrorWork, romcomHorrorWork))
           }
       }
     }
@@ -502,21 +341,13 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
           assertJsonResponse(
             routes,
             s"/$apiPrefix/works?genres.label=horrible%20heartwarming") {
-            Status.OK -> s"""
-              {
-                ${resultList(apiPrefix, totalResults = 1)},
-                "results": [
-                  ${workResponse(romcomHorrorWork)}
-                ]
-              }
-            """
+            Status.OK -> worksListResponse(apiPrefix, works = Seq(romcomHorrorWork))
           }
       }
     }
   }
 
   describe("filtering works by subject") {
-
     val nineteenthCentury = createSubjectWith("19th Century")
     val paris = createSubjectWith("Paris")
 
@@ -546,30 +377,14 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
       nineteenthCenturyParisWork,
       noSubjectWork)
 
-    def workResponse(work: IdentifiedWork): String =
-      s"""
-        | {
-        |   "type": "Work",
-        |   "id": "${work.canonicalId}",
-        |   "title": "${work.data.title.get}",
-        |   "alternativeTitles": []
-        | }
-      """.stripMargin
-
     it("filters by subjects") {
       withApi {
         case (indexV2, routes) =>
           insertIntoElasticsearch(indexV2, works: _*)
           assertJsonResponse(routes, s"/$apiPrefix/works?subjects.label=paris") {
-            Status.OK -> s"""
-              {
-                ${resultList(apiPrefix, totalResults = 2)},
-                "results": [
-                  ${workResponse(parisWork)},
-                  ${workResponse(nineteenthCenturyParisWork)}
-                ]
-              }
-            """
+            Status.OK -> worksListResponse(
+              apiPrefix, works = Seq(parisWork, nineteenthCenturyParisWork)
+            )
           }
       }
     }
@@ -581,21 +396,15 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
           assertJsonResponse(
             routes,
             s"/$apiPrefix/works?subjects.label=19th%20century%20paris") {
-            Status.OK -> s"""
-              {
-                ${resultList(apiPrefix, totalResults = 1)},
-                "results": [
-                  ${workResponse(nineteenthCenturyParisWork)}
-                ]
-              }
-            """
+            Status.OK -> worksListResponse(
+              apiPrefix, works = Seq(nineteenthCenturyParisWork)
+            )
           }
       }
     }
   }
 
   describe("filtering works by license") {
-
     val ccByWork = createLicensedWork("A", List(License.CCBY))
     val ccByNcWork = createLicensedWork("B", List(License.CCBYNC))
     val bothLicenseWork =
@@ -609,15 +418,10 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
         case (indexV2, routes) =>
           insertIntoElasticsearch(indexV2, works: _*)
           assertJsonResponse(routes, s"/$apiPrefix/works?license=cc-by") {
-            Status.OK -> s"""
-              {
-                ${resultList(apiPrefix, totalResults = 2)},
-                "results": [
-                  ${workResponse(ccByWork)},
-                  ${workResponse(bothLicenseWork)}
-                ]
-              }
-            """
+            Status.OK -> worksListResponse(
+              apiPrefix = apiPrefix,
+              works = Seq(ccByWork, bothLicenseWork)
+            )
           }
       }
     }
@@ -629,16 +433,10 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
           assertJsonResponse(
             routes,
             s"/$apiPrefix/works?license=cc-by,cc-by-nc") {
-            Status.OK -> s"""
-              {
-                ${resultList(apiPrefix, totalResults = 3)},
-                "results": [
-                  ${workResponse(ccByWork)},
-                  ${workResponse(ccByNcWork)},
-                  ${workResponse(bothLicenseWork)}
-                ]
-              }
-            """
+            Status.OK -> worksListResponse(
+              apiPrefix = apiPrefix,
+              works = Seq(ccByWork, ccByNcWork, bothLicenseWork)
+            )
           }
       }
     }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2FiltersTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2FiltersTest.scala
@@ -171,7 +171,9 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
           assertJsonResponse(
             routes,
             s"/$apiPrefix/works?workType=${ManuscriptsAsian.id}") {
-            Status.OK -> worksListResponse(apiPrefix, works = Seq(manuscriptWork))
+            Status.OK -> worksListResponse(
+              apiPrefix,
+              works = Seq(manuscriptWork))
           }
       }
     }
@@ -184,7 +186,9 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
           assertJsonResponse(
             routes,
             s"/$apiPrefix/works?workType=${ManuscriptsAsian.id},${CDRoms.id}") {
-            Status.OK -> worksListResponse(apiPrefix, works = Seq(cdRomWork, manuscriptWork))
+            Status.OK -> worksListResponse(
+              apiPrefix,
+              works = Seq(cdRomWork, manuscriptWork))
           }
       }
     }
@@ -197,7 +201,9 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
           assertJsonResponse(
             routes,
             s"/$apiPrefix/works?query=apple&workType=${ManuscriptsAsian.id},${CDRoms.id}") {
-            Status.OK -> worksListResponse(apiPrefix, works = Seq(cdRomWork, manuscriptWork))
+            Status.OK -> worksListResponse(
+              apiPrefix,
+              works = Seq(cdRomWork, manuscriptWork))
           }
       }
     }
@@ -292,7 +298,9 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
         case (indexV2, routes) =>
           insertIntoElasticsearch(indexV2, works: _*)
           assertJsonResponse(routes, s"/$apiPrefix/works?language=eng,ger") {
-            Status.OK -> worksListResponse(apiPrefix, works = Seq(englishWork, germanWork))
+            Status.OK -> worksListResponse(
+              apiPrefix,
+              works = Seq(englishWork, germanWork))
           }
       }
     }
@@ -329,7 +337,9 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
         case (indexV2, routes) =>
           insertIntoElasticsearch(indexV2, works: _*)
           assertJsonResponse(routes, s"/$apiPrefix/works?genres.label=horrible") {
-            Status.OK -> worksListResponse(apiPrefix, works = Seq(horrorWork, romcomHorrorWork))
+            Status.OK -> worksListResponse(
+              apiPrefix,
+              works = Seq(horrorWork, romcomHorrorWork))
           }
       }
     }
@@ -341,7 +351,9 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
           assertJsonResponse(
             routes,
             s"/$apiPrefix/works?genres.label=horrible%20heartwarming") {
-            Status.OK -> worksListResponse(apiPrefix, works = Seq(romcomHorrorWork))
+            Status.OK -> worksListResponse(
+              apiPrefix,
+              works = Seq(romcomHorrorWork))
           }
       }
     }
@@ -383,7 +395,8 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
           insertIntoElasticsearch(indexV2, works: _*)
           assertJsonResponse(routes, s"/$apiPrefix/works?subjects.label=paris") {
             Status.OK -> worksListResponse(
-              apiPrefix, works = Seq(parisWork, nineteenthCenturyParisWork)
+              apiPrefix,
+              works = Seq(parisWork, nineteenthCenturyParisWork)
             )
           }
       }
@@ -397,7 +410,8 @@ class ApiV2FiltersTest extends ApiV2WorksTestBase {
             routes,
             s"/$apiPrefix/works?subjects.label=19th%20century%20paris") {
             Status.OK -> worksListResponse(
-              apiPrefix, works = Seq(nineteenthCenturyParisWork)
+              apiPrefix,
+              works = Seq(nineteenthCenturyParisWork)
             )
           }
       }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -5,14 +5,15 @@ import uk.ac.wellcome.models.work.internal._
 class ApiV2WorksTest extends ApiV2WorksTestBase {
 
   it("returns a list of works") {
-    withApi { case (indexV2, routes) =>
-      val works = createIdentifiedWorks(count = 3).sortBy { _.canonicalId }
+    withApi {
+      case (indexV2, routes) =>
+        val works = createIdentifiedWorks(count = 3).sortBy { _.canonicalId }
 
-      insertIntoElasticsearch(indexV2, works: _*)
+        insertIntoElasticsearch(indexV2, works: _*)
 
-      assertJsonResponse(routes, s"/$apiPrefix/works") {
-        Status.OK -> worksListResponse(apiPrefix, works = works)
-      }
+        assertJsonResponse(routes, s"/$apiPrefix/works") {
+          Status.OK -> worksListResponse(apiPrefix, works = works)
+        }
     }
   }
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -5,39 +5,14 @@ import uk.ac.wellcome.models.work.internal._
 class ApiV2WorksTest extends ApiV2WorksTestBase {
 
   it("returns a list of works") {
-    withApi {
-      case (indexV2, routes) =>
-        val works = createIdentifiedWorks(count = 3).sortBy { _.canonicalId }
+    withApi { case (indexV2, routes) =>
+      val works = createIdentifiedWorks(count = 3).sortBy { _.canonicalId }
 
-        insertIntoElasticsearch(indexV2, works: _*)
+      insertIntoElasticsearch(indexV2, works: _*)
 
-        assertJsonResponse(routes, s"/$apiPrefix/works") {
-          Status.OK -> s"""
-            {
-              ${resultList(apiPrefix, totalResults = 3)},
-              "results": [
-               {
-                 "type": "Work",
-                 "id": "${works(0).canonicalId}",
-                 "title": "${works(0).data.title.get}",
-                 "alternativeTitles": []
-               },
-               {
-                 "type": "Work",
-                 "id": "${works(1).canonicalId}",
-                 "title": "${works(1).data.title.get}",
-                 "alternativeTitles": []
-               },
-               {
-                 "type": "Work",
-                 "id": "${works(2).canonicalId}",
-                 "title": "${works(2).data.title.get}",
-                 "alternativeTitles": []
-               }
-              ]
-            }
-          """
-        }
+      assertJsonResponse(routes, s"/$apiPrefix/works") {
+        Status.OK -> worksListResponse(apiPrefix, works = works)
+      }
     }
   }
 
@@ -103,12 +78,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
               "prevPage": "$apiScheme://$apiHost/$apiPrefix/works?page=1&pageSize=1",
               "nextPage": "$apiScheme://$apiHost/$apiPrefix/works?page=3&pageSize=1",
               "results": [
-                {
-                  "type": "Work",
-                  "id": "${works(1).canonicalId}",
-                  "title": "${works(1).data.title.get}",
-                  "alternativeTitles": []
-                }
+                ${workResponse(works(1))}
               ]
             }
           """
@@ -124,12 +94,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
             totalResults = 3)},
               "nextPage": "$apiScheme://$apiHost/$apiPrefix/works?page=2&pageSize=1",
               "results": [
-                {
-                  "type": "Work",
-                  "id": "${works(0).canonicalId}",
-                  "title": "${works(0).data.title.get}",
-                  "alternativeTitles": []
-                }
+                ${workResponse(works(0))}
               ]
             }
           """
@@ -145,12 +110,7 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
             totalResults = 3)},
               "prevPage": "$apiScheme://$apiHost/$apiPrefix/works?page=2&pageSize=1",
               "results": [
-                {
-                  "type": "Work",
-                  "id": "${works(2).canonicalId}",
-                  "title": "${works(2).data.title.get}",
-                  "alternativeTitles": []
-                }
+                ${workResponse(works(2))}
               ]
             }
           """
@@ -170,32 +130,20 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
   it("returns matching results if doing a full-text search") {
     withApi {
       case (indexV2, routes) =>
-        val work1 = createIdentifiedWorkWith(
+        val workDodo = createIdentifiedWorkWith(
           title = Some("A drawing of a dodo")
         )
-        val work2 = createIdentifiedWorkWith(
+        val workMouse = createIdentifiedWorkWith(
           title = Some("A mezzotint of a mouse")
         )
-        insertIntoElasticsearch(indexV2, work1, work2)
+        insertIntoElasticsearch(indexV2, workDodo, workMouse)
 
         assertJsonResponse(routes, s"/$apiPrefix/works?query=cat") {
           Status.OK -> emptyJsonResult(apiPrefix)
         }
 
         assertJsonResponse(routes, s"/$apiPrefix/works?query=dodo") {
-          Status.OK -> s"""
-            {
-              ${resultList(apiPrefix, totalResults = 1)},
-              "results": [
-               {
-                 "type": "Work",
-                 "id": "${work1.canonicalId}",
-                 "title": "${work1.data.title.get}",
-                 "alternativeTitles": []
-               }
-              ]
-            }
-          """
+          Status.OK -> worksListResponse(apiPrefix, works = Seq(workDodo))
         }
     }
   }
@@ -252,37 +200,13 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
           insertIntoElasticsearch(index = altIndex, altWork)
 
           assertJsonResponse(routes, s"/$apiPrefix/works?query=pangolins") {
-            Status.OK -> s"""
-              {
-                ${resultList(apiPrefix, totalResults = 1)},
-                "results": [
-                 {
-                   "type": "Work",
-                   "id": "${work.canonicalId}",
-                   "title": "${work.data.title.get}",
-                   "alternativeTitles": []
-                 }
-                ]
-              }
-            """
+            Status.OK -> worksListResponse(apiPrefix, works = Seq(work))
           }
 
           assertJsonResponse(
             routes,
             s"/$apiPrefix/works?query=pangolins&_index=${altIndex.name}") {
-            Status.OK -> s"""
-              {
-                ${resultList(apiPrefix, totalResults = 1)},
-                "results": [
-                 {
-                   "type": "Work",
-                   "id": "${altWork.canonicalId}",
-                   "title": "${altWork.data.title.get}",
-                   "alternativeTitles": []
-                 }
-                ]
-              }
-            """
+            Status.OK -> worksListResponse(apiPrefix, works = Seq(altWork))
           }
         }
     }
@@ -346,37 +270,10 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
         insertIntoElasticsearch(indexV2, work1, work2, work3, work4, work5)
 
         assertJsonResponse(routes, s"/$apiPrefix/works?sort=production.dates") {
-          Status.OK -> s"""
-            {
-              ${resultList(apiPrefix, totalResults = 5)},
-              "results": [{
-	            	 "id": "5",
-	            	 "title": "${work5.data.title.get}",
-                 "alternativeTitles": [],
-	            	 "type": "Work"
-	            }, {
-	            	 "id": "1",
-	            	 "title": "${work1.data.title.get}",
-                 "alternativeTitles": [],
-	            	 "type": "Work"
-	            }, {
-	            	 "id": "3",
-	            	 "title": "${work3.data.title.get}",
-                 "alternativeTitles": [],
-	            	 "type": "Work"
-	            }, {
-	            	 "id": "2",
-	            	 "title": "${work2.data.title.get}",
-                 "alternativeTitles": [],
-	            	 "type": "Work"
-	            }, {
-	            	 "id": "4",
-	            	 "title": "${work4.data.title.get}",
-                 "alternativeTitles": [],
-	            	 "type": "Work"
-	            }]
-            }
-          """
+          Status.OK -> worksListResponse(
+            apiPrefix = apiPrefix,
+            works = Seq(work5, work1, work3, work2, work4)
+          )
         }
     }
   }
@@ -401,27 +298,10 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
         assertJsonResponse(
           routes,
           s"/$apiPrefix/works?sort=production.dates&sortOrder=desc") {
-          Status.OK -> s"""
-            {
-              ${resultList(apiPrefix, totalResults = 3)},
-              "results": [{
-	            	 "id": "2",
-	            	 "title": "${work2.data.title.get}",
-                 "alternativeTitles": [],
-	            	 "type": "Work"
-	            }, {
-	            	 "id": "3",
-	            	 "title": "${work3.data.title.get}",
-                 "alternativeTitles": [],
-	            	 "type": "Work"
-	            }, {
-	            	 "id": "1",
-	            	 "title": "${work1.data.title.get}",
-                 "alternativeTitles": [],
-	            	 "type": "Work"
-	            }]
-            }
-          """
+          Status.OK -> worksListResponse(
+            apiPrefix = apiPrefix,
+            works = Seq(work2, work3, work1)
+          )
         }
     }
   }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestInvisible.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTestInvisible.scala
@@ -26,25 +26,7 @@ class ApiV2WorksTestInvisible extends ApiV2WorksTestBase {
         insertIntoElasticsearch(indexV2, worksToIndex: _*)
 
         assertJsonResponse(routes, s"/$apiPrefix/works") {
-          Status.OK -> s"""
-             |{
-             |  ${resultList(apiPrefix, totalResults = 2)},
-             |  "results": [
-             |   {
-             |     "type": "Work",
-             |     "id": "${works(0).canonicalId}",
-             |     "title": "${works(0).data.title.get}",
-             |     "alternativeTitles": []
-             |   },
-             |   {
-             |     "type": "Work",
-             |     "id": "${works(1).canonicalId}",
-             |     "title": "${works(1).data.title.get}",
-             |     "alternativeTitles": []
-             |   }
-             |  ]
-             |}
-          """.stripMargin
+          Status.OK -> worksListResponse(apiPrefix, works = works)
         }
     }
   }
@@ -58,19 +40,7 @@ class ApiV2WorksTestInvisible extends ApiV2WorksTestBase {
         insertIntoElasticsearch(indexV2, work, deletedWork)
 
         assertJsonResponse(routes, s"/$apiPrefix/works?query=deleted") {
-          Status.OK -> s"""
-             |{
-             |  ${resultList(apiPrefix, totalResults = 1)},
-             |  "results": [
-             |   {
-             |     "type": "Work",
-             |     "id": "${work.canonicalId}",
-             |     "title": "${work.data.title.get}",
-             |     "alternativeTitles": []
-             |   }
-             |  ]
-             |}
-          """.stripMargin
+          Status.OK -> worksListResponse(apiPrefix, works = Seq(work))
         }
     }
   }


### PR DESCRIPTION
Often we only care about the order of works being returned, and we're not fussed about the fields.  We also don't want to do the busy work of updating the `totalResults=` parameter, so just build it programatically.

Follows #360.