### PR TITLE
Delete records in the Sierra adapter, even if they were modified on the same day

### DIFF
--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlow.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlow.scala
@@ -1,42 +1,15 @@
 package uk.ac.wellcome.platform.sierra_reader.flow
 
-import java.time.format.DateTimeFormatter
-import java.time.{Instant, LocalDate, ZoneOffset}
+import java.time.Instant
 
 import akka.NotUsed
 import akka.stream.scaladsl.Flow
 import io.circe.Json
-import io.circe.optics.JsonPath.root
 import uk.ac.wellcome.models.transformable.sierra.AbstractSierraRecord
+import uk.ac.wellcome.platform.sierra_reader.parsers.SierraRecordParser
 
 object SierraRecordWrapperFlow {
   def apply[T <: AbstractSierraRecord](
     createRecord: (String, String, Instant) => T): Flow[Json, T, NotUsed] =
-    Flow.fromFunction({ json =>
-      val id = getId(json)
-      val data = json.noSpaces
-      val modifiedDate = getModifiedDate(json)
-
-      createRecord(id, data, modifiedDate)
-    })
-
-  private def getModifiedDate(json: Json): Instant = {
-    val maybeUpdatedDate = root.updatedDate.string.getOption(json)
-
-    maybeUpdatedDate match {
-      case Some(updatedDate) => Instant.parse(updatedDate)
-      case None              => getDeletedDateTimeAtStartOfDay(json)
-    }
-  }
-
-  private def getDeletedDateTimeAtStartOfDay(json: Json): Instant = {
-    val formatter = DateTimeFormatter.ISO_DATE
-    LocalDate
-      .parse(root.deletedDate.string.getOption(json).get, formatter)
-      .atStartOfDay()
-      .toInstant(ZoneOffset.UTC)
-  }
-
-  private def getId(json: Json) =
-    root.id.string.getOption(json).get
+    Flow.fromFunction(SierraRecordParser(createRecord))
 }

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/parsers/SierraRecordParser.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/parsers/SierraRecordParser.scala
@@ -1,0 +1,38 @@
+package uk.ac.wellcome.platform.sierra_reader.parsers
+
+import java.time.format.DateTimeFormatter
+import java.time.{Instant, LocalDate, ZoneOffset}
+
+import io.circe.Json
+import io.circe.optics.JsonPath.root
+import uk.ac.wellcome.models.transformable.sierra.AbstractSierraRecord
+
+object SierraRecordParser {
+  def apply[T <: AbstractSierraRecord](createRecord: (String, String, Instant) => T)(json: Json): T = {
+    val id = getId(json)
+    val data = json.noSpaces
+    val modifiedDate = getModifiedDate(json)
+
+    createRecord(id, data, modifiedDate)
+  }
+
+  private def getModifiedDate(json: Json): Instant = {
+    val maybeUpdatedDate = root.updatedDate.string.getOption(json)
+
+    maybeUpdatedDate match {
+      case Some(updatedDate) => Instant.parse(updatedDate)
+      case None              => getDeletedDateTimeAtStartOfDay(json)
+    }
+  }
+
+  private def getDeletedDateTimeAtStartOfDay(json: Json): Instant = {
+    val formatter = DateTimeFormatter.ISO_DATE
+    LocalDate
+      .parse(root.deletedDate.string.getOption(json).get, formatter)
+      .atStartOfDay()
+      .toInstant(ZoneOffset.UTC)
+  }
+
+  private def getId(json: Json): String =
+    root.id.string.getOption(json).get
+}

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/parsers/SierraRecordParser.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/parsers/SierraRecordParser.scala
@@ -8,7 +8,8 @@ import io.circe.optics.JsonPath.root
 import uk.ac.wellcome.models.transformable.sierra.AbstractSierraRecord
 
 object SierraRecordParser {
-  def apply[T <: AbstractSierraRecord](createRecord: (String, String, Instant) => T)(json: Json): T = {
+  def apply[T <: AbstractSierraRecord](
+    createRecord: (String, String, Instant) => T)(json: Json): T = {
     val id = getId(json)
     val data = json.noSpaces
     val modifiedDate = getModifiedDate(json)

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/parsers/SierraRecordParser.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/parsers/SierraRecordParser.scala
@@ -26,19 +26,20 @@ object SierraRecordParser {
   // consistently.
   //
   // If a record was deleted and modified on the same day, we should treat the
-  // deletion as taking precedence.  If it was deleted and then un-deleted
-  // TODO: Is that even possible?
+  // deletion as taking precedence.  After a record is deleted in Sierra, it
+  // cannot be un-deleted.
   //
-  //
-
   private def getModifiedDate(json: Json): Instant = {
     val maybeUpdatedDate = root.updatedDate.string.getOption(json)
 
     maybeUpdatedDate match {
-      case Some(updatedDate) => Instant.parse(updatedDate)
+      case Some(updatedDate) => getUpdatedAsDateTime(updatedDate)
       case None              => getDeletedAsDatetime(json)
     }
   }
+
+  private def getUpdatedAsDateTime(updatedDate: String): Instant =
+    Instant.parse(updatedDate)
 
   private def getDeletedAsDatetime(json: Json): Instant = {
     val formatter = DateTimeFormatter.ISO_DATE

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlowTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlowTest.scala
@@ -39,7 +39,7 @@ class SierraRecordWrapperFlowTest
     testWith(wrapperFlow)
   }
 
-  it("creates a SierraRecord from a bib") {
+  it("pares a bib record from the stream") {
     withMaterializer { implicit materializer =>
       withRecordWrapperFlow(SierraBibRecord.apply) { wrapperFlow =>
         val id = createSierraBibNumber
@@ -70,7 +70,7 @@ class SierraRecordWrapperFlowTest
     }
   }
 
-  it("creates a SierraRecord from an item") {
+  it("parses an item record from the stream") {
     withMaterializer { implicit materializer =>
       withRecordWrapperFlow(SierraItemRecord.apply) { wrapperFlow =>
         val id = createSierraItemNumber
@@ -105,39 +105,6 @@ class SierraRecordWrapperFlowTest
           .via(wrapperFlow)
           .runWith(Sink.head)
 
-        whenReady(futureRecord) { sierraRecord =>
-          assertSierraRecordsAreEqual(sierraRecord, expectedRecord)
-        }
-      }
-    }
-  }
-
-  it("is able to handle deleted bibs") {
-    withMaterializer { implicit materializer =>
-      withRecordWrapperFlow(SierraBibRecord.apply) { wrapperFlow =>
-        val id = createSierraBibNumber
-        val deletedDate = "2014-01-31"
-        val jsonString =
-          s"""
-          |{
-          |  "id" : "$id",
-          |  "deletedDate" : "$deletedDate",
-          |  "deleted" : true
-          |}
-          |""".stripMargin
-
-        val expectedRecord = createSierraBibRecordWith(
-          id = id,
-          data = jsonString,
-          modifiedDate = Instant.parse(s"${deletedDate}T00:00:00Z")
-        )
-
-        val json = parse(jsonString).right.get
-
-        val futureRecord = Source
-          .single(json)
-          .via(wrapperFlow)
-          .runWith(Sink.head)
         whenReady(futureRecord) { sierraRecord =>
           assertSierraRecordsAreEqual(sierraRecord, expectedRecord)
         }

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlowTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlowTest.scala
@@ -39,7 +39,7 @@ class SierraRecordWrapperFlowTest
     testWith(wrapperFlow)
   }
 
-  it("pares a bib record from the stream") {
+  it("parses a bib record from the stream") {
     withMaterializer { implicit materializer =>
       withRecordWrapperFlow(SierraBibRecord.apply) { wrapperFlow =>
         val id = createSierraBibNumber

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/parsers/SierraRecordParserTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/parsers/SierraRecordParserTest.scala
@@ -7,11 +7,15 @@ import org.scalatest.compatible.Assertion
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil.toJson
 import uk.ac.wellcome.json.utils.JsonAssertions
-import uk.ac.wellcome.models.transformable.sierra.{AbstractSierraRecord, SierraBibRecord, SierraItemRecord}
+import uk.ac.wellcome.models.transformable.sierra.{
+  AbstractSierraRecord,
+  SierraBibRecord,
+  SierraItemRecord
+}
 import uk.ac.wellcome.models.transformable.sierra.test.utils.SierraGenerators
 
 class SierraRecordParserTest
-  extends FunSpec
+    extends FunSpec
     with Matchers
     with JsonAssertions
     with SierraGenerators {

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/parsers/SierraRecordParserTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/parsers/SierraRecordParserTest.scala
@@ -1,0 +1,110 @@
+package uk.ac.wellcome.platform.sierra_reader.parsers
+
+import java.time.Instant
+
+import io.circe.parser.parse
+import org.scalatest.compatible.Assertion
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.json.JsonUtil.toJson
+import uk.ac.wellcome.json.utils.JsonAssertions
+import uk.ac.wellcome.models.transformable.sierra.{AbstractSierraRecord, SierraBibRecord, SierraItemRecord}
+import uk.ac.wellcome.models.transformable.sierra.test.utils.SierraGenerators
+
+class SierraRecordParserTest
+  extends FunSpec
+    with Matchers
+    with JsonAssertions
+    with SierraGenerators {
+  it("parses a bib record") {
+    val id = createSierraBibNumber
+    val updatedDate = "2013-12-13T12:43:16Z"
+    val jsonString =
+      s"""
+       |{
+       |  "id": "$id",
+       |  "updatedDate": "$updatedDate"
+       |}
+        """.stripMargin
+
+    val expectedRecord = createSierraBibRecordWith(
+      id = id,
+      data = jsonString,
+      modifiedDate = Instant.parse(updatedDate)
+    )
+
+    val json = parse(jsonString).right.get
+
+    assertSierraRecordsAreEqual(
+      SierraRecordParser(SierraBibRecord.apply)(json),
+      expectedRecord
+    )
+  }
+
+  it("parses an item record") {
+    val id = createSierraItemNumber
+    val updatedDate = "2014-04-14T14:14:14Z"
+
+    // We need to encode the bib IDs as strings, _not_ as typed
+    // objects -- the format needs to map what we get from the
+    // Sierra API.
+    //
+    val bibIds = (1 to 4).map { _ =>
+      createSierraRecordNumberString
+    }
+    val jsonString =
+      s"""
+       |{
+       |  "id": "$id",
+       |  "updatedDate": "$updatedDate",
+       |  "bibIds": ${toJson(bibIds).get}
+       |}
+        """.stripMargin
+
+    val expectedRecord = createSierraItemRecordWith(
+      id = id,
+      data = jsonString,
+      modifiedDate = Instant.parse(updatedDate)
+    )
+
+    val json = parse(jsonString).right.get
+
+    assertSierraRecordsAreEqual(
+      SierraRecordParser(SierraItemRecord.apply)(json),
+      expectedRecord
+    )
+  }
+
+  it("parses the date from deleted records") {
+    val id = createSierraBibNumber
+    val deletedDate = "2014-01-31"
+    val jsonString =
+      s"""
+         |{
+         |  "id" : "$id",
+         |  "deletedDate" : "$deletedDate",
+         |  "deleted" : true
+         |}
+         |""".stripMargin
+
+    val expectedRecord = createSierraBibRecordWith(
+      id = id,
+      data = jsonString,
+      modifiedDate = Instant.parse(s"${deletedDate}T00:00:00Z")
+    )
+
+    val json = parse(jsonString).right.get
+
+    assertSierraRecordsAreEqual(
+      SierraRecordParser(SierraBibRecord.apply)(json),
+      expectedRecord
+    )
+  }
+
+  private def assertSierraRecordsAreEqual(
+    x: AbstractSierraRecord,
+    y: AbstractSierraRecord): Assertion = {
+    x.id shouldBe x.id
+    assertJsonStringsAreEqual(x.data, y.data)
+    x.modifiedDate shouldBe y.modifiedDate
+  }
+}

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/parsers/SierraRecordParserTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/parsers/SierraRecordParserTest.scala
@@ -89,7 +89,7 @@ class SierraRecordParserTest
     val expectedRecord = createSierraBibRecordWith(
       id = id,
       data = jsonString,
-      modifiedDate = Instant.parse(s"${deletedDate}T00:00:00Z")
+      modifiedDate = Instant.parse(s"${deletedDate}T23:59:59.999999999Z")
     )
 
     val json = parse(jsonString).right.get


### PR DESCRIPTION
Fix for the first half of https://github.com/wellcometrust/platform/issues/4173

Waiting for somebody to confirm if records can ever be un-deleted.