### PR TITLE
Increase ingestor batchSize and make it easier to change batchSize

### DIFF
--- a/pipeline/ingestor/src/main/resources/application.conf
+++ b/pipeline/ingestor/src/main/resources/application.conf
@@ -1,6 +1,7 @@
 es.host=${?es_host}
 es.port=${?es_port}
 es.index=${?es_index}
+es.ingest.batchSize=${?es_ingest_batchSize}
 aws.metrics.namespace=${?metrics_namespace}
 es.username=${?es_username}
 es.password=${?es_password}

--- a/pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/config/builders/IngestorConfigBuilder.scala
+++ b/pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/config/builders/IngestorConfigBuilder.scala
@@ -13,7 +13,7 @@ object IngestorConfigBuilder {
     // TODO: Work out how to get a Duration from a Typesafe flag.
     val flushInterval = 1 minute
 
-    val batchSize = config.getOrElse[Int]("es.ingest.batchSize")(default = 100)
+    val batchSize = config.required[Int]("es.ingest.batchSize")
 
     val indexName = config.required[String]("es.index")
 

--- a/pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/config/builders/IngestorConfigBuilder.scala
+++ b/pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/config/builders/IngestorConfigBuilder.scala
@@ -30,7 +30,7 @@ object IngestorConfigBuilder {
                     default: Option[Int] = None): Int =
     Try(config.getAnyRef(path))
       .map {
-        case value: String => value.toInt
+        case value: String  => value.toInt
         case value: Integer => value.asInstanceOf[Int]
         case obj =>
           throw new RuntimeException(

--- a/pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/config/builders/IngestorConfigBuilder.scala
+++ b/pipeline/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/config/builders/IngestorConfigBuilder.scala
@@ -1,11 +1,12 @@
 package uk.ac.wellcome.platform.ingestor.config.builders
 
 import com.sksamuel.elastic4s.Index
-import com.typesafe.config.Config
+import com.typesafe.config.{Config, ConfigException}
 import uk.ac.wellcome.platform.ingestor.config.models.IngestorConfig
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
 
 import scala.concurrent.duration._
+import scala.util.Try
 
 object IngestorConfigBuilder {
   def buildIngestorConfig(config: Config): IngestorConfig = {
@@ -13,7 +14,7 @@ object IngestorConfigBuilder {
     // TODO: Work out how to get a Duration from a Typesafe flag.
     val flushInterval = 1 minute
 
-    val batchSize = config.required[Int]("es.ingest.batchSize")
+    val batchSize = intFromConfig(config, "es.ingest.batchSize")
 
     val indexName = config.required[String]("es.index")
 
@@ -23,4 +24,23 @@ object IngestorConfigBuilder {
       index = Index(indexName)
     )
   }
+
+  def intFromConfig(config: Config,
+                    path: String,
+                    default: Option[Int] = None): Int =
+    Try(config.getAnyRef(path))
+      .map {
+        case value: String => value.toInt
+        case value: Integer => value.asInstanceOf[Int]
+        case obj =>
+          throw new RuntimeException(
+            s"$path is invalid type: got $obj (type ${obj.getClass}), expected Int")
+      }
+      .recover {
+        case exc: ConfigException.Missing =>
+          default getOrElse {
+            throw new RuntimeException(s"${path} not defined in Config")
+          }
+      }
+      .get
 }

--- a/pipeline/terraform/stack/service_ingestor.tf
+++ b/pipeline/terraform/stack/service_ingestor.tf
@@ -36,9 +36,10 @@ module "ingestor" {
     metrics_namespace = "${local.namespace_hyphen}_ingestor"
     es_index          = "${var.es_works_index}"
     ingest_queue_id   = "${module.ingestor_queue.id}"
+    es_ingest_batchSize = 1000
   }
 
-  env_vars_length = 3
+  env_vars_length = 4
 
   secret_env_vars = {
     es_host     = "catalogue/ingestor/es_host"


### PR DESCRIPTION
Sometimes during reindexes, we see a lot of stuff ending up in the ingestor dlq. No errors in the logs and no failure metrics being sent to cloudwatch. Also, some of them do get ingested and some successes are notified.

My working theory is that the ingestor picks up messages quicker than it's able to ingest them so some of them stay in memory for longer than the visibility timeout of the queue, which means some of them end up redriven in the DLQ even though they haven't actually failed. 
This might be related to the default batchSIze of 100, which seems a bit small, so increasing to see if the problem goes away