### PR TITLE
hardcode elastic index name for API

### DIFF
--- a/api/api/src/main/resources/application.conf
+++ b/api/api/src/main/resources/application.conf
@@ -1,6 +1,5 @@
 es.host=${?es_host}
 es.port=${?es_port}
-es.index.v2=${?es_index_v2}
 es.username=${?es_username}
 es.password=${?es_password}
 es.protocol=${?es_protocol}

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/Main.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/Main.scala
@@ -5,6 +5,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer
 import com.typesafe.config.Config
+import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.elasticsearch.typesafe.ElasticBuilder
 import uk.ac.wellcome.platform.api.models.ApiConfig
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
@@ -26,8 +27,7 @@ object Main extends WellcomeTypesafeApp {
     Tracing.init(config)
     val elasticClient = ElasticBuilder.buildElasticClient(config)
 
-    val elasticConfig =
-      ElasticBuilder.buildElasticConfig()
+    val elasticConfig = ElasticConfig()
 
     val apiConfig =
       ApiConfig(

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/Main.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/Main.scala
@@ -6,7 +6,7 @@ import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer
 import com.sksamuel.elastic4s.Index
 import com.typesafe.config.Config
-import uk.ac.wellcome.elasticsearch.DisplayElasticConfig
+import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.elasticsearch.typesafe.ElasticBuilder
 import uk.ac.wellcome.platform.api.models.ApiConfig
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
@@ -29,7 +29,7 @@ object Main extends WellcomeTypesafeApp {
     val elasticClient = ElasticBuilder.buildElasticClient(config)
 
     val elasticConfig =
-      DisplayElasticConfig(indexV2 = Index(config.required("es.index.v2")))
+      ElasticBuilder.buildElasticConfig()
 
     val apiConfig =
       ApiConfig(

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/Main.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/Main.scala
@@ -4,9 +4,7 @@ import akka.Done
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer
-import com.sksamuel.elastic4s.Index
 import com.typesafe.config.Config
-import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.elasticsearch.typesafe.ElasticBuilder
 import uk.ac.wellcome.platform.api.models.ApiConfig
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/Router.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/Router.scala
@@ -15,7 +15,7 @@ import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 import com.sksamuel.elastic4s.{ElasticClient, ElasticError, Index}
 import io.circe.Printer
 import uk.ac.wellcome.platform.api.services.{ElasticsearchService, WorksService}
-import uk.ac.wellcome.elasticsearch.DisplayElasticConfig
+import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.platform.api.elasticsearch.ElasticErrorHandler
 import uk.ac.wellcome.platform.api.swagger.SwaggerDocs
 import uk.ac.wellcome.models.work.internal._
@@ -26,7 +26,7 @@ import uk.ac.wellcome.display.models.Implicits._
 import uk.ac.wellcome.display.json.DisplayJsonUtil
 
 class Router(elasticClient: ElasticClient,
-             elasticConfig: DisplayElasticConfig,
+             elasticConfig: ElasticConfig,
              apiConfig: ApiConfig)(implicit ec: ExecutionContext)
     extends FailFastCirceSupport
     with Directives
@@ -82,7 +82,7 @@ class Router(elasticClient: ElasticClient,
   def multipleWorks(params: MultipleWorksParams): Future[Route] =
     transactFuture("GET /works")({
       val searchOptions = params.searchOptions(apiConfig)
-      val index = params._index.map(Index(_)).getOrElse(elasticConfig.indexV2)
+      val index = params._index.map(Index(_)).getOrElse(elasticConfig.index)
       worksService
         .listOrSearchWorks(index, searchOptions)
         .map {
@@ -104,7 +104,7 @@ class Router(elasticClient: ElasticClient,
 
   def singleWork(id: String, params: SingleWorkParams): Future[Route] =
     transactFuture("GET /works/{workId}")({
-      val index = params._index.map(Index(_)).getOrElse(elasticConfig.indexV2)
+      val index = params._index.map(Index(_)).getOrElse(elasticConfig.index)
       val includes = params.include.getOrElse(V2WorksIncludes())
       worksService
         .findWorkById(id)(index)

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/ApiFixture.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/ApiFixture.scala
@@ -12,7 +12,7 @@ import com.sksamuel.elastic4s.Index
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.api.Router
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
-import uk.ac.wellcome.elasticsearch.DisplayElasticConfig
+import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.platform.api.models.ApiConfig
 
 trait ApiFixture
@@ -35,7 +35,7 @@ trait ApiFixture
     withLocalWorksIndex { indexV2 =>
       val router = new Router(
         elasticClient,
-        DisplayElasticConfig(indexV2 = indexV2),
+        ElasticConfig(index = indexV2),
         ApiConfig(
           host = apiHost,
           scheme = apiScheme,

--- a/api/api/src/universal/conf/application.ini.template
+++ b/api/api/src/universal/conf/application.ini.template
@@ -1,7 +1,6 @@
 -api.host=${api_host}
 -es.host=${es_host}
 -es.port=${es_port}
--es.index.v2=${es_index_v2}
 -es.username=${es_username}
 -es.password=${es_password}
 -es.protocol=${es_protocol}

--- a/api/terraform/catalogue_api/main.tf
+++ b/api/terraform/catalogue_api/main.tf
@@ -16,7 +16,6 @@ module "service" {
   container_port = "${local.api_container_port}"
 
   container_image = "${var.api_container_image}"
-  es_config       = "${var.es_config}"
   listener_port   = "${var.listener_port}"
 
   nginx_container_image = "${var.nginx_container_image}"

--- a/api/terraform/catalogue_api/service/main.tf
+++ b/api/terraform/catalogue_api/service/main.tf
@@ -47,7 +47,7 @@ module "task" {
   sidecar_cpu    = 512
   sidecar_memory = 1024
 
-  app_env_vars_length = 4
+  app_env_vars_length = 3
 
   app_env_vars = {
     api_host         = "api.wellcomecollection.org"
@@ -62,6 +62,8 @@ module "task" {
     APP_PORT = "${var.container_port}"
   }
 
+  secret_app_env_vars_length = 7
+
   secret_app_env_vars = {
     es_host        = "catalogue/api/es_host"
     es_port        = "catalogue/api/es_port"
@@ -71,8 +73,6 @@ module "task" {
     apm_server_url = "catalogue/api/apm_server_url"
     apm_secret     = "catalogue/api/apm_secret"
   }
-
-  secret_app_env_vars_length = 7
 
   aws_region = "eu-west-1"
   task_name  = "${var.namespace}"

--- a/api/terraform/catalogue_api/service/main.tf
+++ b/api/terraform/catalogue_api/service/main.tf
@@ -51,7 +51,6 @@ module "task" {
 
   app_env_vars = {
     api_host         = "api.wellcomecollection.org"
-    es_index_v2      = "${var.es_config["index_v2"]}"
     apm_service_name = "${var.namespace}"
     logstash_host    = "${var.logstash_host}"
   }

--- a/api/terraform/catalogue_api/service/variables.tf
+++ b/api/terraform/catalogue_api/service/variables.tf
@@ -1,7 +1,3 @@
-variable "es_config" {
-  type = "map"
-}
-
 variable "subnets" {
   type = "list"
 }

--- a/api/terraform/catalogue_api/variables.tf
+++ b/api/terraform/catalogue_api/variables.tf
@@ -1,10 +1,6 @@
 variable "namespace" {}
 variable "environment" {}
 
-variable "es_config" {
-  type = "map"
-}
-
 variable "task_desired_count" {}
 
 variable "subnets" {

--- a/api/terraform/locals.tf
+++ b/api/terraform/locals.tf
@@ -4,16 +4,6 @@ locals {
   prod_name        = "prod"
   staging_name     = "staging"
 
-  prod_es_config = {
-    index_v2 = "v2-20200107"
-    doc_type = "work"
-  }
-
-  staging_es_config = {
-    index_v2 = "v2-20200107"
-    doc_type = "work"
-  }
-
   prod_task_number    = 3
   staging_task_number = 1
 

--- a/api/terraform/main.tf
+++ b/api/terraform/main.tf
@@ -6,7 +6,6 @@ module "catalogue_api_prod" {
   nginx_container_image = "${module.prod_images.services["nginx_api-gw"]}"
   listener_port         = "${local.prod_listener_port}"
   task_desired_count    = "${local.prod_task_number}"
-  es_config             = "${local.prod_es_config}"
 
   namespace    = "${local.namespace}"
   vpc_id       = "${local.vpc_id}"
@@ -35,7 +34,6 @@ module "catalogue_api_staging" {
   nginx_container_image = "${module.staging_images.services["nginx_api-gw"]}"
   listener_port         = "${local.staging_listener_port}"
   task_desired_count    = "${local.staging_task_number}"
-  es_config             = "${local.staging_es_config}"
 
   namespace    = "${local.namespace}"
   vpc_id       = "${local.vpc_id}"

--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ElasticConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ElasticConfig.scala
@@ -5,3 +5,9 @@ import com.sksamuel.elastic4s.Index
 case class ElasticConfig(
   index: Index
 )
+
+object ElasticConfig {
+  // We use this to share config across API applications
+  // i.e. The API and the snapshot generator.
+  def apply(): ElasticConfig = ElasticConfig(index = Index("v2-20200131"))
+}

--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ElasticConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ElasticConfig.scala
@@ -2,6 +2,6 @@ package uk.ac.wellcome.elasticsearch
 
 import com.sksamuel.elastic4s.Index
 
-case class DisplayElasticConfig(
-  indexV2: Index
+case class ElasticConfig(
+  index: Index
 )

--- a/common/elasticsearch_typesafe/src/main/scala/uk/ac/wellcome/elasticsearch/typesafe/ElasticBuilder.scala
+++ b/common/elasticsearch_typesafe/src/main/scala/uk/ac/wellcome/elasticsearch/typesafe/ElasticBuilder.scala
@@ -1,9 +1,8 @@
 package uk.ac.wellcome.elasticsearch.typesafe
 
-import com.sksamuel.elastic4s.Index
 import com.sksamuel.elastic4s.ElasticClient
 import com.typesafe.config.Config
-import uk.ac.wellcome.elasticsearch.{ElasticClientBuilder, ElasticConfig}
+import uk.ac.wellcome.elasticsearch.ElasticClientBuilder
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
 
 object ElasticBuilder {
@@ -26,9 +25,4 @@ object ElasticBuilder {
       password = password
     )
   }
-
-  def buildElasticConfig(): ElasticConfig =
-    ElasticConfig(
-      index = Index("v2-20200131")
-    )
 }

--- a/common/elasticsearch_typesafe/src/main/scala/uk/ac/wellcome/elasticsearch/typesafe/ElasticBuilder.scala
+++ b/common/elasticsearch_typesafe/src/main/scala/uk/ac/wellcome/elasticsearch/typesafe/ElasticBuilder.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.elasticsearch.typesafe
 import com.sksamuel.elastic4s.Index
 import com.sksamuel.elastic4s.ElasticClient
 import com.typesafe.config.Config
-import uk.ac.wellcome.elasticsearch.{DisplayElasticConfig, ElasticClientBuilder}
+import uk.ac.wellcome.elasticsearch.{ElasticClientBuilder, ElasticConfig}
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
 
 object ElasticBuilder {
@@ -27,8 +27,8 @@ object ElasticBuilder {
     )
   }
 
-  def buildElasticConfig(config: Config): DisplayElasticConfig =
-    DisplayElasticConfig(
-      indexV2 = Index(config.required[String]("es.index.v2"))
+  def buildElasticConfig(): ElasticConfig =
+    ElasticConfig(
+      index = Index("v2-20200131")
     )
 }

--- a/pipeline/terraform/stack/variables.tf
+++ b/pipeline/terraform/stack/variables.tf
@@ -20,19 +20,20 @@ variable "release_label" {}
 variable "miro_adapter_topic_names" {
   type = "list"
 }
-variable "miro_adapter_topic_count" {
-}
+
+variable "miro_adapter_topic_count" {}
+
 variable "mets_adapter_topic_names" {
   type = "list"
 }
-variable "mets_adapter_topic_count" {
-}
+
+variable "mets_adapter_topic_count" {}
 
 variable "sierra_adapter_topic_names" {
   type = "list"
 }
-variable "sierra_adapter_topic_count" {
-}
+
+variable "sierra_adapter_topic_count" {}
 
 variable "vhs_miro_read_policy" {}
 
@@ -40,17 +41,12 @@ variable "vhs_sierra_read_policy" {}
 variable "vhs_sierra_sourcedata_bucket_name" {}
 variable "vhs_sierra_sourcedata_table_name" {}
 
-variable "mets_adapter_read_policy" {
-}
+variable "mets_adapter_read_policy" {}
 
-variable "mets_adapter_table_name" {
-}
+variable "mets_adapter_table_name" {}
 
 variable "private_subnets" {
   type = "list"
 }
 
-variable "read_storage_s3_role_arn" {
-}
-
-
+variable "read_storage_s3_role_arn" {}

--- a/snapshots/snapshot_generator/src/main/resources/application.conf
+++ b/snapshots/snapshot_generator/src/main/resources/application.conf
@@ -3,7 +3,6 @@ aws.sqs.queue.url=${?queue_url}
 aws.metrics.namespace=${?metrics_namespace}
 es.host=${?es_host}
 es.port=${?es_port}
-es.index.v2=${?es_index_v2}
 es.username=${?es_username}
 es.password=${?es_password}
 es.protocol=${?es_protocol}

--- a/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/Main.scala
+++ b/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/Main.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.platform.snapshot_generator
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.Config
+import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.elasticsearch.typesafe.ElasticBuilder
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.typesafe.{SNSBuilder, SQSBuilder}
@@ -27,7 +28,7 @@ object Main extends WellcomeTypesafeApp {
     val snapshotService = new SnapshotService(
       akkaS3Client = AkkaS3Builder.buildAkkaS3Client(config),
       elasticClient = ElasticBuilder.buildElasticClient(config),
-      elasticConfig = ElasticBuilder.buildElasticConfig()
+      elasticConfig = ElasticConfig()
     )
 
     new SnapshotGeneratorWorkerService(

--- a/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/Main.scala
+++ b/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/Main.scala
@@ -27,7 +27,7 @@ object Main extends WellcomeTypesafeApp {
     val snapshotService = new SnapshotService(
       akkaS3Client = AkkaS3Builder.buildAkkaS3Client(config),
       elasticClient = ElasticBuilder.buildElasticClient(config),
-      elasticConfig = ElasticBuilder.buildElasticConfig(config)
+      elasticConfig = ElasticBuilder.buildElasticConfig()
     )
 
     new SnapshotGeneratorWorkerService(

--- a/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotService.scala
+++ b/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotService.scala
@@ -13,7 +13,7 @@ import grizzled.slf4j.Logging
 
 import uk.ac.wellcome.display.models._
 import uk.ac.wellcome.display.models.v2.DisplayWorkV2
-import uk.ac.wellcome.elasticsearch.DisplayElasticConfig
+import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
 import uk.ac.wellcome.platform.snapshot_generator.flow.{
   DisplayWorkToJsonStringFlow,
@@ -28,7 +28,7 @@ import uk.ac.wellcome.platform.snapshot_generator.source.ElasticsearchWorksSourc
 
 class SnapshotService(akkaS3Client: S3Client,
                       elasticClient: ElasticClient,
-                      elasticConfig: DisplayElasticConfig)(
+                      elasticConfig: ElasticConfig)(
   implicit actorSystem: ActorSystem,
   materializer: ActorMaterializer,
   ec: ExecutionContext

--- a/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotService.scala
+++ b/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotService.scala
@@ -51,7 +51,7 @@ class SnapshotService(akkaS3Client: S3Client,
         runStream(
           publicBucketName = publicBucketName,
           publicObjectKey = publicObjectKey,
-          index = elasticConfig.indexV2,
+          index = elasticConfig.index,
           toDisplayWork = DisplayWorkV2.apply(_, V2WorksIncludes.includeAll())
         )
     }

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/fixtures/SnapshotServiceFixture.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/fixtures/SnapshotServiceFixture.scala
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
 import com.sksamuel.elastic4s.Index
 import com.sksamuel.elastic4s.ElasticClient
 import org.scalatest.Suite
-import uk.ac.wellcome.elasticsearch.DisplayElasticConfig
+import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.platform.snapshot_generator.services.SnapshotService
 import uk.ac.wellcome.fixtures.TestWith
@@ -25,7 +25,7 @@ trait SnapshotServiceFixture extends ElasticsearchFixtures { this: Suite =>
     testWith: TestWith[SnapshotService, R])(
     implicit actorSystem: ActorSystem,
     materializer: ActorMaterializer): R = {
-    val elasticConfig = DisplayElasticConfig(indexV2 = indexV2)
+    val elasticConfig = ElasticConfig(index = indexV2)
 
     val snapshotService = new SnapshotService(
       elasticClient = elasticClient,


### PR DESCRIPTION
After a few different tries at how to do this, having the index hardcoded seems like a way that makes sense.

This does mean we need to build to have a release, but means fewer steps in deployment.