### PR TITLE
Store CALM records in adapter

### DIFF
--- a/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmRecord.scala
+++ b/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmRecord.scala
@@ -1,3 +1,3 @@
 package uk.ac.wellcome.calm_adapter
 
-case class CalmRecord(data: Map[String, String])
+case class CalmRecord(id: String, data: Map[String, String])

--- a/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmStore.scala
+++ b/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmStore.scala
@@ -1,0 +1,32 @@
+package uk.ac.wellcome.calm_adapter
+
+import uk.ac.wellcome.storage.{Identified, Version, NoVersionExistsError}
+import uk.ac.wellcome.storage.store.VersionedStore
+
+class CalmStore(store: VersionedStore[String, Int, Map[String, String]]) {
+
+  type Key = Version[String, Int]
+
+  type Result[T] = Either[Throwable, T]
+
+  def putRecord(record: CalmRecord): Result[Option[Key]] = 
+    shouldStoreRecord(record)
+      .flatMap {
+        case false         => Right(None)
+        case true          => store
+          .putLatest(record.id)(record.data)
+          .map { case Identified(key, _) => Some(key) }
+          .left
+          .map(_.e)
+      }
+
+  def shouldStoreRecord(record: CalmRecord): Result[Boolean] =
+    store
+      .getLatest(record.id)
+      .map { case Identified(_, storedData) => record.data != storedData }
+      .left
+      .flatMap { 
+        case NoVersionExistsError(_) => Right(true)
+        case err => Left(err.e)
+      }
+}

--- a/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmXmlResponse.scala
+++ b/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmXmlResponse.scala
@@ -92,7 +92,7 @@ case class CalmSummaryResponse(val root: Elem)
         val data = node.map(child => child.label -> child.text).toMap
         data
           .get("RecordID")
-          .map(id  =>  Right(CalmRecord(id, data)))
+          .map(id => Right(CalmRecord(id, data)))
           .getOrElse(Left(new Exception("RecordID not found")))
       }
 }

--- a/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmXmlResponse.scala
+++ b/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmXmlResponse.scala
@@ -88,12 +88,12 @@ case class CalmSummaryResponse(val root: Elem)
       .flatMap(_.childWithTag("SummaryList"))
       .flatMap(_.childWithTag("Summary"))
       .map(_ \ "_")
-      .map { node =>
-        CalmRecord(
-          node
-            .map(child => child.label -> child.text)
-            .toMap
-        )
+      .flatMap { node =>
+        val data = node.map(child => child.label -> child.text).toMap
+        data
+          .get("RecordID")
+          .map(id  =>  Right(CalmRecord(id, data)))
+          .getOrElse(Left(new Exception("RecordID not found")))
       }
 }
 

--- a/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/Main.scala
+++ b/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/Main.scala
@@ -24,7 +24,8 @@ object Main extends WellcomeTypesafeApp {
       new CalmRetriever {
         def apply(query: CalmQuery): Future[List[CalmRecord]] =
           ???
-      }
+      },
+      new CalmStore(???)
     )
   }
 }

--- a/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmRetrieverTest.scala
+++ b/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmRetrieverTest.scala
@@ -166,7 +166,7 @@ class CalmRetrieverTest
     }
   }
 
-  it("fails if no RecordID in the response") {
+  it("fails if there is no RecordID in the response") {
     val responses = List(
       searchResponse(1),
       summaryResponse(Nil)

--- a/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmRetrieverTest.scala
+++ b/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmRetrieverTest.scala
@@ -30,14 +30,15 @@ class CalmRetrieverTest
       searchResponse(2),
       summaryResponse(
         List("RecordID" -> "1", "keyA" -> "valueA", "keyB" -> "valueB")),
-      summaryResponse(
-        List("RecordID" -> "2", "keyC" -> "valueC"))
+      summaryResponse(List("RecordID" -> "2", "keyC" -> "valueC"))
     )
     withCalmRetriever(responses) {
       case (calmRetriever, _) =>
         whenReady(calmRetriever(query)) { records =>
           records shouldBe List(
-            CalmRecord("1", Map("RecordID" -> "1", "keyA" -> "valueA", "keyB" -> "valueB")),
+            CalmRecord(
+              "1",
+              Map("RecordID" -> "1", "keyA" -> "valueA", "keyB" -> "valueB")),
             CalmRecord("2", Map("RecordID" -> "2", "keyC" -> "valueC")),
           )
         }

--- a/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmStoreTest.scala
+++ b/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmStoreTest.scala
@@ -17,7 +17,7 @@ class CalmStoreTest extends FunSpec with Matchers {
     val record = CalmRecord("A", Map("key" -> "value"))
     calmStore(data).putRecord(record) shouldBe Right(Some(Version("A", 0)))
     data.entries shouldBe Map(
-      Version("A", 0) ->  Map("key" -> "value")
+      Version("A", 0) -> Map("key" -> "value")
     )
   }
 
@@ -26,8 +26,8 @@ class CalmStoreTest extends FunSpec with Matchers {
     val record = CalmRecord("A", Map("key" -> "new"))
     calmStore(data).putRecord(record) shouldBe Right(Some(Version("A", 2)))
     data.entries shouldBe Map(
-      Version("A", 1) ->  Map("key" -> "old"),
-      Version("A", 2) ->  Map("key" -> "new")
+      Version("A", 1) -> Map("key" -> "old"),
+      Version("A", 2) -> Map("key" -> "new")
     )
   }
 
@@ -36,7 +36,7 @@ class CalmStoreTest extends FunSpec with Matchers {
     val record = CalmRecord("A", Map("key" -> "new"))
     calmStore(data).putRecord(record) shouldBe Right(None)
     data.entries shouldBe Map(
-      Version("A", 4) ->  Map("key" -> "new"),
+      Version("A", 4) -> Map("key" -> "new"),
     )
   }
 
@@ -53,8 +53,7 @@ class CalmStoreTest extends FunSpec with Matchers {
     data.entries shouldBe Map.empty
   }
 
-  def dataStore(
-    entries: Map[Key, Data] = Map.empty) =
+  def dataStore(entries: Map[Key, Data] = Map.empty) =
     new MemoryStore(entries) with MemoryMaxima[String, Data]
 
   def calmStore(data: MemoryStore[Key, Data] with Maxima[String, Int]) =

--- a/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmStoreTest.scala
+++ b/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmStoreTest.scala
@@ -1,0 +1,62 @@
+package uk.ac.wellcome.calm_adapter
+
+import org.scalatest.{FunSpec, Matchers}
+
+import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryVersionedStore}
+import uk.ac.wellcome.storage.maxima.Maxima
+import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
+import uk.ac.wellcome.storage.{StoreReadError, Version}
+
+class CalmStoreTest extends FunSpec with Matchers {
+
+  type Key = Version[String, Int]
+  type Data = Map[String, String]
+
+  it("stores new CALM records") {
+    val data = dataStore()
+    val record = CalmRecord("A", Map("key" -> "value"))
+    calmStore(data).putRecord(record) shouldBe Right(Some(Version("A", 0)))
+    data.entries shouldBe Map(
+      Version("A", 0) ->  Map("key" -> "value")
+    )
+  }
+
+  it("stores already seen CALM records when the data has changed") {
+    val data = dataStore(Map(Version("A", 1) -> Map("key" -> "old")))
+    val record = CalmRecord("A", Map("key" -> "new"))
+    calmStore(data).putRecord(record) shouldBe Right(Some(Version("A", 2)))
+    data.entries shouldBe Map(
+      Version("A", 1) ->  Map("key" -> "old"),
+      Version("A", 2) ->  Map("key" -> "new")
+    )
+  }
+
+  it("doesn't store already seen CALM records when unchanged data") {
+    val data = dataStore(Map(Version("A", 4) -> Map("key" -> "new")))
+    val record = CalmRecord("A", Map("key" -> "new"))
+    calmStore(data).putRecord(record) shouldBe Right(None)
+    data.entries shouldBe Map(
+      Version("A", 4) ->  Map("key" -> "new"),
+    )
+  }
+
+  it("doesn't store CALM records when checking the stored data fails") {
+    val data = dataStore()
+    val record = CalmRecord("A", Map("key" -> "value"))
+    val calmStore = new CalmStore(
+      new MemoryVersionedStore(data) {
+        override def getLatest(id: String): ReadEither =
+          Left(StoreReadError(new Exception("Not today mate")))
+      }
+    )
+    calmStore.putRecord(record) shouldBe a[Left[_, _]]
+    data.entries shouldBe Map.empty
+  }
+
+  def dataStore(
+    entries: Map[Key, Data] = Map.empty) =
+    new MemoryStore(entries) with MemoryMaxima[String, Data]
+
+  def calmStore(data: MemoryStore[Key, Data] with Maxima[String, Int]) =
+    new CalmStore(new MemoryVersionedStore(data))
+}

--- a/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmXmlResponseTest.scala
+++ b/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmXmlResponseTest.scala
@@ -68,6 +68,7 @@ class CalmXmlResponseTest extends FunSpec with Matchers {
                     <RefNo>WT/B/2/5/2/3</RefNo>
                     <Date>September 1996-April 2002  </Date>
                     <Modified><span class="HIT">30</span>/01/2020</Modified>
+                    <RecordID>123</RecordID>
                   </Summary>
                 </SummaryList>
               </SummaryHeaderResult>
@@ -76,12 +77,14 @@ class CalmXmlResponseTest extends FunSpec with Matchers {
         </soap:Envelope>
       CalmSummaryResponse(xml).parse shouldBe Right(
         CalmRecord(
+          "123",
           Map(
             "RecordType" -> "Component",
             "IDENTITY" -> "",
             "RefNo" -> "WT/B/2/5/2/3",
             "Date" -> "September 1996-April 2002  ",
-            "Modified" -> "30/01/2020"
+            "Modified" -> "30/01/2020",
+            "RecordID" -> "123"
           )
         )
       )


### PR DESCRIPTION
## Issue

https://github.com/wellcometrust/platform/issues/4210

## Description

This PR adds to the adapter a store for the CALM records, which will be made accessible from the transformer.

Messages are only emitted to the transformer if either

1) We have never seen a record with that `RecordID` before
2) The data for a particular `RecordID` has changed