### PR TITLE
add test to ensure collection can be indexed

### DIFF
--- a/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/IndexConfigTest.scala
+++ b/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/IndexConfigTest.scala
@@ -24,6 +24,7 @@ import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.{
   AccessCondition,
   AccessStatus,
+  Collection,
   IdentifiedBaseWork,
   Person,
   Subject,
@@ -111,6 +112,26 @@ class IndexConfigTest
         items = List(
           createIdentifiedItemWith(locations = List(createDigitalLocationWith(
             accessConditions = List(accessCondition))))))
+      whenReady(indexObject(index, sampleWork)) { _ =>
+        assertObjectIndexed(index, sampleWork)
+      }
+    }
+  }
+
+  // Because we use copy_to and some other index functionality
+  // the potentially fails at PUT index time, we urn this test
+  // e.g. copy_to was previously set to `collection.depth`
+  // which would not work as the mapping is strict and `collection`
+  // only exists at the `data.collection` level
+  it("puts a work with a collection") {
+    val collection =
+      Some(
+        Collection(
+          path = "PATH/FOR/THE/COLLECTION",
+          label = Some("PATH/FOR/THE/COLLECTION")))
+
+    withLocalWorksIndex { index =>
+      val sampleWork = createIdentifiedWorkWith(collection = collection)
       whenReady(indexObject(index, sampleWork)) { _ =>
         assertObjectIndexed(index, sampleWork)
       }

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
@@ -149,7 +149,8 @@ trait WorksGenerators extends ItemsGenerators with ProductionEventGenerators {
     duration: Option[Int] = None,
     items: List[Item[Minted]] = Nil,
     version: Int = 1,
-    merged: Boolean = false
+    merged: Boolean = false,
+    collection: Option[Collection] = None,
   ): IdentifiedWork =
     IdentifiedWork(
       canonicalId = canonicalId,
@@ -175,7 +176,8 @@ trait WorksGenerators extends ItemsGenerators with ProductionEventGenerators {
         notes = notes,
         duration = duration,
         items = items,
-        merged = merged
+        merged = merged,
+        collection = collection,
       )
     )
 


### PR DESCRIPTION
as #401 was a bug, this makes sure it doesn't happen.

We'll be adding tests for the queries on collections which will ensure depth etc has been calculated properly, so leaving those till them.