### PR TITLE
Don't store CalmRecord's older than the data currently stored

### DIFF
--- a/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerService.scala
+++ b/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerService.scala
@@ -23,7 +23,8 @@ case class CalmWindow(date: LocalDate)
   *  Consists of the following stages:
   *  - Retrieve all CALM records which have modified field the same date as the
   *    window
-  *  - Store these records in VHS, filtering out ones where the data is unchanged
+  *  - Store these records in VHS, filtering out ones older than what is
+  *    currently in  the store
   *  - Publish the VHS key to SNS
   */
 class CalmAdapterWorkerService(

--- a/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmRecord.scala
+++ b/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmRecord.scala
@@ -1,3 +1,9 @@
 package uk.ac.wellcome.calm_adapter
 
-case class CalmRecord(id: String, data: Map[String, String])
+import java.time.Instant
+
+case class CalmRecord(
+  id: String,
+  data: Map[String, String],
+  retrievedAt: Instant
+)

--- a/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmSession.scala
+++ b/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmSession.scala
@@ -1,0 +1,5 @@
+package uk.ac.wellcome.calm_adapter
+
+import akka.http.scaladsl.model.headers.Cookie
+
+case class CalmSession(numHits: Int, cookie: Cookie)

--- a/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmStore.scala
+++ b/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmStore.scala
@@ -26,7 +26,7 @@ class CalmStore(store: VersionedStore[String, Int, CalmRecord]) {
       .getLatest(record.id)
       .map {
         case Identified(_, storedRecord) =>
-          record.retrievedAt.toEpochMilli > storedRecord.retrievedAt.toEpochMilli
+          record.retrievedAt.isAfter(storedRecord.retrievedAt)
       }
       .left
       .flatMap {

--- a/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmStore.scala
+++ b/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmStore.scala
@@ -30,7 +30,8 @@ class CalmStore(store: VersionedStore[String, Int, CalmRecord]) {
           val differingData = record.data != storedRecord.data
           if (sameTimestamp && differingData)
             Left(
-              new Exception("Cannot resolve latest data as timestamps are equal")
+              new Exception(
+                "Cannot resolve latest data as timestamps are equal")
             )
           else
             Right(record.retrievedAt.isAfter(storedRecord.retrievedAt))

--- a/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmStore.scala
+++ b/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmStore.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.calm_adapter
 import uk.ac.wellcome.storage.{Identified, NoVersionExistsError, Version}
 import uk.ac.wellcome.storage.store.VersionedStore
 
-class CalmStore(store: VersionedStore[String, Int, Map[String, String]]) {
+class CalmStore(store: VersionedStore[String, Int, CalmRecord]) {
 
   type Key = Version[String, Int]
 
@@ -15,7 +15,7 @@ class CalmStore(store: VersionedStore[String, Int, Map[String, String]]) {
         case false => Right(None)
         case true =>
           store
-            .putLatest(record.id)(record.data)
+            .putLatest(record.id)(record)
             .map { case Identified(key, _) => Some(key) }
             .left
             .map(_.e)
@@ -24,7 +24,10 @@ class CalmStore(store: VersionedStore[String, Int, Map[String, String]]) {
   def shouldStoreRecord(record: CalmRecord): Result[Boolean] =
     store
       .getLatest(record.id)
-      .map { case Identified(_, storedData) => record.data != storedData }
+      .map {
+        case Identified(_, storedRecord) =>
+          record.retrievedAt.toEpochMilli > storedRecord.retrievedAt.toEpochMilli
+      }
       .left
       .flatMap {
         case NoVersionExistsError(_) => Right(true)

--- a/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmStoreTest.scala
+++ b/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmStoreTest.scala
@@ -35,7 +35,7 @@ class CalmStoreTest extends FunSpec with Matchers {
     )
   }
 
-  it("doesn't store already seen CALM records when older data") {
+  it("does not replace a stored CALM record if the retrieval date on the new record is older") {
     val oldRecord = CalmRecord("A", Map("key" -> "old"), retrievedAt)
     val newRecord = CalmRecord(
       "A",

--- a/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmStoreTest.scala
+++ b/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmStoreTest.scala
@@ -35,7 +35,8 @@ class CalmStoreTest extends FunSpec with Matchers {
     )
   }
 
-  it("does not replace a stored CALM record if the retrieval date on the new record is older") {
+  it(
+    "does not replace a stored CALM record if the retrieval date on the new record is older") {
     val oldRecord = CalmRecord("A", Map("key" -> "old"), retrievedAt)
     val newRecord = CalmRecord(
       "A",

--- a/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmStoreTest.scala
+++ b/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmStoreTest.scala
@@ -58,6 +58,14 @@ class CalmStoreTest extends FunSpec with Matchers {
     data.entries shouldBe Map.empty
   }
 
+  it("errors if the data differs but timestamp is the same") {
+    val x = CalmRecord("A", Map("key" -> "x"), retrievedAt)
+    val y = CalmRecord("A", Map("key" -> "y"), retrievedAt)
+    val data = dataStore(Version("A", 2) -> x)
+    calmStore(data).putRecord(y) shouldBe a[Left[_, _]]
+    data.entries shouldBe Map(Version("A", 2) -> x)
+  }
+
   def dataStore(entries: (Key, CalmRecord)*) =
     new MemoryStore(entries.toMap) with MemoryMaxima[String, CalmRecord]
 

--- a/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmStoreTest.scala
+++ b/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmStoreTest.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.calm_adapter
 
 import org.scalatest.{FunSpec, Matchers}
+import java.time.Instant
 
 import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryVersionedStore}
 import uk.ac.wellcome.storage.maxima.Maxima
@@ -10,39 +11,44 @@ import uk.ac.wellcome.storage.{StoreReadError, Version}
 class CalmStoreTest extends FunSpec with Matchers {
 
   type Key = Version[String, Int]
-  type Data = Map[String, String]
+
+  val retrievedAt = Instant.ofEpochSecond(123456)
 
   it("stores new CALM records") {
     val data = dataStore()
-    val record = CalmRecord("A", Map("key" -> "value"))
+    val record = CalmRecord("A", Map("key" -> "value"), retrievedAt)
     calmStore(data).putRecord(record) shouldBe Right(Some(Version("A", 0)))
+    data.entries shouldBe Map(Version("A", 0) -> record)
+  }
+
+  it("stores already seen CALM records when newer data") {
+    val oldRecord = CalmRecord("A", Map("key" -> "old"), retrievedAt)
+    val newRecord = CalmRecord(
+      "A",
+      Map("key" -> "new"),
+      Instant.ofEpochSecond(retrievedAt.getEpochSecond + 2))
+    val data = dataStore(Version("A", 1) -> oldRecord)
+    calmStore(data).putRecord(newRecord) shouldBe Right(Some(Version("A", 2)))
     data.entries shouldBe Map(
-      Version("A", 0) -> Map("key" -> "value")
+      Version("A", 1) -> oldRecord,
+      Version("A", 2) -> newRecord
     )
   }
 
-  it("stores already seen CALM records when the data has changed") {
-    val data = dataStore(Map(Version("A", 1) -> Map("key" -> "old")))
-    val record = CalmRecord("A", Map("key" -> "new"))
-    calmStore(data).putRecord(record) shouldBe Right(Some(Version("A", 2)))
-    data.entries shouldBe Map(
-      Version("A", 1) -> Map("key" -> "old"),
-      Version("A", 2) -> Map("key" -> "new")
-    )
-  }
-
-  it("doesn't store already seen CALM records when unchanged data") {
-    val data = dataStore(Map(Version("A", 4) -> Map("key" -> "new")))
-    val record = CalmRecord("A", Map("key" -> "new"))
-    calmStore(data).putRecord(record) shouldBe Right(None)
-    data.entries shouldBe Map(
-      Version("A", 4) -> Map("key" -> "new"),
-    )
+  it("doesn't store already seen CALM records when older data") {
+    val oldRecord = CalmRecord("A", Map("key" -> "old"), retrievedAt)
+    val newRecord = CalmRecord(
+      "A",
+      Map("key" -> "new"),
+      Instant.ofEpochSecond(retrievedAt.getEpochSecond + 2))
+    val data = dataStore(Version("A", 4) -> newRecord)
+    calmStore(data).putRecord(oldRecord) shouldBe Right(None)
+    data.entries shouldBe Map(Version("A", 4) -> newRecord)
   }
 
   it("doesn't store CALM records when checking the stored data fails") {
     val data = dataStore()
-    val record = CalmRecord("A", Map("key" -> "value"))
+    val record = CalmRecord("A", Map("key" -> "value"), retrievedAt)
     val calmStore = new CalmStore(
       new MemoryVersionedStore(data) {
         override def getLatest(id: String): ReadEither =
@@ -53,9 +59,9 @@ class CalmStoreTest extends FunSpec with Matchers {
     data.entries shouldBe Map.empty
   }
 
-  def dataStore(entries: Map[Key, Data] = Map.empty) =
-    new MemoryStore(entries) with MemoryMaxima[String, Data]
+  def dataStore(entries: (Key, CalmRecord)*) =
+    new MemoryStore(entries.toMap) with MemoryMaxima[String, CalmRecord]
 
-  def calmStore(data: MemoryStore[Key, Data] with Maxima[String, Int]) =
+  def calmStore(data: MemoryStore[Key, CalmRecord] with Maxima[String, Int]) =
     new CalmStore(new MemoryVersionedStore(data))
 }

--- a/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmStoreTest.scala
+++ b/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmStoreTest.scala
@@ -22,11 +22,10 @@ class CalmStoreTest extends FunSpec with Matchers {
   }
 
   it("replaces a previously stored CALM record if the retrieval date is newer") {
-    val oldRecord = CalmRecord("A", Map("key" -> "old"), retrievedAt)
-    val newRecord = CalmRecord(
-      "A",
-      Map("key" -> "new"),
-      Instant.ofEpochSecond(retrievedAt.getEpochSecond + 2))
+    val oldTime = retrievedAt
+    val newTime = Instant.ofEpochSecond(retrievedAt.getEpochSecond + 2)
+    val oldRecord = CalmRecord("A", Map("key" -> "old"), oldTime)
+    val newRecord = CalmRecord("A", Map("key" -> "new"), newTime)
     val data = dataStore(Version("A", 1) -> oldRecord)
     calmStore(data).putRecord(newRecord) shouldBe Right(Some(Version("A", 2)))
     data.entries shouldBe Map(
@@ -37,11 +36,10 @@ class CalmStoreTest extends FunSpec with Matchers {
 
   it(
     "does not replace a stored CALM record if the retrieval date on the new record is older") {
-    val oldRecord = CalmRecord("A", Map("key" -> "old"), retrievedAt)
-    val newRecord = CalmRecord(
-      "A",
-      Map("key" -> "new"),
-      Instant.ofEpochSecond(retrievedAt.getEpochSecond + 2))
+    val oldTime = retrievedAt
+    val newTime = Instant.ofEpochSecond(retrievedAt.getEpochSecond + 2)
+    val oldRecord = CalmRecord("A", Map("key" -> "old"), oldTime)
+    val newRecord = CalmRecord("A", Map("key" -> "old"), newTime)
     val data = dataStore(Version("A", 4) -> newRecord)
     calmStore(data).putRecord(oldRecord) shouldBe Right(None)
     data.entries shouldBe Map(Version("A", 4) -> newRecord)

--- a/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmStoreTest.scala
+++ b/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmStoreTest.scala
@@ -21,7 +21,7 @@ class CalmStoreTest extends FunSpec with Matchers {
     data.entries shouldBe Map(Version("A", 0) -> record)
   }
 
-  it("stores already seen CALM records when newer data") {
+  it("replaces a previously stored CALM record if the retrieval date is newer") {
     val oldRecord = CalmRecord("A", Map("key" -> "old"), retrievedAt)
     val newRecord = CalmRecord(
       "A",


### PR DESCRIPTION
## Issue

https://github.com/wellcometrust/platform/issues/4210

## Description

Currently we check whether the the Calm record in the store differs to that which has just been retrieved, swallowing the message if the data is unchanged. There are 2 issues relating to this:

1) If messages arrive out of order, we could end up storing older records than what currently exists.
2) If the message fails publishing to SNS post storage, the next time round it is picked up from the queue it will appear as nothing needs to be done, as the data already exists in the store.

To fix the above we do the following:

a) Use the timestamp from the Calm API response header to make it impossible to store older data
b) Always publish the key to SNS if the retrieved data is more recent

Note that point b here will potentially result in many redundant messages to the transformer (especially as we are using a daily window, but will want updates relatively regularly), so to mitigate this in a future PR we may add an extra `published` field to `CalmRecord`, which is written after SNS message is successfully sent.