### PR TITLE
CalmRecord should store list of values

### DIFF
--- a/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmRecord.scala
+++ b/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmRecord.scala
@@ -4,6 +4,6 @@ import java.time.Instant
 
 case class CalmRecord(
   id: String,
-  data: Map[String, String],
+  data: Map[String, List[String]],
   retrievedAt: Instant
 )

--- a/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmRetrieverTest.scala
+++ b/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmRetrieverTest.scala
@@ -39,11 +39,14 @@ class CalmRetrieverTest
           records shouldBe List(
             CalmRecord(
               "1",
-              Map("RecordID" -> "1", "keyA" -> "valueA", "keyB" -> "valueB"),
+              Map(
+                "RecordID" -> List("1"),
+                "keyA" -> List("valueA"),
+                "keyB" -> List("valueB")),
               retrievedAt),
             CalmRecord(
               "2",
-              Map("RecordID" -> "2", "keyC" -> "valueC"),
+              Map("RecordID" -> List("2"), "keyC" -> List("valueC")),
               retrievedAt),
           )
         }

--- a/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmStoreTest.scala
+++ b/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmStoreTest.scala
@@ -16,7 +16,7 @@ class CalmStoreTest extends FunSpec with Matchers {
 
   it("stores new CALM records") {
     val data = dataStore()
-    val record = CalmRecord("A", Map("key" -> "value"), retrievedAt)
+    val record = CalmRecord("A", Map("key" -> List("value")), retrievedAt)
     calmStore(data).putRecord(record) shouldBe Right(Some(Version("A", 0)))
     data.entries shouldBe Map(Version("A", 0) -> record)
   }
@@ -24,8 +24,8 @@ class CalmStoreTest extends FunSpec with Matchers {
   it("replaces a previously stored CALM record if the retrieval date is newer") {
     val oldTime = retrievedAt
     val newTime = Instant.ofEpochSecond(retrievedAt.getEpochSecond + 2)
-    val oldRecord = CalmRecord("A", Map("key" -> "old"), oldTime)
-    val newRecord = CalmRecord("A", Map("key" -> "new"), newTime)
+    val oldRecord = CalmRecord("A", Map("key" -> List("old")), oldTime)
+    val newRecord = CalmRecord("A", Map("key" -> List("new")), newTime)
     val data = dataStore(Version("A", 1) -> oldRecord)
     calmStore(data).putRecord(newRecord) shouldBe Right(Some(Version("A", 2)))
     data.entries shouldBe Map(
@@ -38,8 +38,8 @@ class CalmStoreTest extends FunSpec with Matchers {
     "does not replace a stored CALM record if the retrieval date on the new record is older") {
     val oldTime = retrievedAt
     val newTime = Instant.ofEpochSecond(retrievedAt.getEpochSecond + 2)
-    val oldRecord = CalmRecord("A", Map("key" -> "old"), oldTime)
-    val newRecord = CalmRecord("A", Map("key" -> "old"), newTime)
+    val oldRecord = CalmRecord("A", Map("key" -> List("old")), oldTime)
+    val newRecord = CalmRecord("A", Map("key" -> List("old")), newTime)
     val data = dataStore(Version("A", 4) -> newRecord)
     calmStore(data).putRecord(oldRecord) shouldBe Right(None)
     data.entries shouldBe Map(Version("A", 4) -> newRecord)
@@ -47,7 +47,7 @@ class CalmStoreTest extends FunSpec with Matchers {
 
   it("doesn't store CALM records when checking the stored data fails") {
     val data = dataStore()
-    val record = CalmRecord("A", Map("key" -> "value"), retrievedAt)
+    val record = CalmRecord("A", Map("key" -> List("value")), retrievedAt)
     val calmStore = new CalmStore(
       new MemoryVersionedStore(data) {
         override def getLatest(id: String): ReadEither =
@@ -59,8 +59,8 @@ class CalmStoreTest extends FunSpec with Matchers {
   }
 
   it("errors if the data differs but timestamp is the same") {
-    val x = CalmRecord("A", Map("key" -> "x"), retrievedAt)
-    val y = CalmRecord("A", Map("key" -> "y"), retrievedAt)
+    val x = CalmRecord("A", Map("key" -> List("x")), retrievedAt)
+    val y = CalmRecord("A", Map("key" -> List("y")), retrievedAt)
     val data = dataStore(Version("A", 2) -> x)
     calmStore(data).putRecord(y) shouldBe a[Left[_, _]]
     data.entries shouldBe Map(Version("A", 2) -> x)


### PR DESCRIPTION
## Issue

https://github.com/wellcometrust/platform/issues/4210

## Description

Repeated keys in Calm XML are not handled, even though they have been seen to exist in the data.

Here we update from a `Map[String, String]` to a `Map[String, List[String]]` to handle multiple values. We will leave it up to the transformer to make sense of this data.