### PR TITLE
New tf 0.12 pipeline

### DIFF
--- a/pipeline/terraform0.12/ecr.tf
+++ b/pipeline/terraform0.12/ecr.tf
@@ -1,0 +1,39 @@
+resource "aws_ecr_repository" "ecr_repository_nginx_services" {
+  name = "uk.ac.wellcome/nginx_services"
+}
+
+resource "aws_ecr_repository" "ecr_repository_transformer_miro" {
+  name = "uk.ac.wellcome/transformer_miro"
+}
+
+resource "aws_ecr_repository" "ecr_repository_transformer_sierra" {
+  name = "uk.ac.wellcome/transformer_sierra"
+}
+
+resource "aws_ecr_repository" "ecr_repository_transformer_mets" {
+  name = "uk.ac.wellcome/transformer_mets"
+}
+
+resource "aws_ecr_repository" "ecr_repository_id_minter" {
+  name = "uk.ac.wellcome/id_minter"
+}
+
+resource "aws_ecr_repository" "ecr_repository_recorder" {
+  name = "uk.ac.wellcome/recorder"
+}
+
+resource "aws_ecr_repository" "ecr_repository_matcher" {
+  name = "uk.ac.wellcome/matcher"
+}
+
+resource "aws_ecr_repository" "ecr_repository_merger" {
+  name = "uk.ac.wellcome/merger"
+}
+
+resource "aws_ecr_repository" "ecr_repository_ingestor" {
+  name = "uk.ac.wellcome/ingestor"
+}
+
+resource "aws_ecr_repository" "ecr_repository_elasticdump" {
+  name = "uk.ac.wellcome/elasticdump"
+}

--- a/pipeline/terraform0.12/iam.tf
+++ b/pipeline/terraform0.12/iam.tf
@@ -1,0 +1,32 @@
+resource "aws_iam_role" "read_storage_s3" {
+  name               = "read_storage_s3_role"
+  assume_role_policy = data.aws_iam_policy_document.no-assume-role-policy.json
+}
+
+data "aws_iam_policy_document" "no-assume-role-policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "storage_s3_read" {
+  role   = aws_iam_role.read_storage_s3.name
+  policy = data.aws_iam_policy_document.allow_storage_access.json
+}
+
+data "aws_iam_policy_document" "allow_storage_access" {
+  statement {
+    actions = [
+      "s3:GetObject*",
+      "s3:ListBucket",
+    ]
+
+    resources = ["arn:aws:s3:::${local.storage_bucket}", "arn:aws:s3:::${local.storage_bucket}/*"]
+  }
+}
+

--- a/pipeline/terraform0.12/locals.tf
+++ b/pipeline/terraform0.12/locals.tf
@@ -1,0 +1,35 @@
+locals {
+  miro_updates_topic_name = data.terraform_remote_state.shared_infra.outputs.miro_updates_topic_name
+  vhs_miro_read_policy    = data.terraform_remote_state.catalogue_infra_critical.outputs.vhs_miro_read_policy
+  storage_bucket          = "wellcomecollection-storage"
+
+  # Sierra adapter VHS
+  vhs_sierra_read_policy            = data.terraform_remote_state.catalogue_infra_critical.outputs.vhs_sierra_read_policy
+  vhs_sierra_sourcedata_bucket_name = data.terraform_remote_state.catalogue_infra_critical.outputs.vhs_sierra_bucket_name
+  vhs_sierra_sourcedata_table_name  = data.terraform_remote_state.catalogue_infra_critical.outputs.vhs_sierra_table_name
+
+  # Sierra adapter topics
+  sierra_merged_items_topic_name = data.terraform_remote_state.sierra_adapter.outputs.merged_items_topic_name
+  sierra_merged_bibs_topic_name  = data.terraform_remote_state.sierra_adapter.outputs.merged_bibs_topic_name
+
+  # Mets adapter VHS
+  mets_adapter_read_policy = data.terraform_remote_state.catalogue_infra_critical.outputs.mets_dynamo_read_policy
+  mets_adapter_table_name  = data.terraform_remote_state.catalogue_infra_critical.outputs.mets_dynamo_table_name
+
+  # Mets adapter topics
+  mets_adapter_topic_name = data.terraform_remote_state.mets_adapter.outputs.mets_adapter_topic_name
+
+  # Reindexer topics
+  miro_reindexer_topic_name   = data.terraform_remote_state.shared_infra.outputs.catalogue_miro_reindex_topic_name
+  sierra_reindexer_topic_name = data.terraform_remote_state.shared_infra.outputs.catalogue_sierra_reindex_topic_name
+  mets_reindexer_topic_name   = data.terraform_remote_state.reindexer.outputs.mets_reindexer_topic_name
+
+  # Infra stuff
+  infra_bucket                 = data.terraform_remote_state.shared_infra.outputs.infra_bucket
+  aws_region                   = "eu-west-1"
+  dlq_alarm_arn                = data.terraform_remote_state.shared_infra.outputs.dlq_alarm_arn
+  vpc_id                       = data.terraform_remote_state.shared_infra.outputs.catalogue_vpc_delta_id
+  private_subnets              = data.terraform_remote_state.shared_infra.outputs.catalogue_vpc_delta_private_subnets
+  rds_access_security_group_id = data.terraform_remote_state.catalogue_infra_critical.outputs.rds_access_security_group_id
+}
+

--- a/pipeline/terraform0.12/main.tf
+++ b/pipeline/terraform0.12/main.tf
@@ -1,0 +1,50 @@
+module "catalogue_pipeline_20200131" {
+  source = "./stack"
+
+  namespace = "catalogue-20200211"
+
+  release_label = "prod"
+
+  account_id      = data.aws_caller_identity.current.account_id
+  aws_region      = local.aws_region
+  vpc_id          = local.vpc_id
+  subnets         = local.private_subnets
+  private_subnets = local.private_subnets
+
+  dlq_alarm_arn = local.dlq_alarm_arn
+
+  # Transformer config
+  #
+  # If this pipeline is meant to be reindexed, remember to uncomment the
+  # reindexer topic names.
+
+  sierra_adapter_topic_count = 2
+  sierra_adapter_topic_names = [
+    //    local.sierra_reindexer_topic_name,
+    local.sierra_merged_bibs_topic_name,
+
+    local.sierra_merged_items_topic_name,
+  ]
+  miro_adapter_topic_count = 1
+  miro_adapter_topic_names = [
+    //    local.miro_reindexer_topic_name,
+    local.miro_updates_topic_name,
+  ]
+  mets_adapter_topic_count = 1
+  mets_adapter_topic_names = [
+    //    local.mets_reindexer_topic_name,
+    local.mets_adapter_topic_name,
+  ]
+  # Elasticsearch
+  es_works_index = "v2-20200131"
+  # RDS
+  rds_ids_access_security_group_id = local.rds_access_security_group_id
+  # Adapter VHS
+  vhs_sierra_read_policy            = local.vhs_sierra_read_policy
+  vhs_miro_read_policy              = local.vhs_miro_read_policy
+  vhs_sierra_sourcedata_bucket_name = local.vhs_sierra_sourcedata_bucket_name
+  vhs_sierra_sourcedata_table_name  = local.vhs_sierra_sourcedata_table_name
+  mets_adapter_read_policy          = local.mets_adapter_read_policy
+  mets_adapter_table_name           = local.mets_adapter_table_name
+  read_storage_s3_role_arn          = aws_iam_role.read_storage_s3.arn
+}

--- a/pipeline/terraform0.12/modules/queue/main.tf
+++ b/pipeline/terraform0.12/modules/queue/main.tf
@@ -1,0 +1,30 @@
+locals {
+  queue_name = replace(var.name, "-", "_")
+}
+
+module "queue" {
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
+  queue_name = replace(var.name, "-", "_")
+  aws_region = var.aws_region
+  topic_arns = var.topic_arns
+
+  visibility_timeout_seconds = var.visibility_timeout_seconds
+  max_receive_count          = var.max_receive_count
+
+  alarm_topic_arn = var.dlq_alarm_arn
+}
+
+module "scaling_alarm" {
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.2"
+  queue_name = local.queue_name
+
+  queue_high_actions = var.queue_high_actions
+  queue_low_actions  = var.queue_low_actions
+}
+
+resource "aws_iam_role_policy" "read_from_q" {
+  count = length(var.role_names)
+
+  role   = var.role_names[count.index]
+  policy = module.queue.read_policy
+}

--- a/pipeline/terraform0.12/modules/queue/outputs.tf
+++ b/pipeline/terraform0.12/modules/queue/outputs.tf
@@ -1,0 +1,15 @@
+output "url" {
+  value = module.queue.url
+}
+
+output "name" {
+  value = module.queue.name
+}
+
+output "arn" {
+  value = module.queue.arn
+}
+
+output "read_policy" {
+  value = module.queue.read_policy
+}

--- a/pipeline/terraform0.12/modules/queue/variables.tf
+++ b/pipeline/terraform0.12/modules/queue/variables.tf
@@ -1,0 +1,34 @@
+variable "name" {
+}
+
+variable "aws_region" {
+}
+
+variable "topic_arns" {
+  type = list(string)
+}
+
+variable "dlq_alarm_arn" {
+}
+
+variable "role_names" {
+  type = list(string)
+}
+
+variable "visibility_timeout_seconds" {
+  default = "300"
+}
+
+variable "max_receive_count" {
+  default = 3
+}
+
+variable "queue_high_actions" {
+  default = []
+  type    = list(string)
+}
+
+variable "queue_low_actions" {
+  default = []
+  type    = list(string)
+}

--- a/pipeline/terraform0.12/modules/service/pipeline_service/iam.tf
+++ b/pipeline/terraform0.12/modules/service/pipeline_service/iam.tf
@@ -1,0 +1,38 @@
+resource "aws_iam_role_policy" "read_from_q" {
+  role   = module.worker.task_role_name
+  policy = var.queue_read_policy
+}
+
+resource "aws_iam_role_policy" "cloudwatch_push_metrics" {
+  role   = module.worker.task_role_name
+  policy = data.aws_iam_policy_document.allow_cloudwatch_push_metrics.json
+}
+
+data "aws_iam_policy_document" "allow_cloudwatch_push_metrics" {
+  statement {
+    actions = [
+      "cloudwatch:PutMetricData",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "task_s3_messages_get" {
+  role   = module.worker.task_role_name
+  policy = data.aws_iam_policy_document.allow_s3_messages_get.json
+}
+
+data "aws_iam_policy_document" "allow_s3_messages_get" {
+  statement {
+    actions = [
+      "s3:GetObject",
+    ]
+
+    resources = [
+      "${var.messages_bucket_arn}/*",
+    ]
+  }
+}

--- a/pipeline/terraform0.12/modules/service/pipeline_service/main.tf
+++ b/pipeline/terraform0.12/modules/service/pipeline_service/main.tf
@@ -1,0 +1,38 @@
+module "worker" {
+  source = "../worker"
+
+  env_vars        = var.env_vars
+  secret_env_vars = var.secret_env_vars
+
+  subnets = var.subnets
+
+  container_image = var.container_image
+
+  namespace_id = var.namespace_id
+
+  cluster_name = var.cluster_name
+  cluster_arn  = var.cluster_arn
+
+  service_name = var.service_name
+
+  desired_task_count = var.desired_task_count
+
+  launch_type = var.launch_type
+
+  security_group_ids = var.security_group_ids
+
+  cpu    = var.cpu
+  memory = var.memory
+}
+
+module "scaling" {
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//autoscaling?ref=v1.2.0"
+
+  name = var.service_name
+
+  cluster_name = var.cluster_name
+  service_name = var.service_name
+
+  min_capacity = var.min_capacity
+  max_capacity = var.max_capacity
+}

--- a/pipeline/terraform0.12/modules/service/pipeline_service/outputs.tf
+++ b/pipeline/terraform0.12/modules/service/pipeline_service/outputs.tf
@@ -1,0 +1,15 @@
+output "task_role_name" {
+  value = module.worker.task_role_name
+}
+
+output "task_role_arn" {
+  value = module.worker.task_role_arn
+}
+
+output "scale_up_arn" {
+  value = module.scaling.scale_up_arn
+}
+
+output "scale_down_arn" {
+  value = module.scaling.scale_down_arn
+}

--- a/pipeline/terraform0.12/modules/service/pipeline_service/variables.tf
+++ b/pipeline/terraform0.12/modules/service/pipeline_service/variables.tf
@@ -1,0 +1,60 @@
+variable "env_vars" {
+  type = map(string)
+}
+
+variable "secret_env_vars" {
+  type    = map(string)
+  default = {}
+}
+
+variable "subnets" {
+  type = list(string)
+}
+
+variable "container_image" {
+}
+
+variable "namespace_id" {
+}
+
+variable "cluster_name" {
+}
+
+variable "cluster_arn" {
+}
+
+variable "service_name" {
+}
+
+variable "min_capacity" {
+  default = 1
+}
+
+variable "max_capacity" {
+  default = 1
+}
+
+variable "desired_task_count" {
+  default = 1
+}
+
+variable "launch_type" {
+  default = "FARGATE"
+}
+
+variable "security_group_ids" {
+  type    = list(string)
+  default = []
+}
+
+variable "cpu" {
+  default = 512
+}
+
+variable "memory" {
+  default = 1024
+}
+
+variable "messages_bucket_arn" {}
+
+variable "queue_read_policy" {}

--- a/pipeline/terraform0.12/modules/service/worker/main.tf
+++ b/pipeline/terraform0.12/modules/service/worker/main.tf
@@ -1,0 +1,37 @@
+module "service" {
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//service?ref=v1.2.0"
+
+  service_name = var.service_name
+
+  cluster_arn = var.cluster_arn
+
+  task_definition_arn = module.task_definition.arn
+
+  subnets = var.subnets
+
+  namespace_id = var.namespace_id
+
+  security_group_ids = var.security_group_ids
+
+  launch_type = var.launch_type
+
+  desired_task_count = var.desired_task_count
+}
+
+module "task_definition" {
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//task_definition/single_container?ref=v1.2.0"
+
+  task_name = var.service_name
+
+  container_image = var.container_image
+
+  cpu    = var.cpu
+  memory = var.memory
+
+  env_vars        = var.env_vars
+  secret_env_vars = var.secret_env_vars
+
+  launch_type = var.launch_type
+
+  aws_region = "eu-west-1"
+}

--- a/pipeline/terraform0.12/modules/service/worker/outputs.tf
+++ b/pipeline/terraform0.12/modules/service/worker/outputs.tf
@@ -1,0 +1,7 @@
+output "task_role_name" {
+  value = module.task_definition.task_role_name
+}
+
+output "task_role_arn" {
+  value = module.task_definition.task_role_arn
+}

--- a/pipeline/terraform0.12/modules/service/worker/variables.tf
+++ b/pipeline/terraform0.12/modules/service/worker/variables.tf
@@ -1,0 +1,48 @@
+variable "env_vars" {
+  type = map(string)
+}
+
+variable "secret_env_vars" {
+  type    = map(string)
+  default = {}
+}
+
+variable "subnets" {
+  type = list(string)
+}
+
+variable "container_image" {
+}
+
+variable "namespace_id" {
+}
+
+variable "cluster_name" {
+}
+
+variable "cluster_arn" {
+}
+
+variable "service_name" {
+}
+
+variable "desired_task_count" {
+  default = 1
+}
+
+variable "launch_type" {
+  default = "FARGATE"
+}
+
+variable "security_group_ids" {
+  type    = list(string)
+  default = []
+}
+
+variable "cpu" {
+  default = 512
+}
+
+variable "memory" {
+  default = 1024
+}

--- a/pipeline/terraform0.12/modules/topic/main.tf
+++ b/pipeline/terraform0.12/modules/topic/main.tf
@@ -1,0 +1,30 @@
+module "topic" {
+  source = "git::https://github.com/wellcometrust/terraform.git//sns?ref=v19.12.0"
+  name   = var.name
+}
+
+resource "aws_iam_role_policy" "task_sns" {
+  count = length(var.role_names)
+
+  role   = var.role_names[count.index]
+  policy = module.topic.publish_policy
+}
+
+resource "aws_iam_role_policy" "task_s3_messages_put" {
+  count = length(var.role_names)
+
+  role   = var.role_names[count.index]
+  policy = data.aws_iam_policy_document.allow_s3_messages_put.json
+}
+
+data "aws_iam_policy_document" "allow_s3_messages_put" {
+  statement {
+    actions = [
+      "s3:PutObject",
+    ]
+
+    resources = [
+      "${var.messages_bucket_arn}/*",
+    ]
+  }
+}

--- a/pipeline/terraform0.12/modules/topic/outputs.tf
+++ b/pipeline/terraform0.12/modules/topic/outputs.tf
@@ -1,0 +1,7 @@
+output "name" {
+  value = module.topic.name
+}
+
+output "arn" {
+  value = module.topic.arn
+}

--- a/pipeline/terraform0.12/modules/topic/variables.tf
+++ b/pipeline/terraform0.12/modules/topic/variables.tf
@@ -1,0 +1,7 @@
+variable "name" {}
+
+variable "role_names" {
+  type = list(string)
+}
+
+variable "messages_bucket_arn" {}

--- a/pipeline/terraform0.12/stack/dynamo.tf
+++ b/pipeline/terraform0.12/stack/dynamo.tf
@@ -1,0 +1,104 @@
+# Graph table
+
+resource "aws_dynamodb_table" "matcher_graph_table" {
+  name     = "${local.namespace_hyphen}_works-graph"
+  hash_key = "id"
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+
+  attribute {
+    name = "componentId"
+    type = "S"
+  }
+
+  billing_mode = "PAY_PER_REQUEST"
+
+  global_secondary_index {
+    name            = "work-sets-index"
+    hash_key        = "componentId"
+    projection_type = "ALL"
+  }
+}
+
+data "aws_iam_policy_document" "graph_table_readwrite" {
+  statement {
+    actions = [
+      "dynamodb:UpdateItem",
+      "dynamodb:PutItem",
+      "dynamodb:BatchGetItem",
+      "dynamodb:GetItem",
+    ]
+
+    resources = [
+      "${aws_dynamodb_table.matcher_graph_table.arn}",
+    ]
+  }
+
+  statement {
+    actions = [
+      "dynamodb:Query",
+    ]
+
+    resources = [
+      "${aws_dynamodb_table.matcher_graph_table.arn}/index/*",
+    ]
+  }
+}
+
+# Lock table
+
+resource "aws_dynamodb_table" "matcher_lock_table" {
+  name     = "${local.namespace_hyphen}_matcher-lock-table"
+  hash_key = "id"
+
+  billing_mode = "PAY_PER_REQUEST"
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+
+  attribute {
+    name = "contextId"
+    type = "S"
+  }
+
+  global_secondary_index {
+    name            = "context-ids-index"
+    hash_key        = "contextId"
+    projection_type = "ALL"
+  }
+
+  ttl {
+    attribute_name = "expires"
+    enabled        = true
+  }
+}
+
+data "aws_iam_policy_document" "lock_table_readwrite" {
+  statement {
+    actions = [
+      "dynamodb:UpdateItem",
+      "dynamodb:PutItem",
+      "dynamodb:GetItem",
+      "dynamodb:DeleteItem",
+    ]
+
+    resources = [
+      "${aws_dynamodb_table.matcher_lock_table.arn}",
+    ]
+  }
+
+  statement {
+    actions = [
+      "dynamodb:Query",
+    ]
+
+    resources = [
+      "${aws_dynamodb_table.matcher_lock_table.arn}/index/*",
+    ]
+  }
+}

--- a/pipeline/terraform0.12/stack/ecs.tf
+++ b/pipeline/terraform0.12/stack/ecs.tf
@@ -1,0 +1,3 @@
+resource "aws_ecs_cluster" "cluster" {
+  name = local.namespace_hyphen
+}

--- a/pipeline/terraform0.12/stack/images.tf
+++ b/pipeline/terraform0.12/stack/images.tf
@@ -1,0 +1,31 @@
+locals {
+  services = [
+    "ingestor",
+    "matcher",
+    "merger",
+    "id_minter",
+    "recorder",
+    "transformer_miro",
+    "transformer_mets",
+    "transformer_sierra",
+  ]
+}
+
+data "aws_ssm_parameter" "image_ids" {
+  count = length(local.services)
+
+  name = "/catalogue_pipeline/images/${var.release_label}/${local.services[count.index]}"
+}
+
+locals {
+  image_ids = zipmap(local.services, data.aws_ssm_parameter.image_ids.*.value)
+
+  id_minter_image = local.image_ids["id_minter"]
+  recorder_image  = local.image_ids["recorder"]
+  matcher_image   = local.image_ids["matcher"]
+  merger_image    = local.image_ids["merger"]
+  ingestor_image  = local.image_ids["ingestor"]
+  transformer_miro_image   = local.image_ids["transformer_miro"]
+  transformer_mets_image   = local.image_ids["transformer_mets"]
+  transformer_sierra_image = local.image_ids["transformer_sierra"]
+}

--- a/pipeline/terraform0.12/stack/locals.tf
+++ b/pipeline/terraform0.12/stack/locals.tf
@@ -1,0 +1,5 @@
+locals {
+  logstash_transit_service_name = "${local.namespace_hyphen}_logstash_transit"
+  logstash_host                 = "${local.logstash_transit_service_name}.${local.namespace_hyphen}"
+  namespace_hyphen              = "${replace(var.namespace,"_","-")}"
+}

--- a/pipeline/terraform0.12/stack/network.tf
+++ b/pipeline/terraform0.12/stack/network.tf
@@ -1,4 +1,4 @@
 resource "aws_service_discovery_private_dns_namespace" "namespace" {
-  name = "${local.namespace_hyphen}"
-  vpc  = "${var.vpc_id}"
+  name = local.namespace_hyphen
+  vpc  = var.vpc_id
 }

--- a/pipeline/terraform0.12/stack/network.tf
+++ b/pipeline/terraform0.12/stack/network.tf
@@ -1,0 +1,4 @@
+resource "aws_service_discovery_private_dns_namespace" "namespace" {
+  name = "${local.namespace_hyphen}"
+  vpc  = "${var.vpc_id}"
+}

--- a/pipeline/terraform0.12/stack/s3.tf
+++ b/pipeline/terraform0.12/stack/s3.tf
@@ -1,0 +1,19 @@
+resource "aws_s3_bucket" "messages" {
+  bucket = "wellcomecollection-${local.namespace_hyphen}-messages"
+  acl    = "private"
+
+  # Normally S3 buckets have prevent_destroy = true
+  # but these are transient between stacks, so we allow it.
+  force_destroy = true
+
+  lifecycle_rule {
+    id      = "expire_messages"
+    enabled = true
+
+    expiration {
+      // SQS messages are kept in queues for 4 days
+      // expiration of messages in s3 should be the same
+      days = 4
+    }
+  }
+}

--- a/pipeline/terraform0.12/stack/security_groups.tf
+++ b/pipeline/terraform0.12/stack/security_groups.tf
@@ -1,0 +1,28 @@
+resource "aws_security_group" "service_egress" {
+  name        = "${local.namespace_hyphen}_service_egress"
+  description = "Allow traffic between services"
+  vpc_id      = var.vpc_id
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+
+    cidr_blocks = [
+      "0.0.0.0/0",
+    ]
+  }
+}
+
+resource "aws_security_group" "interservice" {
+  name        = "${local.namespace_hyphen}_interservice"
+  description = "Allow traffic between services"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    self      = true
+  }
+}

--- a/pipeline/terraform0.12/stack/service_id_minter.tf
+++ b/pipeline/terraform0.12/stack/service_id_minter.tf
@@ -1,0 +1,71 @@
+module "id_minter_topic" {
+  source = "../modules/topic"
+
+  name       = "${local.namespace_hyphen}_id_minter"
+//  role_names = ["${module.id_minter.task_role_name}"]
+  role_names = []
+  messages_bucket_arn = aws_s3_bucket.messages.arn
+}
+
+//module "id_minter_queue" {
+//  source      = "../modules/queue"
+//  name  = "${local.namespace_hyphen}_id_minter"
+////  topic_names = ["${module.merger_topic.name}"]
+//  topic_names = []
+//  topic_count = 1
+//  aws_region      = var.aws_region
+//  dlq_alarm_arn = var.dlq_alarm_arn
+//  role_names = [module.id_minter.task_role_name]
+//  topic_arns = ["module.id_minter_topic.name"]
+//}
+//
+//module "id_minter" {
+//  source = "../modules/service/pipeline_service"
+//
+//  service_name = "${local.namespace_hyphen}_id_minter"
+//
+//  container_image = "${local.id_minter_image}"
+//
+//  security_group_ids = [
+//    "${module.egress_security_group.sg_id}",
+//    "${var.rds_ids_access_security_group_id}",
+//    "${aws_security_group.interservice.id}",
+//  ]
+//
+//  cluster_name  = "${aws_ecs_cluster.cluster.name}"
+//  cluster_arn    = "${aws_ecs_cluster.cluster.id}"
+//  namespace_id  = "${aws_service_discovery_private_dns_namespace.namespace.id}"
+//  subnets       = "${var.subnets}"
+//  aws_region    = "${var.aws_region}"
+//  logstash_host = "${local.logstash_host}"
+//
+//  env_vars = {
+//    metrics_namespace    = "${local.namespace_hyphen}_id_minter"
+//    messages_bucket_name = "${aws_s3_bucket.messages.id}"
+//
+//    queue_url       = "${module.id_minter_queue.id}"
+//    topic_arn       = "${module.id_minter_topic.arn}"
+//    max_connections = 8
+//  }
+//
+//  env_vars_length = 5
+//
+//  secret_env_vars = {
+//    cluster_url = "catalogue/id_minter/rds_host"
+//    db_port     = "catalogue/id_minter/rds_port"
+//    db_username = "catalogue/id_minter/rds_user"
+//    db_password = "catalogue/id_minter/rds_password"
+//  }
+//
+//  secret_env_vars_length = "4"
+//
+//  // The maximum number of connections to RDS is 45.
+//  // Each id minter task is configured to have 8 connections
+//  // in the connection pool (see `max_connections` parameterabove).
+//  // To avoid exceeding the maximum nuber of connections to RDS,
+//  // the maximum capacity for the id minter should be no higher than 5
+//  max_capacity = 5
+//
+//  messages_bucket_arn = "${aws_s3_bucket.messages.arn}"
+//  queue_read_policy   = "${module.id_minter_queue.read_policy}"
+//}

--- a/pipeline/terraform0.12/stack/service_ingestor.tf
+++ b/pipeline/terraform0.12/stack/service_ingestor.tf
@@ -1,0 +1,55 @@
+# Input queue
+
+module "ingestor_queue" {
+  source      = "../modules/queue"
+  name = "${local.namespace_hyphen}-ingestor"
+  aws_region      = var.aws_region
+  dlq_alarm_arn = var.dlq_alarm_arn
+  role_names = [module.ingestor.task_role_name]
+  topic_arns = [module.id_minter_topic.arn]
+}
+
+module "ingestor" {
+  source = "../modules/service/pipeline_service"
+  service_name = "${local.namespace_hyphen}_ingestor"
+  container_image = local.ingestor_image
+
+  security_group_ids = [
+    aws_security_group.service_egress.id,
+    aws_security_group.interservice.id,
+  ]
+
+  cluster_name  = aws_ecs_cluster.cluster.name
+  cluster_arn    = aws_ecs_cluster.cluster.arn
+  namespace_id  = aws_service_discovery_private_dns_namespace.namespace.id
+  subnets       = var.subnets
+
+  env_vars = {
+    metrics_namespace   = "${local.namespace_hyphen}_ingestor"
+    es_index            = var.es_works_index
+    ingest_queue_id     = module.ingestor_queue.arn
+    es_ingest_batchSize = 100
+    logstash_host = local.logstash_host
+  }
+
+  secret_env_vars = {
+    es_host     = "catalogue/ingestor/es_host"
+    es_port     = "catalogue/ingestor/es_port"
+    es_username = "catalogue/ingestor/es_username"
+    es_password = "catalogue/ingestor/es_password"
+    es_protocol = "catalogue/ingestor/es_protocol"
+  }
+  max_capacity           = 10
+
+  messages_bucket_arn    = aws_s3_bucket.messages.arn
+  queue_read_policy      = module.ingestor_queue.read_policy
+}
+
+// TODO: (tf0.12 upgrade) do we need this?
+//module "ingestor_scaling_alarm" {
+//  source     = "git::https://github.com/wellcometrust/terraform-modules.git//autoscaling/alarms/queue?ref=v19.12.0"
+//  queue_name = module.ingestor_queue.name
+//
+//  queue_high_actions = [module.ingestor.scale_up_arn]
+//  queue_low_actions  = [module.ingestor.scale_down_arn]
+//}

--- a/pipeline/terraform0.12/stack/service_logstash_transit.tf
+++ b/pipeline/terraform0.12/stack/service_logstash_transit.tf
@@ -1,4 +1,3 @@
-
 module "logstash_transit" {
   source = "../modules/service/worker"
 
@@ -29,3 +28,4 @@ module "logstash_transit" {
 
   container_image = "wellcome/logstash_transit:edgelord"
 }
+

--- a/pipeline/terraform0.12/stack/services.tf
+++ b/pipeline/terraform0.12/stack/services.tf
@@ -1,0 +1,31 @@
+
+module "logstash_transit" {
+  source = "../modules/service/worker"
+
+  security_group_ids = [
+    aws_security_group.interservice.id,
+    aws_security_group.service_egress.id,
+  ]
+
+  cluster_arn  = aws_ecs_cluster.cluster.arn
+  cluster_name = aws_ecs_cluster.cluster.name
+  namespace_id = aws_service_discovery_private_dns_namespace.namespace.id
+  subnets      = var.private_subnets
+  service_name = local.logstash_transit_service_name
+
+  env_vars = {
+    XPACK_MONITORING_ENABLED = "false"
+    NAMESPACE                = var.namespace
+  }
+
+  secret_env_vars = {
+    ES_HOST = "catalogue/logstash/es_host"
+    ES_USER = "catalogue/logstash/es_user"
+    ES_PASS = "catalogue/logstash/es_pass"
+  }
+
+  cpu    = 1024
+  memory = 2048
+
+  container_image = "wellcome/logstash_transit:edgelord"
+}

--- a/pipeline/terraform0.12/stack/variables.tf
+++ b/pipeline/terraform0.12/stack/variables.tf
@@ -5,7 +5,9 @@ variable "subnets" {
 }
 
 variable "vpc_id" {}
-variable "aws_region" {}
+variable "aws_region" {
+  default = "eu-west-1"
+}
 
 variable "account_id" {}
 
@@ -50,3 +52,4 @@ variable "private_subnets" {
 }
 
 variable "read_storage_s3_role_arn" {}
+

--- a/pipeline/terraform0.12/stack/variables.tf
+++ b/pipeline/terraform0.12/stack/variables.tf
@@ -1,0 +1,52 @@
+variable "namespace" {}
+
+variable "subnets" {
+  type = list(string)
+}
+
+variable "vpc_id" {}
+variable "aws_region" {}
+
+variable "account_id" {}
+
+variable "dlq_alarm_arn" {}
+
+variable "es_works_index" {}
+
+variable "rds_ids_access_security_group_id" {}
+
+variable "release_label" {}
+
+variable "miro_adapter_topic_names" {
+  type = list(string)
+}
+
+variable "miro_adapter_topic_count" {}
+
+variable "mets_adapter_topic_names" {
+  type = list(string)
+}
+
+variable "mets_adapter_topic_count" {}
+
+variable "sierra_adapter_topic_names" {
+  type = list(string)
+}
+
+variable "sierra_adapter_topic_count" {}
+
+variable "vhs_miro_read_policy" {}
+
+variable "vhs_sierra_read_policy" {}
+variable "vhs_sierra_sourcedata_bucket_name" {}
+variable "vhs_sierra_sourcedata_table_name" {}
+
+variable "mets_adapter_read_policy" {}
+
+variable "mets_adapter_table_name" {}
+
+variable "private_subnets" {
+  type = list(string)
+}
+
+variable "read_storage_s3_role_arn" {}

--- a/pipeline/terraform0.12/stack/vhs.tf
+++ b/pipeline/terraform0.12/stack/vhs.tf
@@ -1,3 +1,4 @@
+// TODO: (tf0.12 upgrade) upgrade this
 module "vhs_recorder" {
   source = "git::https://github.com/wellcometrust/terraform.git//vhs/modules/vhs?ref=v19.7.2"
 

--- a/pipeline/terraform0.12/stack/vhs.tf
+++ b/pipeline/terraform0.12/stack/vhs.tf
@@ -1,0 +1,5 @@
+module "vhs_recorder" {
+  source = "git::https://github.com/wellcometrust/terraform.git//vhs/modules/vhs?ref=v19.7.2"
+
+  name = "${local.namespace_hyphen}-recorder"
+}

--- a/pipeline/terraform0.12/terraform.tf
+++ b/pipeline/terraform0.12/terraform.tf
@@ -1,0 +1,90 @@
+provider "aws" {
+  region = "eu-west-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::760097843905:role/platform-admin"
+  }
+}
+
+terraform {
+  required_version = ">= 0.9"
+
+  backend "s3" {
+    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+
+    bucket         = "wellcomecollection-platform-infra"
+    key            = "terraform/catalogue_pipeline_tf_0.12.tfstate"
+    dynamodb_table = "terraform-locktable"
+    region         = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "catalogue_infra_critical" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+    bucket   = "wellcomecollection-platform-infra"
+    key      = "terraform/catalogue/infrastructure/critical.tfstate"
+    region   = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "catalogue_pipeline_data" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+    bucket   = "wellcomecollection-platform-infra"
+    key      = "terraform/catalogue_pipeline_data.tfstate"
+    region   = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "shared_infra" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+    bucket   = "wellcomecollection-platform-infra"
+    key      = "terraform/shared_infra.tfstate"
+    region   = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "sierra_adapter" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+    bucket   = "wellcomecollection-platform-infra"
+    key      = "terraform/sierra_adapter.tfstate"
+    region   = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "mets_adapter" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    bucket   = "wellcomecollection-platform-infra"
+    key      = "terraform/mets_adapter.tfstate"
+    region   = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "reindexer" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    bucket   = "wellcomecollection-platform-infra"
+    key      = "terraform/reindexer.tfstate"
+    region   = "eu-west-1"
+  }
+}
+
+data "aws_caller_identity" "current" {
+}
+

--- a/pipeline/terraform0.12/versions.tf
+++ b/pipeline/terraform0.12/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Moving to tf0.12.

Thought of moving to the new catalogue AWS account too - but then thought against it for timing and not creating too many moving parts.

This is necessary so we can start using the new tf ecs service that allows you to not use cloudfront logs.