### PR TITLE
Process Calm windows in batches

### DIFF
--- a/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerService.scala
+++ b/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerService.scala
@@ -2,9 +2,9 @@ package uk.ac.wellcome.calm_adapter
 
 import java.time.LocalDate
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Success
 import akka.Done
 import akka.stream.scaladsl._
+import akka.stream.ActorMaterializer
 import grizzled.slf4j.Logging
 import com.amazonaws.services.sqs.model.{Message => SQSMessage}
 
@@ -18,28 +18,30 @@ import uk.ac.wellcome.bigmessaging.FlowOps
 case class CalmWindow(date: LocalDate)
 
 /** Processes SQS messages consisting of a daily window, and publishes any CALM
-  *  records to the transformer that have been modified within this window.
+  * records to the transformer that have been modified within this window.
   *
-  *  Consists of the following stages:
-  *  - Retrieve all CALM records which have modified field the same date as the
-  *    window
-  *  - Store these records in VHS, filtering out ones older than what is
-  *    currently in  the store
-  *  - Publish the VHS key to SNS
+  * Consists of the following stages:
+  * - Retrieve all CALM records which have modified field the same date as the
+  *   window
+  * - Store these records in VHS, filtering out ones older than what is
+  *   currently in  the store
+  * - Publish the VHS key to SNS
   */
-class CalmAdapterWorkerService(
-  msgStream: SQSStream[NotificationMessage],
-  msgSender: SNSMessageSender,
-  calmRetriever: CalmRetriever,
-  calmStore: CalmStore,
-  concurrentHttpConnections: Int = 3)(implicit val ec: ExecutionContext)
+class CalmAdapterWorkerService(msgStream: SQSStream[NotificationMessage],
+                               msgSender: SNSMessageSender,
+                               calmRetriever: CalmRetriever,
+                               calmStore: CalmStore,
+                               concurrentWindows: Int = 2)(
+  implicit
+  val ec: ExecutionContext,
+  materializer: ActorMaterializer)
     extends Runnable
     with FlowOps
     with Logging {
 
   /** Encapsulates context to pass along each akka-stream stage. Newer versions
-    *  of akka-streams have the asSourceWithContext/ asFlowWithContext idioms for
-    *  this purpose, which we can migrate to if the library is updated.
+    * of akka-streams have the asSourceWithContext/ asFlowWithContext idioms for
+    * this purpose, which we can migrate to if the library is updated.
     */
   case class Context(msg: SQSMessage)
 
@@ -48,46 +50,53 @@ class CalmAdapterWorkerService(
   def run(): Future[Done] =
     msgStream.runStream(
       className,
-      source => {
+      source =>
         source
           .via(unwrapMessage)
-          .via(retrieveCalmRecords)
-          .via(storeCalmRecord)
-          .via(publishKey)
+          .via(processWindow)
           .map { case (Context(msg), _) => msg }
-      }
     )
 
   def unwrapMessage =
     Flow[(SQSMessage, NotificationMessage)]
       .map {
         case (msg, NotificationMessage(body)) =>
-          (msg, fromJson[CalmWindow](body).toEither)
+          (Context(msg), fromJson[CalmWindow](body).toEither)
       }
       .via(catchErrors)
-      .map { case (msg, window) => (Context(msg), window) }
 
-  def retrieveCalmRecords =
+  /** We process the whole window as a single batch, rather than demultiplexing
+    * into stream of individual records. This is because we need to emit exactly
+    * one delete action per message received.
+    */
+  def processWindow =
     Flow[(Context, CalmWindow)]
-      .mapAsync(concurrentHttpConnections) {
+      .mapAsync(concurrentWindows) {
         case (ctx, CalmWindow(date)) =>
           calmRetriever(CalmQuery.ModifiedDate(date))
-            .transform(result => Success(result.toEither))
-            .map(records => (ctx, records))
+            .map(calmStore.putRecord)
+            .via(publishKey)
+            .runWith(Sink.seq)
+            .map(checkResultsForErrors(_, date))
+            .map((ctx, _))
       }
-      .via(catchErrors)
-      .mapConcat {
-        case (ctx, records) => records.map(record => (ctx, record))
-      }
-
-  def storeCalmRecord =
-    Flow[(Context, CalmRecord)]
-      .map { case (ctx, record) => (ctx, calmStore.putRecord(record)) }
       .via(catchErrors)
 
   def publishKey =
-    Flow[(Context, Option[Version[String, Int]])]
-      .mapWithContext {
-        case (ctx, key) => msgSender.sendT(key).toEither.right.map(_ => key)
+    Flow[Result[Option[Version[String, Int]]]]
+      .map {
+        case Right(Some(key)) =>
+          msgSender.sendT(key).toEither.right.map(_ => Some(key))
+        case Right(None) => Right(None)
+        case Left(err)   => Left(err)
       }
+
+  def checkResultsForErrors(results: Seq[Result[_]],
+                            date: LocalDate): Result[Unit] = {
+    val errs = results.collect { case Left(err) => err }.toList
+    if (errs.nonEmpty)
+      Left(new Exception(s"Errors processing window $date: $errs"))
+    else
+      Right(())
+  }
 }

--- a/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/Main.scala
+++ b/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/Main.scala
@@ -1,8 +1,10 @@
 package uk.ac.wellcome.calm_adapter
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
+import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
+import akka.stream.scaladsl._
 
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
@@ -22,7 +24,7 @@ object Main extends WellcomeTypesafeApp {
       SQSBuilder.buildSQSStream(config),
       SNSBuilder.buildSNSMessageSender(config, subject = "CALM adapter"),
       new CalmRetriever {
-        def apply(query: CalmQuery): Future[List[CalmRecord]] =
+        def apply(query: CalmQuery): Source[CalmRecord, NotUsed] =
           ???
       },
       new CalmStore(???)

--- a/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerServiceTest.scala
+++ b/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerServiceTest.scala
@@ -1,10 +1,160 @@
 package uk.ac.wellcome.calm_adapter
 
+import scala.util.{Failure, Try}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.language.reflectiveCalls
+import java.time.{Instant, LocalDate}
 import org.scalatest.{FunSpec, Matchers}
+import akka.stream.scaladsl._
+import io.circe.Encoder
 
-class CalmAdapterWorkerServiceTest extends FunSpec with Matchers {
+import uk.ac.wellcome.akka.fixtures.Akka
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.messaging.fixtures.{SNS, SQS}
+import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
+import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSMessageSender}
+import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryVersionedStore}
+import uk.ac.wellcome.storage.Version
+import uk.ac.wellcome.storage.maxima.Maxima
+import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
+import uk.ac.wellcome.json.JsonUtil._
 
-  it("this is a placeholder test") {
-    1 == 1 shouldBe true
+class CalmAdapterWorkerServiceTest
+    extends FunSpec
+    with Matchers
+    with Akka
+    with SQS
+    with SNS {
+
+  type Key = Version[String, Int]
+
+  val instantA = Instant.ofEpochSecond(123456)
+  val instantB = Instant.ofEpochSecond(instantA.getEpochSecond + 1)
+  val instantC = Instant.ofEpochSecond(instantA.getEpochSecond + 2)
+  val recordA = CalmRecord("A", Map("RecordID" -> List("A")), instantA)
+  val recordB = CalmRecord("B", Map("RecordID" -> List("B")), instantB)
+  val recordC = CalmRecord("C", Map("RecordID" -> List("C")), instantC)
+  val queryDate = LocalDate.of(2000, 1, 1)
+
+  it("should process an incoming window, storing records and publishing keys") {
+    val store = dataStore()
+    val retriever = calmRetriever(List(recordA, recordB, recordC))
+    withCalmAdapterWorkerService(retriever, store) {
+      case (calmAdapter, QueuePair(queue, dlq), topic) =>
+        sendNotificationToSQS(queue, CalmWindow(queryDate))
+        Thread.sleep(500)
+        store.entries shouldBe Map(
+          Version("A", 0) -> recordA,
+          Version("B", 0) -> recordB,
+          Version("C", 0) -> recordC
+        )
+        retriever.previousQuery shouldBe Some(CalmQuery.ModifiedDate(queryDate))
+        assertQueueEmpty(queue)
+        assertQueueEmpty(dlq)
+        getMessages(topic) shouldBe List(
+          Version("A", 0),
+          Version("B", 0),
+          Version("C", 0)
+        )
+    }
   }
+
+  it("should complete successfully when no records returned from the query") {
+    val store = dataStore()
+    val retriever = calmRetriever(Nil)
+    withCalmAdapterWorkerService(retriever, store) {
+      case (calmAdapter, QueuePair(queue, dlq), topic) =>
+        sendNotificationToSQS(queue, CalmWindow(queryDate))
+        Thread.sleep(500)
+        store.entries shouldBe Map.empty
+        assertQueueEmpty(queue)
+        assertQueueEmpty(dlq)
+        getMessages(topic) shouldBe Nil
+    }
+  }
+
+  it("should send the message to the DLQ if publishing of any record fails") {
+    val store = dataStore()
+    val retriever = new CalmRetriever {
+      def apply(query: CalmQuery) = {
+        val timestamp = Instant.now
+        val records = List(
+          CalmRecord("A", Map.empty, timestamp),
+          CalmRecord("B", Map.empty, timestamp),
+          CalmRecord("C", Map.empty, timestamp),
+        )
+        Source.fromIterator(() => records.toIterator)
+      }
+    }
+    val createBrokenMsgSender = (topic: SNS.Topic) =>
+      new SNSMessageSender(
+        snsClient = snsClient,
+        snsConfig = createSNSConfigWith(topic),
+        subject = "BrokenSNSMessageSender"
+      ) {
+        override def sendT[T](item: T)(
+          implicit encoder: Encoder[T]): Try[Unit] = {
+          if (item.asInstanceOf[Version[String, Int]].id == "B")
+            Failure(new Exception("Waaah I couldn't send message"))
+          else
+            super.sendT(item)
+        }
+    }
+    withCalmAdapterWorkerService(retriever, store, createBrokenMsgSender(_)) {
+      case (calmAdapter, QueuePair(queue, dlq), topic) =>
+        sendNotificationToSQS(queue, CalmWindow(queryDate))
+        Thread.sleep(2000)
+        assertQueueEmpty(queue)
+        assertQueueHasSize(dlq, 1)
+    }
+  }
+
+  def withCalmAdapterWorkerService[R](
+    retriever: CalmRetriever,
+    store: MemoryStore[Key, CalmRecord] with Maxima[String, Int],
+    createMsgSender: SNS.Topic => SNSMessageSender = createMsgSender(_))(
+    testWith: TestWith[(CalmAdapterWorkerService, QueuePair, SNS.Topic), R]) =
+    withActorSystem { implicit actorSystem =>
+      withLocalSnsTopic { topic =>
+        withLocalSqsQueueAndDlq {
+          case QueuePair(queue, dlq) =>
+            withSQSStream[NotificationMessage, R](queue) { stream =>
+              withMaterializer { implicit materializer =>
+                val calmAdapter = new CalmAdapterWorkerService(
+                  stream,
+                  createMsgSender(topic),
+                  retriever,
+                  new CalmStore(new MemoryVersionedStore(store))
+                )
+                calmAdapter.run()
+                testWith((calmAdapter, QueuePair(queue, dlq), topic))
+              }
+            }
+        }
+      }
+    }
+
+  def createMsgSender(topic: SNS.Topic) =
+    new SNSMessageSender(
+      snsClient = snsClient,
+      snsConfig = createSNSConfigWith(topic),
+      subject = "SNSMessageSender"
+    )
+
+  def calmRetriever(records: List[CalmRecord]) =
+    new CalmRetriever {
+      var previousQuery: Option[CalmQuery] = None
+      def apply(query: CalmQuery) = {
+        previousQuery = Some(query)
+        Source.fromIterator(() => records.toIterator)
+      }
+    }
+
+  def dataStore(entries: (Key, CalmRecord)*) =
+    new MemoryStore(entries.toMap) with MemoryMaxima[String, CalmRecord]
+
+  def getMessages(topic: SNS.Topic) =
+    listMessagesReceivedFromSNS(topic)
+      .map(msgInfo => fromJson[Version[String, Int]](msgInfo.message).get)
+      .toList
 }

--- a/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/MetsAdapterWorkerServiceTest.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/MetsAdapterWorkerServiceTest.scala
@@ -146,7 +146,7 @@ class MetsAdapterWorkerServiceTest
 
   it("doesn't process the update when storageSpace isn't equal to 'digitised'") {
     val vhs = createStore()
-    withWorkerService(bagRetriever, vhs, createBrokenMsgSender(_)) {
+    withWorkerService(bagRetriever, vhs) {
       case (workerService, QueuePair(queue, dlq), topic) =>
         sendNotificationToSQS(queue, ingestUpdate("something-different", "123"))
         Thread.sleep(2000)


### PR DESCRIPTION
## Issue

https://github.com/wellcometrust/platform/issues/4210

## Description

Currently we demultiplex all records within a window into separate messages in a stream. The unintended consequence of this is that when a single record has been processed, the message will be deleted from SQS, even if the others fail.

To prevent this, here we process a window as a single batch, only emitting the delete action when all have completed. Internally this processing of the records in a window is within a stream, in order to retain the advantages of concurrency and backpressure, but we wait for the whole stream to complete before emitting a delete action.