### PR TITLE
Avoid redundant publishing of Calm records to transformer

### DIFF
--- a/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmRecord.scala
+++ b/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmRecord.scala
@@ -5,5 +5,6 @@ import java.time.Instant
 case class CalmRecord(
   id: String,
   data: Map[String, List[String]],
-  retrievedAt: Instant
+  retrievedAt: Instant,
+  published: Boolean = false
 )

--- a/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmStore.scala
+++ b/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmStore.scala
@@ -34,7 +34,7 @@ class CalmStore(store: VersionedStore[String, Int, CalmRecord]) {
                 "Cannot resolve latest data as timestamps are equal")
             )
           else
-            Right(record.retrievedAt.isAfter(storedRecord.retrievedAt))
+            Right(compareRecords(record, storedRecord))
       }
       .left
       .flatMap {
@@ -42,4 +42,8 @@ class CalmStore(store: VersionedStore[String, Int, CalmRecord]) {
         case err                     => Left(err.e)
       }
       .flatMap(identity)
+
+  def compareRecords(record: CalmRecord, storedRecord: CalmRecord): Boolean =
+    record.retrievedAt.isAfter(storedRecord.retrievedAt) &&
+      (record.data != storedRecord.data || !storedRecord.published)
 }

--- a/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmStore.scala
+++ b/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmStore.scala
@@ -1,6 +1,11 @@
 package uk.ac.wellcome.calm_adapter
 
-import uk.ac.wellcome.storage.{Identified, NoVersionExistsError, Version}
+import uk.ac.wellcome.storage.{
+  Identified,
+  NoVersionExistsError,
+  StorageError,
+  Version
+}
 import uk.ac.wellcome.storage.store.VersionedStore
 
 class CalmStore(store: VersionedStore[String, Int, CalmRecord]) {
@@ -9,32 +14,33 @@ class CalmStore(store: VersionedStore[String, Int, CalmRecord]) {
 
   type Result[T] = Either[Throwable, T]
 
-  def putRecord(record: CalmRecord): Result[Option[Key]] =
+  def putRecord(record: CalmRecord): Result[Option[(Key, CalmRecord)]] =
     shouldStoreRecord(record)
       .flatMap {
         case false => Right(None)
         case true =>
           store
             .putLatest(record.id)(record)
-            .map { case Identified(key, _) => Some(key) }
+            .map { case Identified(key, record) => Some(key -> record) }
             .left
-            .map(_.e)
+            .map(toReadableException)
       }
+
+  def setRecordPublished(key: Key, record: CalmRecord): Result[Key] =
+    store
+      .put(Version(key.id, key.version + 1))(record.copy(published = true))
+      .map { case Identified(key, _) => key }
+      .left
+      .map(toReadableException)
 
   def shouldStoreRecord(record: CalmRecord): Result[Boolean] =
     store
       .getLatest(record.id)
       .map {
         case Identified(_, storedRecord) =>
-          val sameTimestamp = record.retrievedAt == storedRecord.retrievedAt
-          val differingData = record.data != storedRecord.data
-          if (sameTimestamp && differingData)
-            Left(
-              new Exception(
-                "Cannot resolve latest data as timestamps are equal")
-            )
-          else
-            Right(compareRecords(record, storedRecord))
+          checkResolvable(record, storedRecord)
+            .map(Left(_))
+            .getOrElse(Right(compareRecords(record, storedRecord)))
       }
       .left
       .flatMap {
@@ -43,7 +49,29 @@ class CalmStore(store: VersionedStore[String, Int, CalmRecord]) {
       }
       .flatMap(identity)
 
+  def checkResolvable(record: CalmRecord,
+                      storedRecord: CalmRecord): Option[Exception] = {
+    val sameTimestamp = record.retrievedAt == storedRecord.retrievedAt
+    val differingData = record.data != storedRecord.data
+    if (sameTimestamp && differingData)
+      Some(
+        new Exception("Cannot resolve latest data as timestamps are equal")
+      )
+    else
+      None
+  }
+
   def compareRecords(record: CalmRecord, storedRecord: CalmRecord): Boolean =
     record.retrievedAt.isAfter(storedRecord.retrievedAt) &&
       (record.data != storedRecord.data || !storedRecord.published)
+
+  /** Errors in the storage library sometimes wrap empty Exception objects with
+    * no message, meaning if we return them directly we lose any indication as
+    * to what has occured. Here we make sure the Exception is somewhat readable.
+    */
+  def toReadableException(err: StorageError): Throwable =
+    if (Option(err.e.getMessage).exists(_.trim.nonEmpty))
+      err.e
+    else
+      new Exception(err.getClass.getSimpleName)
 }

--- a/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerServiceTest.scala
+++ b/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerServiceTest.scala
@@ -45,8 +45,11 @@ class CalmAdapterWorkerServiceTest
         Thread.sleep(500)
         store.entries shouldBe Map(
           Version("A", 0) -> recordA,
+          Version("A", 1) -> recordA.copy(published = true),
           Version("B", 0) -> recordB,
-          Version("C", 0) -> recordC
+          Version("B", 1) -> recordB.copy(published = true),
+          Version("C", 0) -> recordC,
+          Version("C", 1) -> recordC.copy(published = true)
         )
         retriever.previousQuery shouldBe Some(CalmQuery.ModifiedDate(queryDate))
         assertQueueEmpty(queue)

--- a/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmStoreTest.scala
+++ b/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmStoreTest.scala
@@ -16,82 +16,115 @@ class CalmStoreTest extends FunSpec with Matchers {
   val oldData = Map("key" -> List("old"))
   val newData = Map("key" -> List("new"))
 
-  it("stores new CALM records") {
-    val data = dataStore()
-    val record = CalmRecord("A", Map("key" -> List("value")), retrievedAt)
-    calmStore(data).putRecord(record) shouldBe Right(Some(Version("A", 0)))
-    data.entries shouldBe Map(Version("A", 0) -> record)
+  describe("putRecord") {
+    it("stores new CALM records") {
+      val data = dataStore()
+      val record = CalmRecord("A", Map("key" -> List("value")), retrievedAt)
+      calmStore(data).putRecord(record) shouldBe Right(
+        Some(Version("A", 0) -> record))
+      data.entries shouldBe Map(Version("A", 0) -> record)
+    }
+
+    it(
+      "replaces a stored CALM record if the retrieval date is newer and the data differs") {
+      val oldTime = retrievedAt
+      val newTime = Instant.ofEpochSecond(retrievedAt.getEpochSecond + 2)
+      val oldRecord = CalmRecord("A", oldData, oldTime, published = true)
+      val newRecord = CalmRecord("A", newData, newTime)
+      val data = dataStore(Version("A", 1) -> oldRecord)
+      calmStore(data).putRecord(newRecord) shouldBe Right(
+        Some(Version("A", 2) -> newRecord))
+      data.entries shouldBe Map(
+        Version("A", 1) -> oldRecord,
+        Version("A", 2) -> newRecord
+      )
+    }
+
+    it(
+      "does not replace a stored CALM record if the retrieval date is newer and the data is the same") {
+      val oldTime = retrievedAt
+      val newTime = Instant.ofEpochSecond(retrievedAt.getEpochSecond + 2)
+      val oldRecord = CalmRecord("A", oldData, oldTime, published = true)
+      val newRecord = CalmRecord("A", oldData, newTime)
+      val data = dataStore(Version("A", 1) -> oldRecord)
+      calmStore(data).putRecord(newRecord) shouldBe Right(None)
+      data.entries shouldBe Map(Version("A", 1) -> oldRecord)
+    }
+
+    it(
+      "replaces a stored CALM record if the data is the same but it is not recorded as published") {
+      val oldTime = retrievedAt
+      val newTime = Instant.ofEpochSecond(retrievedAt.getEpochSecond + 2)
+      val oldRecord = CalmRecord("A", oldData, oldTime, published = false)
+      val newRecord = CalmRecord("A", oldData, newTime)
+      val data = dataStore(Version("A", 1) -> oldRecord)
+      calmStore(data).putRecord(newRecord) shouldBe Right(
+        Some(Version("A", 2) -> newRecord))
+      data.entries shouldBe Map(
+        Version("A", 1) -> oldRecord,
+        Version("A", 2) -> newRecord
+      )
+    }
+
+    it(
+      "does not replace a stored CALM record if the retrieval date on the new record is older") {
+      val oldTime = retrievedAt
+      val newTime = Instant.ofEpochSecond(retrievedAt.getEpochSecond + 2)
+      val oldRecord = CalmRecord("A", oldData, oldTime)
+      val newRecord = CalmRecord("A", newData, newTime)
+      val data = dataStore(Version("A", 4) -> newRecord)
+      calmStore(data).putRecord(oldRecord) shouldBe Right(None)
+      data.entries shouldBe Map(Version("A", 4) -> newRecord)
+    }
+
+    it("doesn't store CALM records when checking the stored data fails") {
+      val data = dataStore()
+      val record = CalmRecord("A", Map("key" -> List("value")), retrievedAt)
+      val calmStore = new CalmStore(
+        new MemoryVersionedStore(data) {
+          override def getLatest(id: String): ReadEither =
+            Left(StoreReadError(new Exception("Not today mate")))
+        }
+      )
+      calmStore.putRecord(record) shouldBe a[Left[_, _]]
+      data.entries shouldBe Map.empty
+    }
+
+    it("errors if the data differs but timestamp is the same") {
+      val x = CalmRecord("A", Map("key" -> List("x")), retrievedAt)
+      val y = CalmRecord("A", Map("key" -> List("y")), retrievedAt)
+      val data = dataStore(Version("A", 2) -> x)
+      calmStore(data).putRecord(y) shouldBe a[Left[_, _]]
+      data.entries shouldBe Map(Version("A", 2) -> x)
+    }
   }
 
-  it(
-    "replaces a stored CALM record if the retrieval date is newer and the data differs") {
-    val oldTime = retrievedAt
-    val newTime = Instant.ofEpochSecond(retrievedAt.getEpochSecond + 2)
-    val oldRecord = CalmRecord("A", oldData, oldTime, published = true)
-    val newRecord = CalmRecord("A", newData, newTime)
-    val data = dataStore(Version("A", 1) -> oldRecord)
-    calmStore(data).putRecord(newRecord) shouldBe Right(Some(Version("A", 2)))
-    data.entries shouldBe Map(
-      Version("A", 1) -> oldRecord,
-      Version("A", 2) -> newRecord
-    )
-  }
+  describe("setRecordPublished") {
+    it("sets Calm records as published") {
+      val record = CalmRecord("A", Map("key" -> List("value")), retrievedAt)
+      val data = dataStore(Version("A", 5) -> record)
+      calmStore(data).setRecordPublished(Version("A", 5), record) shouldBe
+        Right(Version("A", 6))
+      data.entries shouldBe Map(
+        Version("A", 5) -> record,
+        Version("A", 6) -> record.copy(published = true),
+      )
+    }
 
-  it(
-    "does not replace a stored CALM record if the retrieval date is newer and the data is the same") {
-    val oldTime = retrievedAt
-    val newTime = Instant.ofEpochSecond(retrievedAt.getEpochSecond + 2)
-    val oldRecord = CalmRecord("A", oldData, oldTime, published = true)
-    val newRecord = CalmRecord("A", oldData, newTime)
-    val data = dataStore(Version("A", 1) -> oldRecord)
-    calmStore(data).putRecord(newRecord) shouldBe Right(None)
-    data.entries shouldBe Map(Version("A", 1) -> oldRecord)
-  }
-
-  it(
-    "replaces a stored CALM record if the data is the same but it is not recorded as published") {
-    val oldTime = retrievedAt
-    val newTime = Instant.ofEpochSecond(retrievedAt.getEpochSecond + 2)
-    val oldRecord = CalmRecord("A", oldData, oldTime, published = false)
-    val newRecord = CalmRecord("A", oldData, newTime)
-    val data = dataStore(Version("A", 1) -> oldRecord)
-    calmStore(data).putRecord(newRecord) shouldBe Right(Some(Version("A", 2)))
-    data.entries shouldBe Map(
-      Version("A", 1) -> oldRecord,
-      Version("A", 2) -> newRecord
-    )
-  }
-
-  it(
-    "does not replace a stored CALM record if the retrieval date on the new record is older") {
-    val oldTime = retrievedAt
-    val newTime = Instant.ofEpochSecond(retrievedAt.getEpochSecond + 2)
-    val oldRecord = CalmRecord("A", oldData, oldTime)
-    val newRecord = CalmRecord("A", newData, newTime)
-    val data = dataStore(Version("A", 4) -> newRecord)
-    calmStore(data).putRecord(oldRecord) shouldBe Right(None)
-    data.entries shouldBe Map(Version("A", 4) -> newRecord)
-  }
-
-  it("doesn't store CALM records when checking the stored data fails") {
-    val data = dataStore()
-    val record = CalmRecord("A", Map("key" -> List("value")), retrievedAt)
-    val calmStore = new CalmStore(
-      new MemoryVersionedStore(data) {
-        override def getLatest(id: String): ReadEither =
-          Left(StoreReadError(new Exception("Not today mate")))
-      }
-    )
-    calmStore.putRecord(record) shouldBe a[Left[_, _]]
-    data.entries shouldBe Map.empty
-  }
-
-  it("errors if the data differs but timestamp is the same") {
-    val x = CalmRecord("A", Map("key" -> List("x")), retrievedAt)
-    val y = CalmRecord("A", Map("key" -> List("y")), retrievedAt)
-    val data = dataStore(Version("A", 2) -> x)
-    calmStore(data).putRecord(y) shouldBe a[Left[_, _]]
-    data.entries shouldBe Map(Version("A", 2) -> x)
+    it("fails setting Calm record as published if version already exists") {
+      val record = CalmRecord("A", Map("key" -> List("value")), retrievedAt)
+      val data = dataStore(
+        Version("A", 5) -> record,
+        Version("A", 6) -> record.copy(data = newData)
+      )
+      val result = calmStore(data).setRecordPublished(Version("A", 5), record)
+      result shouldBe a[Left[_, _]]
+      result.left.get.getMessage shouldBe "VersionAlreadyExistsError"
+      data.entries shouldBe Map(
+        Version("A", 5) -> record,
+        Version("A", 6) -> record.copy(data = newData)
+      )
+    }
   }
 
   def dataStore(entries: (Key, CalmRecord)*) =


### PR DESCRIPTION
## Issue

https://github.com/wellcomecollection/platform/issues/4210

## Description

Currently the Calm adapter will publish lots of redundant messages to the transformer, as we need to always republish records within a window when they are already in the store (in case the publishing failed previously).

Here we add a new `published` field on `CalmRecord`, which is set to true after publishing succeeds. We then swallow records which have exactly the same data as what is currently stored and this have flag set to `true` (indicating the data has already been successfully sent to the transformer).